### PR TITLE
Use RELEASE_PAT for release push (bypasses admin-gated ruleset)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,10 +45,16 @@ jobs:
       new_tag: ${{ steps.bump.outputs.new_tag }}
 
     steps:
+      # Use RELEASE_PAT (a fine-grained PAT owned by a Repository admin)
+      # instead of the default GITHUB_TOKEN. The master branch ruleset
+      # bypasses "Repository admin", and only a real admin's identity
+      # counts toward that role — the github-actions[bot] does not.
+      # Without this the "Release vX.Y.Z" commit push is rejected:
+      #   remote: - Changes must be made through a pull request.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0         # Full history for tag lookup
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The master branch ruleset blocks direct pushes via 'Changes must be made through a pull request'. The publish workflow's version job commits 'Release vX.Y.Z' and pushes it with the tag, so without a bypass it hits:

  remote: error: GH013: Repository rule violations found for refs/heads/master.
  remote: - Changes must be made through a pull request.

The default GITHUB_TOKEN authenticates as github-actions[bot], which has no bypass-relevant role. A fine-grained PAT owned by a Repository admin does, so switch the checkout step to use RELEASE_PAT.

Ruleset bypass list must include 'Repository admin' for this to work.

Setup:
  1. Create fine-grained PAT: contents r/w, pull-requests r/w, scoped to MindMadeLab/quartermaster-sdk-py.
  2. Add as repo secret 'RELEASE_PAT'.
  3. Ruleset bypass list -> add 'Repository admin' role.