### PR TITLE
Fix NodeRegistry naming collision with engine's runtime registry

### DIFF
--- a/quartermaster-nodes/README.md
+++ b/quartermaster-nodes/README.md
@@ -12,7 +12,7 @@ Composable node types for building AI agent graphs.
 - **Framework-agnostic** via the `NodeContext` protocol -- integrates with any runtime
 - **Stateless class-based design** -- all nodes use `@classmethod` with no instance state
 - **Chain-of-Responsibility pattern** for composable LLM processing pipelines
-- **NodeRegistry** with auto-discovery, version tracking, and catalog generation
+- **NodeCatalog** with auto-discovery, version tracking, and catalog generation (formerly `NodeRegistry` — old name still works as an alias)
 - **Configurable flow behavior** per node: traversal strategy, thought type, message type, error handling
 
 ## Installation
@@ -28,28 +28,35 @@ pip install quartermaster-nodes
 ### Register and Discover Nodes
 
 ```python
-from quartermaster_nodes import NodeRegistry
+from quartermaster_nodes import NodeCatalog
 from quartermaster_nodes.nodes import InstructionNodeV1, StartNodeV1, EndNodeV1, Decision1
 
 # Manual registration
-registry = NodeRegistry()
-registry.register(StartNodeV1)
-registry.register(InstructionNodeV1)
-registry.register(Decision1)
-registry.register(EndNodeV1)
+catalog = NodeCatalog()
+catalog.register(StartNodeV1)
+catalog.register(InstructionNodeV1)
+catalog.register(Decision1)
+catalog.register(EndNodeV1)
 
 # Or auto-discover all built-in nodes
-registry = NodeRegistry()
-count = registry.discover("quartermaster_nodes.nodes")
+catalog = NodeCatalog()
+count = catalog.discover("quartermaster_nodes.nodes")
 print(f"Discovered {count} nodes")
 
 # Look up a node by name
-node_cls = registry.get("InstructionNode")
+node_cls = catalog.get("InstructionNode")
 print(node_cls.info().description)
 
 # Generate a JSON catalog of all nodes
-catalog = registry.catalog_json()
+all_nodes = catalog.catalog_json()
 ```
+
+> **Not the runtime registry.** `NodeCatalog` is a design-time catalog of node
+> class definitions. If you're wiring up `FlowRunner`, you want a **runtime
+> executor registry** — use `quartermaster_engine.SimpleNodeRegistry` for that.
+> `NodeRegistry` (the old name, still aliased here) collides with
+> `quartermaster_engine.nodes.NodeRegistry` (a Protocol); passing the wrong one
+> to `FlowRunner` now raises a clear `TypeError` instead of `AttributeError`.
 
 ### Creating a Custom Node
 
@@ -262,7 +269,7 @@ Defines a node's flow behavior constraints.
 | `message_type` | `AvailableMessageTypes` | Message role (Automatic, User, Assistant, etc.) |
 | `error_handling_strategy` | `AvailableErrorHandlingStrategies` | Stop, Continue, or Retry |
 
-### NodeRegistry
+### NodeCatalog (formerly NodeRegistry)
 
 | Method | Description |
 |--------|-------------|
@@ -273,6 +280,9 @@ Defines a node's flow behavior constraints.
 | `catalog_json() -> list[dict]` | JSON-serializable catalog |
 | `discover(package) -> int` | Auto-discover nodes from a package |
 | `count -> int` | Number of registered nodes |
+| `get_executor(...)` | **Guard** — raises `TypeError` pointing you to `quartermaster_engine.SimpleNodeRegistry`. This method exists only to give a helpful error if you accidentally pass a `NodeCatalog` to `FlowRunner`. |
+
+> `NodeRegistry` is kept as a backward-compatible alias for `NodeCatalog`.
 
 ### Chain-of-Responsibility
 
@@ -315,18 +325,37 @@ from quartermaster_graph.enums import NodeType             # Canonical source
 
 ### With quartermaster-engine (execution runtime)
 
-The engine resolves node types from the registry and calls `think()` through an adapter:
+`quartermaster-nodes` and `quartermaster-engine` operate on different axes:
+
+- `NodeCatalog` (this package) — design-time catalog of *node class definitions*
+  for discovery, introspection, and versioning.
+- `SimpleNodeRegistry` (engine) — runtime registry of *node executors* that
+  `FlowRunner` dispatches to.
+
+For runtime execution with `FlowRunner`, register executors directly with the
+engine registry:
 
 ```python
-from quartermaster_nodes import NodeRegistry
-from quartermaster_nodes.nodes import InstructionNodeV1
+from quartermaster_engine import FlowRunner
+from quartermaster_engine.nodes import SimpleNodeRegistry
 
-registry = NodeRegistry()
-registry.discover("quartermaster_nodes.nodes")
+registry = SimpleNodeRegistry()
+registry.register("Instruction1", my_instruction_executor)
+runner = FlowRunner(graph=graph, node_registry=registry)
+```
 
-# The engine looks up nodes by name and invokes think()
-node_cls = registry.get("InstructionNode", "1.0")
-node_cls.think(execution_context)
+The design-time catalog is still useful — to *inspect* available node classes
+before wiring executors:
+
+```python
+from quartermaster_nodes import NodeCatalog
+
+catalog = NodeCatalog()
+catalog.discover("quartermaster_nodes.nodes")
+
+node_cls = catalog.get("InstructionNode", "1.0")
+print(node_cls.info().description)
+node_cls.think(execution_context)  # direct invocation (no engine involved)
 ```
 
 ## Contributing

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -12,7 +12,7 @@ from quartermaster_nodes.enums import (
 from quartermaster_nodes.config import AssistantInfo, FlowNodeConf, FlowRunConfig
 from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistantNode
 from quartermaster_nodes.chain import Chain, Handler
-from quartermaster_nodes.registry import NodeRegistry, register_node
+from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
 __version__ = "0.1.0"
 
@@ -35,7 +35,10 @@ __all__ = [
     # Chain
     "Chain",
     "Handler",
-    # Registry
+    # Catalog (design-time) — NodeRegistry is kept as a deprecated alias
+    # for NodeCatalog; see quartermaster_nodes.registry.registry for the
+    # reason (naming collision with quartermaster_engine.nodes.NodeRegistry).
+    "NodeCatalog",
     "NodeRegistry",
     "register_node",
 ]

--- a/quartermaster-nodes/quartermaster_nodes/registry/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/registry/__init__.py
@@ -1,5 +1,26 @@
-"""Node registry for discovering and managing node types."""
+"""Design-time catalog of node class definitions.
 
-from quartermaster_nodes.registry.registry import NodeRegistry, register_node
+Exports:
 
-__all__ = ["NodeRegistry", "register_node"]
+- ``NodeCatalog`` — the canonical name; a catalog of
+  :class:`~quartermaster_nodes.base.AbstractAssistantNode` subclasses.
+- ``NodeRegistry`` — backward-compatible alias for ``NodeCatalog``.
+  Retained so existing code keeps working; new code should prefer
+  ``NodeCatalog`` to avoid confusion with the runtime registry
+  ``quartermaster_engine.nodes.NodeRegistry`` (a completely different
+  Protocol used by ``FlowRunner``).
+"""
+
+from quartermaster_nodes.registry.registry import (
+    NodeCatalog,
+    NodeRegistry,
+    default_registry,
+    register_node,
+)
+
+__all__ = [
+    "NodeCatalog",
+    "NodeRegistry",  # deprecated alias — kept for backward compatibility
+    "default_registry",
+    "register_node",
+]

--- a/quartermaster-nodes/quartermaster_nodes/registry/registry.py
+++ b/quartermaster-nodes/quartermaster_nodes/registry/registry.py
@@ -1,9 +1,26 @@
-"""Node registry with auto-discovery and catalog generation."""
+"""Node catalog with auto-discovery and catalog generation.
+
+IMPORTANT — naming gotcha:
+=========================
+
+This module exports ``NodeCatalog`` (aliased as ``NodeRegistry`` for
+backward compatibility). It is a *design-time catalog* of node **class
+definitions** — not a runtime executor registry.
+
+The ``FlowRunner`` in ``quartermaster_engine`` expects a **different**
+registry that maps node types to ``NodeExecutor`` instances. Use
+``quartermaster_engine.SimpleNodeRegistry`` (or anything implementing
+the ``quartermaster_engine.nodes.NodeRegistry`` Protocol) for that.
+
+Passing a ``NodeCatalog`` / ``quartermaster_nodes.NodeRegistry`` to
+``FlowRunner(node_registry=...)`` will raise a ``TypeError`` at the
+first node dispatch, pointing here.
+"""
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, NoReturn, Optional, Type
 
 from quartermaster_nodes.base import AbstractAssistantNode
 from quartermaster_nodes.exceptions import NodeNotFoundError
@@ -11,19 +28,30 @@ from quartermaster_nodes.exceptions import NodeNotFoundError
 logger = logging.getLogger(__name__)
 
 
-class NodeRegistry:
-    """Registry for discovering and managing node types.
+class NodeCatalog:
+    """Design-time catalog of node **class definitions**.
 
-    Provides registration, lookup, and catalog generation for all
-    available node types.
+    Tracks which :class:`AbstractAssistantNode` subclasses are
+    available to the framework — their names, versions, metadata
+    schemas, and flow config. Supports auto-discovery from a package.
 
-    Example:
-        registry = NodeRegistry()
-        registry.register(InstructionNodeV1)
-        node_cls = registry.get("Instruction1")
+    .. note::
+
+        This is NOT the registry ``FlowRunner`` uses at runtime.
+        ``FlowRunner`` expects a mapping from node-type strings to
+        ``NodeExecutor`` instances — use
+        ``quartermaster_engine.SimpleNodeRegistry`` for that. See
+        :meth:`get_executor` for the full error message if you've
+        wired the wrong one.
+
+    Example::
+
+        catalog = NodeCatalog()
+        catalog.register(InstructionNodeV1)
+        node_cls = catalog.get("Instruction1")
 
         # Or use auto-discovery
-        registry.discover("quartermaster_nodes.nodes")
+        catalog.discover("quartermaster_nodes.nodes")
     """
 
     def __init__(self) -> None:
@@ -139,14 +167,54 @@ class NodeRegistry:
         """Number of unique registered nodes (name:version pairs)."""
         return sum(1 for k in self._nodes if ":" in k)
 
+    # ------------------------------------------------------------------
+    # Wrong-registry guard
+    # ------------------------------------------------------------------
+    def get_executor(self, node_type: str) -> NoReturn:
+        """Guard — this is NOT an executor registry.
 
-def register_node(registry: NodeRegistry):
-    """Decorator for registering a node class with a registry.
+        ``FlowRunner._execute_logic_node`` calls ``get_executor`` on the
+        registry it was handed. If the hand-off was wrong (passing this
+        catalog instead of ``quartermaster_engine.SimpleNodeRegistry``),
+        we'd crash with an unhelpful ``AttributeError``. Provide a clear
+        redirect instead.
+        """
+        raise TypeError(
+            "quartermaster_nodes.NodeCatalog (aka NodeRegistry) is a "
+            "design-time catalog of node CLASS definitions, not a runtime "
+            "executor registry. FlowRunner expects a registry mapping node "
+            "types to NodeExecutor instances.\n\n"
+            "Use quartermaster_engine.SimpleNodeRegistry instead:\n\n"
+            "    from quartermaster_engine import FlowRunner\n"
+            "    from quartermaster_engine.nodes import SimpleNodeRegistry\n\n"
+            "    registry = SimpleNodeRegistry()\n"
+            "    registry.register('Instruction1', my_instruction_executor)\n"
+            "    runner = FlowRunner(graph=graph, node_registry=registry)\n\n"
+            f"(attempted: get_executor({node_type!r}))"
+        )
 
-    Example:
-        registry = NodeRegistry()
 
-        @register_node(registry)
+# ------------------------------------------------------------------
+# Backward-compatibility alias
+# ------------------------------------------------------------------
+# ``NodeRegistry`` was the original name. It collides with
+# ``quartermaster_engine.nodes.NodeRegistry`` (a Protocol for runtime
+# executors with a completely different API), which caused user-visible
+# confusion — ``FlowRunner(node_registry=quartermaster_nodes.NodeRegistry())``
+# crashed with ``AttributeError: get_executor``. Keep the old name as an
+# alias so existing code compiles, and handle the actual mis-use via the
+# ``get_executor`` guard above.
+NodeRegistry = NodeCatalog
+
+
+def register_node(registry: NodeCatalog):
+    """Decorator for registering a node class with a catalog.
+
+    Example::
+
+        catalog = NodeCatalog()
+
+        @register_node(catalog)
         class MyNode(AbstractAssistantNode):
             ...
     """
@@ -158,5 +226,5 @@ def register_node(registry: NodeRegistry):
     return decorator
 
 
-# Global default registry
-default_registry = NodeRegistry()
+# Global default catalog
+default_registry = NodeCatalog()

--- a/quartermaster-nodes/tests/test_registry/test_catalog_rename.py
+++ b/quartermaster-nodes/tests/test_registry/test_catalog_rename.py
@@ -1,0 +1,103 @@
+"""Regression tests for the NodeRegistry → NodeCatalog rename.
+
+In 0.1.0, ``quartermaster_nodes.NodeRegistry`` and
+``quartermaster_engine.nodes.NodeRegistry`` both existed with different
+APIs. ``FlowRunner.get_executor`` crashed with ``AttributeError`` when
+a user (reasonably) passed the nodes-package registry to the engine.
+
+0.1.1 addresses this two ways:
+
+1. Rename the design-time catalog to ``NodeCatalog`` (canonical name).
+   ``NodeRegistry`` remains as a backward-compat alias.
+2. Add a ``get_executor`` guard on ``NodeCatalog`` that raises a
+   helpful ``TypeError`` instead of ``AttributeError``, pointing users
+   to ``quartermaster_engine.SimpleNodeRegistry``.
+
+These tests lock in both behaviours.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from quartermaster_nodes import NodeCatalog, NodeRegistry
+from quartermaster_nodes.registry import (
+    NodeCatalog as FromRegistry,
+)
+from quartermaster_nodes.registry import (
+    NodeRegistry as NodeRegistryFromRegistry,
+)
+from quartermaster_nodes.registry import default_registry
+from quartermaster_nodes.registry.registry import NodeCatalog as FromInnerModule
+
+
+def test_noderegistry_is_alias_for_nodecatalog() -> None:
+    """Old ``from quartermaster_nodes import NodeRegistry`` must keep working."""
+    assert NodeRegistry is NodeCatalog
+    assert NodeRegistryFromRegistry is FromRegistry
+
+
+def test_same_class_across_import_paths() -> None:
+    """All import paths resolve to the same class object."""
+    assert NodeCatalog is FromRegistry
+    assert NodeCatalog is FromInnerModule
+
+
+def test_default_registry_is_nodecatalog_instance() -> None:
+    """The module-level default is a NodeCatalog — and therefore a NodeRegistry."""
+    assert isinstance(default_registry, NodeCatalog)
+    assert isinstance(default_registry, NodeRegistry)
+
+
+class TestGetExecutorGuard:
+    """The get_executor method must raise TypeError with a clear redirect.
+
+    This prevents the confusing AttributeError that 0.1.0 users hit when
+    they passed quartermaster_nodes.NodeRegistry to FlowRunner.
+    """
+
+    def test_raises_typeerror_not_attributeerror(self) -> None:
+        catalog = NodeCatalog()
+        with pytest.raises(TypeError):
+            catalog.get_executor("Instruction1")
+
+    def test_error_message_redirects_to_simple_node_registry(self) -> None:
+        catalog = NodeCatalog()
+        with pytest.raises(TypeError) as exc_info:
+            catalog.get_executor("Instruction1")
+        msg = str(exc_info.value)
+        # Must mention the correct replacement class
+        assert "SimpleNodeRegistry" in msg
+        assert "quartermaster_engine" in msg
+        # Must include the node type that was attempted
+        assert "Instruction1" in msg
+
+    def test_guard_also_fires_on_alias(self) -> None:
+        """Calling get_executor on the legacy NodeRegistry alias works the same."""
+        registry = NodeRegistry()
+        with pytest.raises(TypeError) as exc_info:
+            registry.get_executor("User1")
+        assert "SimpleNodeRegistry" in str(exc_info.value)
+
+    def test_error_message_contains_working_example(self) -> None:
+        """The error message should include a code snippet users can copy."""
+        catalog = NodeCatalog()
+        with pytest.raises(TypeError) as exc_info:
+            catalog.get_executor("X")
+        msg = str(exc_info.value)
+        assert "from quartermaster_engine import FlowRunner" in msg
+        assert "SimpleNodeRegistry" in msg
+        assert "registry.register" in msg
+
+
+class TestCatalogAPIUnchanged:
+    """The original catalog API (get, has, register, etc.) must still work."""
+
+    def test_empty_catalog_has_no_nodes(self) -> None:
+        catalog = NodeCatalog()
+        assert catalog.count == 0
+        assert catalog.list_nodes() == []
+
+    def test_has_on_empty_catalog_returns_false(self) -> None:
+        catalog = NodeCatalog()
+        assert catalog.has("anything") is False


### PR DESCRIPTION
Bug reported against 0.1.0:

  FlowRunner._execute_logic_node calls
  self.node_registry.get_executor(node.type.value)

  AttributeError: 'NodeRegistry' object has no attribute 'get_executor'

Root cause: two unrelated classes both named 'NodeRegistry'.

  - quartermaster_nodes.NodeRegistry: design-time catalog of node CLASS definitions. API: get, has, register, list_nodes, catalog_json, discover, count.

  - quartermaster_engine.nodes.NodeRegistry (Protocol) + SimpleNodeRegistry: runtime registry of NodeExecutor instances. API: get_executor, list_types, register.

Users reasonably did 'from quartermaster_nodes import NodeRegistry' and passed it to FlowRunner. BOOM.

Fix:

  1. Rename the design-time class to NodeCatalog (canonical name that actually describes what it is). Keep 'NodeRegistry' as a backward- compatible alias so existing imports keep working.

  2. Add a NodeCatalog.get_executor guard that raises TypeError with a clear redirect message + a working code example, instead of the confusing AttributeError.

  3. Update quartermaster-nodes README to clarify the two registries and show the canonical FlowRunner wiring (SimpleNodeRegistry).

New tests in tests/test_registry/test_catalog_rename.py:
  - NodeRegistry is NodeCatalog (alias integrity)
  - All three import paths resolve to the same class
  - default_registry is a NodeCatalog / NodeRegistry instance
  - get_executor raises TypeError, not AttributeError
  - Error message mentions SimpleNodeRegistry, quartermaster_engine, and the attempted node type
  - Error message contains a copy-pastable code example
  - The guard fires on the legacy NodeRegistry alias too
  - Existing catalog API (count, list_nodes, has) still works

All 466 nodes tests + 231 graph tests + 416 engine tests pass. ruff format --check clean.