### PR TITLE
v0.1.3: propagate LLMConfig fields + sync OllamaProvider.chat() shim + release docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,20 @@
 name: Publish to PyPI
 
+# ⚠️ READ RELEASING.md BEFORE CLICKING "Run workflow".
+#
+# This workflow runs on whatever branch you trigger it from — usually
+# master. It does NOT merge develop into master. If develop holds the
+# real changes and master only has the previous release's version-bump
+# commits, clicking Publish ships **empty packages** (just another
+# version bump). v0.1.2 went out empty for exactly this reason.
+#
+# Required ordering for every release:
+#   1. Merge feature PRs to develop.
+#   2. Open + merge a release PR `develop -> master`.
+#   3. Click Run workflow here, branch=master, bump=patch/minor/major.
+#   4. After publish, merge `master` back into `develop` to pick up the
+#      auto-generated `Release vX.Y.Z` commit.
+#
 # Publishing is manual-only: click "Run workflow" in the Actions tab when you
 # want to cut a release. Auto-publish on every push to master was intentionally
 # removed so routine commits (docs, README tweaks, refactors) do not burn through

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,76 @@
+# Releasing Quartermaster
+
+## ⚠️ The trap (don't do this)
+
+The `Publish to PyPI` workflow runs on whatever branch you click "Run workflow" from. It does **NOT** merge `develop` into `master` first. If you click Publish from `master` while the actual changes still live on `develop`, PyPI gets a release containing only the version-bump diff. **This happened with v0.1.2.** The release was empty; downstream integrators were blocked.
+
+## The release flow
+
+Every release crosses two branches: `develop` (where work lands) and `master` (where releases ship from). PyPI publishes from master. Therefore:
+
+```
+feature branch  →  PR → develop  →  release PR → master  →  click Publish
+```
+
+### Step 1 — work merges to `develop`
+
+Open feature/fix PRs against `develop`. CI runs there. Merge when green. **Master is untouched at this point.**
+
+### Step 2 — open a release PR `develop → master`
+
+```bash
+gh pr create --base master --head develop \
+  --title "Release vX.Y.Z: <one-line summary>" \
+  --body "Brings master in line with develop. After merge, click Publish to PyPI with bump=patch (or minor/major)."
+```
+
+Get this PR reviewed and merged. **Master now contains the actual code that will ship.** The publish workflow itself does *not* perform this merge.
+
+### Step 3 — click "Run workflow" on `Publish to PyPI`
+
+[Actions → Publish to PyPI → Run workflow], pick `bump=patch` (or whatever level fits the changes), branch=`master`, `dry_run=false`. The workflow:
+
+1. Reads the last git tag on master (e.g. `v0.1.2`).
+2. Bumps it (`patch` → `0.1.3`).
+3. Updates `version = "X.Y.Z"` in every `pyproject.toml` and the SDK's `__init__.py`.
+4. Updates cross-package dependency pins (`quartermaster-foo>=X.Y.Z`).
+5. Commits as `Release vX.Y.Z`, tags `vX.Y.Z`, pushes.
+6. Builds wheels in matrix per package.
+7. Publishes to PyPI in dependency order (providers → graph → tools → nodes → engine → mcp-client → code-runner → sdk).
+
+### Step 4 — sync `develop` back
+
+After publish, master will have the auto-generated `Release vX.Y.Z` commit that develop doesn't. Bring develop back in line:
+
+```bash
+git checkout develop
+git pull origin develop
+git merge origin/master --no-edit   # picks up the release-bump commits
+git push origin develop
+```
+
+This step is what makes the *next* release PR (`develop → master`) clean — without it, develop slowly drifts behind on version bumps and you get noisy merge conflicts.
+
+## Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| **PyPI shipped empty packages** (just version bumps, no code) | Clicked Publish on master without first merging `develop → master`. | Open a real release PR (Step 2), merge, click Publish again. The yanked-empty release stays as `vX.Y.Z`; the real one becomes `vX.Y.Z+1`. |
+| **`Release vX.Y.Z` commit conflicts when merging develop into master** | Develop didn't get the previous release's bump commit synced back (Step 4 was skipped). | Resolve conflicts by taking master's bumped version strings; commit the merge. |
+| **Publish failed mid-way, only some packages on PyPI** | One sub-package's wheel build or `twine upload` failed; later packages in the dependency chain shipped without their dependency. | Manually publish the missing sub-packages with `twine upload dist-PACKAGE/*` from a local checkout of the `vX.Y.Z` tag. |
+| **`pip install quartermaster-sdk==X.Y.Z` fails** with `No matching distribution found for quartermaster-nodes>=X.Y.Z` | Sub-package upload didn't complete before SDK upload. | Same as above — finish the sub-package upload, then `pip install` will succeed. |
+
+## Hotfix flow (skip develop)
+
+For urgent master-only fixes:
+
+```bash
+git checkout master
+git pull
+git checkout -b hotfix/vX.Y.Z+1-<topic>
+# … fix, commit …
+gh pr create --base master --title "Hotfix: ..." --body "..."
+# merge, then Step 3 (Publish), then Step 4 (sync develop)
+```
+
+Same Step 4 caveat — sync develop back from master so the hotfix isn't lost on the next regular release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,4 +73,6 @@ gh pr create --base master --title "Hotfix: ..." --body "..."
 # merge, then Step 3 (Publish), then Step 4 (sync develop)
 ```
 
+**Hotfix PRs still need at least one review approval before merge** — the Publish workflow has no minimum-approval gate of its own (`RELEASE_PAT` bypasses the admin ruleset), so the PR review is the only thing standing between an unreviewed commit and a public PyPI release. Don't self-approve hotfixes; ping a co-maintainer.
+
 Same Step 4 caveat — sync develop back from master so the hotfix isn't lost on the next regular release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.1.2"
+version = "0.1.3"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/quartermaster-code-runner/pyproject.toml
+++ b/quartermaster-code-runner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-code-runner"
-version = "0.1.2"
+version = "0.1.3"
 description = "Secure sandboxed code execution service supporting Python, Node.js, Go, Rust, Deno, and Bun via Docker containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/quartermaster-engine/pyproject.toml
+++ b/quartermaster-engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-engine"
-version = "0.1.2"
+version = "0.1.3"
 description = "Execution engine for AI agent graphs — traversal, branching, merging, memory, message passing, and error handling"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,13 +25,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "quartermaster-graph>=0.1.2",
-    "quartermaster-providers>=0.1.2",
+    "quartermaster-graph>=0.1.3",
+    "quartermaster-providers>=0.1.3",
     # ``quartermaster-nodes`` ships ``safe_eval`` (a simpleeval sandbox)
     # which the example runner uses for ``Var``/``If``/``Switch`` node
     # expression evaluation.  Pre-0.1.2 this was an implicit workspace
     # dep — it would ImportError when installed standalone.
-    "quartermaster-nodes>=0.1.2",
+    "quartermaster-nodes>=0.1.3",
 ]
 
 [project.optional-dependencies]

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -205,6 +205,56 @@ def _resolve_provider_and_model(
     return provider_name, model
 
 
+# ── LLM config from node metadata ──────────────────────────────────────
+
+# The DSL stores every LLM-configuration knob under one of these keys —
+# see ``quartermaster_graph.builder._llm_meta``.  ``THINKING_LEVELS``
+# mirrors ``quartermaster_nodes.base.AbstractLLMAssistantNode``: the
+# canonical Quartermaster project's mapping from a friendly level name
+# to the (enabled, budget) pair the provider config understands.
+THINKING_LEVELS: dict[str, tuple[bool, int | None]] = {
+    "off": (False, None),
+    "low": (True, 1024),
+    "medium": (True, 4096),
+    "high": (True, 16384),
+}
+
+
+def _build_llm_config(
+    context: ExecutionContext,
+    *,
+    provider_name: str,
+    model: str,
+    stream: bool,
+    system_message: str | None = None,
+    temperature_default: float = 0.7,
+) -> LLMConfig:
+    """Build an :class:`LLMConfig` from the node's metadata.
+
+    Pre-0.1.3 the executors only forwarded model/provider/system_message/
+    temperature/stream — every other DSL knob (``llm_max_output_tokens``,
+    ``llm_max_input_tokens``, ``llm_thinking_level``, ``llm_vision``)
+    was silently dropped.  Setting ``max_output_tokens=50`` and watching
+    the provider burn 2 000 tokens was a real downstream blocker; this
+    helper plugs the gap.
+    """
+    thinking_level = context.get_meta("llm_thinking_level", "off")
+    thinking_enabled, thinking_budget = THINKING_LEVELS.get(thinking_level, (False, None))
+
+    return LLMConfig(
+        model=model,
+        provider=provider_name,
+        system_message=system_message,
+        temperature=context.get_meta("llm_temperature", temperature_default),
+        stream=stream,
+        max_output_tokens=context.get_meta("llm_max_output_tokens", None),
+        max_input_tokens=context.get_meta("llm_max_input_tokens", None),
+        vision=bool(context.get_meta("llm_vision", False)),
+        thinking_enabled=thinking_enabled,
+        thinking_budget=thinking_budget,
+    )
+
+
 class LLMExecutor(NodeExecutor):
     """Calls a real LLM for Instruction, Summarize, and Agent (no-tool) nodes.
 
@@ -244,12 +294,12 @@ class LLMExecutor(NodeExecutor):
         user_input = str(context.memory.get("__user_input__", "Hello"))
         prompt = _format_conversation(conversation, user_input)
 
-        config = LLMConfig(
+        config = _build_llm_config(
+            context,
+            provider_name=provider_name,
             model=model,
-            provider=provider_name,
-            system_message=system_instruction,
-            temperature=context.get_meta("llm_temperature", 0.7),
             stream=True,
+            system_message=system_instruction,
         )
 
         try:
@@ -271,7 +321,10 @@ class LLMExecutor(NodeExecutor):
                 output_text=text,
             )
         except Exception as e:
-            print(f"  [LLM ERROR] {provider_name}/{model}: {e}", flush=True)
+            # Log to module logger; the runner surfaces ``error`` into
+            # ``FlowResult.error`` so callers see the failure without us
+            # spraying stdout in library code.
+            logger.warning("LLMExecutor: %s/%s raised: %s", provider_name, model, e)
             return NodeResult(success=False, data={}, error=str(e))
 
 
@@ -441,21 +494,34 @@ class AgentExecutor(NodeExecutor):
         requires_another_call = True
         hit_iteration_cap = False
 
+        # Build the LLMConfig once: per-turn fields (system message, max
+        # tokens, thinking budget, vision) don't change between iterations
+        # of the same node.  Streaming stays off so the agent can read the
+        # full ``NativeResponse`` (text + tool_calls + stop_reason) atomically.
+        config = _build_llm_config(
+            context,
+            provider_name=provider_name,
+            model=model,
+            stream=False,
+            system_message=system_instruction,
+        )
+
         while requires_another_call and (max_iterations == 0 or iteration < max_iterations):
             iteration += 1
-
-            config = LLMConfig(
-                model=model,
-                provider=provider_name,
-                system_message=system_instruction,
-                temperature=context.get_meta("llm_temperature", 0.7),
-                stream=False,
-            )
 
             try:
                 response = await provider.generate_native_response(prompt, tools, config)
             except Exception as exc:
-                print(f"  [AGENT ERROR] {provider_name}/{model}: {exc}", flush=True)
+                # Bubble the failure into FlowResult.error via the runner's
+                # NodeResult-failure path; keep the verbose detail in logs
+                # so ops can diagnose without the LLM ever seeing it.
+                logger.warning(
+                    "AgentExecutor: %s/%s raised on iteration %d: %s",
+                    provider_name,
+                    model,
+                    iteration,
+                    exc,
+                )
                 return NodeResult(success=False, data={}, error=str(exc))
 
             text_chunk = getattr(response, "text_content", "") or ""
@@ -592,13 +658,19 @@ class DecisionExecutor(NodeExecutor):
         user_input = str(context.memory.get("__user_input__", "Choose"))
         prompt = _format_conversation(conversation, user_input)
 
-        config = LLMConfig(
+        # Decision nodes pin temperature=0 for determinism — the helper
+        # only takes a default for that field, the per-node ``llm_temperature``
+        # is intentionally ignored here.  Everything else (max tokens,
+        # thinking, vision) flows through the metadata.
+        config = _build_llm_config(
+            context,
+            provider_name=provider_name,
             model=model,
-            provider=provider_name,
-            system_message=decision_prompt,
-            temperature=0.0,
             stream=False,
+            system_message=decision_prompt,
+            temperature_default=0.0,
         )
+        config.temperature = 0.0
 
         try:
             response = await provider.generate_text_response(prompt, config)

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -220,6 +220,20 @@ THINKING_LEVELS: dict[str, tuple[bool, int | None]] = {
 }
 
 
+def _coerce_bool(value: Any) -> bool:
+    """Coerce a metadata value to ``bool``, treating string ``"false"`` as False.
+
+    Node metadata round-trips through YAML / JSON in some pipelines and
+    can come back as the string ``"false"`` — and ``bool("false")`` is
+    truthy in Python.  Treat the common falsy-string spellings as
+    ``False`` so a typo in the wire format doesn't silently flip a
+    feature on.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() not in ("", "false", "0", "no", "off")
+    return bool(value)
+
+
 def _build_llm_config(
     context: ExecutionContext,
     *,
@@ -228,6 +242,7 @@ def _build_llm_config(
     stream: bool,
     system_message: str | None = None,
     temperature_default: float = 0.7,
+    temperature_override: float | None = None,
 ) -> LLMConfig:
     """Build an :class:`LLMConfig` from the node's metadata.
 
@@ -237,19 +252,40 @@ def _build_llm_config(
     was silently dropped.  Setting ``max_output_tokens=50`` and watching
     the provider burn 2 000 tokens was a real downstream blocker; this
     helper plugs the gap.
+
+    Args:
+        temperature_default: Used when the node leaves ``llm_temperature``
+            unset.
+        temperature_override: When given, takes precedence over both the
+            node metadata and the default.  Decision nodes use this to
+            pin temperature=0 regardless of what the YAML says.
     """
     thinking_level = context.get_meta("llm_thinking_level", "off")
+    if thinking_level not in THINKING_LEVELS:
+        # Unknown level — fall back to "off" but log so the misconfiguration
+        # is visible.  Silently swallowing was the same class of failure as
+        # the pre-0.1.3 max_output_tokens drop.
+        logger.warning(
+            "Unknown llm_thinking_level=%r (expected one of %s); falling back to 'off'.",
+            thinking_level,
+            sorted(THINKING_LEVELS),
+        )
     thinking_enabled, thinking_budget = THINKING_LEVELS.get(thinking_level, (False, None))
+
+    if temperature_override is not None:
+        temperature = temperature_override
+    else:
+        temperature = context.get_meta("llm_temperature", temperature_default)
 
     return LLMConfig(
         model=model,
         provider=provider_name,
         system_message=system_message,
-        temperature=context.get_meta("llm_temperature", temperature_default),
+        temperature=temperature,
         stream=stream,
         max_output_tokens=context.get_meta("llm_max_output_tokens", None),
         max_input_tokens=context.get_meta("llm_max_input_tokens", None),
-        vision=bool(context.get_meta("llm_vision", False)),
+        vision=_coerce_bool(context.get_meta("llm_vision", False)),
         thinking_enabled=thinking_enabled,
         thinking_budget=thinking_budget,
     )
@@ -658,19 +694,20 @@ class DecisionExecutor(NodeExecutor):
         user_input = str(context.memory.get("__user_input__", "Choose"))
         prompt = _format_conversation(conversation, user_input)
 
-        # Decision nodes pin temperature=0 for determinism — the helper
-        # only takes a default for that field, the per-node ``llm_temperature``
-        # is intentionally ignored here.  Everything else (max tokens,
-        # thinking, vision) flows through the metadata.
+        # Decision nodes pin temperature=0 for determinism regardless of
+        # what the per-node ``llm_temperature`` says.  Use the helper's
+        # explicit override so the contract is enforced at the call site
+        # (vs. mutating the returned config — which only worked because
+        # ``LLMConfig`` is mutable, a fragile guarantee).  Every other
+        # field (max tokens, thinking, vision) still flows through.
         config = _build_llm_config(
             context,
             provider_name=provider_name,
             model=model,
             stream=False,
             system_message=decision_prompt,
-            temperature_default=0.0,
+            temperature_override=0.0,
         )
-        config.temperature = 0.0
 
         try:
             response = await provider.generate_text_response(prompt, config)
@@ -681,7 +718,16 @@ class DecisionExecutor(NodeExecutor):
                     picked = opt
                     break
             return NodeResult(success=True, data={}, output_text="", picked_node=picked)
-        except Exception as e:
+        except Exception as exc:
+            # Decision LLM call failed — pick the first available option so
+            # the flow keeps going.  Log the failure so ops can see it
+            # rather than silently swallowing.
+            logger.warning(
+                "DecisionExecutor: %s/%s raised, defaulting to first option: %s",
+                provider_name,
+                model,
+                exc,
+            )
             picked = options[0] if options else ""
             return NodeResult(success=True, data={}, output_text="", picked_node=picked)
 

--- a/quartermaster-engine/tests/test_smoke_simple_graph.py
+++ b/quartermaster-engine/tests/test_smoke_simple_graph.py
@@ -56,6 +56,64 @@ def provider_registry_with_mock():
     return registry, mock
 
 
+class TestLLMConfigPropagation:
+    """v0.1.3: every DSL knob must reach the provider's ``LLMConfig``.
+
+    The 0.1.1 → 0.1.2 retest report flagged setting ``llm_max_output_tokens=50``
+    and watching the provider burn 2000 tokens.  Root cause: executors built
+    ``LLMConfig`` with only model/provider/system_message/temperature/stream
+    and silently dropped every other field.  v0.1.3 wires them all through.
+    """
+
+    def test_max_output_tokens_reaches_provider(self, provider_registry_with_mock):
+        registry, mock = provider_registry_with_mock
+        graph = Graph("chat").start().user().agent("Tight", max_output_tokens=50).end().build()
+        runner = FlowRunner(graph=graph, provider_registry=registry)
+        result = runner.run("ping")
+        assert result.success, result.error
+        assert mock.last_config is not None
+        assert mock.last_config.max_output_tokens == 50
+
+    def test_max_input_tokens_reaches_provider(self, provider_registry_with_mock):
+        registry, mock = provider_registry_with_mock
+        graph = Graph("chat").start().user().agent("Tight", max_input_tokens=8000).end().build()
+        runner = FlowRunner(graph=graph, provider_registry=registry)
+        runner.run("ping")
+        assert mock.last_config.max_input_tokens == 8000
+
+    def test_thinking_level_high_propagates_enabled_and_budget(self, provider_registry_with_mock):
+        registry, mock = provider_registry_with_mock
+        graph = Graph("chat").start().user().agent("Reasoning", thinking_level="high").end().build()
+        runner = FlowRunner(graph=graph, provider_registry=registry)
+        runner.run("ping")
+        assert mock.last_config.thinking_enabled is True
+        assert mock.last_config.thinking_budget == 16384
+
+    def test_thinking_level_off_disables(self, provider_registry_with_mock):
+        registry, mock = provider_registry_with_mock
+        graph = Graph("chat").start().user().agent("Plain", thinking_level="off").end().build()
+        runner = FlowRunner(graph=graph, provider_registry=registry)
+        runner.run("ping")
+        assert mock.last_config.thinking_enabled is False
+        assert mock.last_config.thinking_budget is None
+
+    def test_vision_flag_propagates(self, provider_registry_with_mock):
+        registry, mock = provider_registry_with_mock
+        graph = (
+            Graph("chat")
+            .start()
+            .user()
+            .vision("Look", model="gemma4:26b", provider="ollama")
+            .end()
+            .build()
+        )
+        runner = FlowRunner(graph=graph, provider_registry=registry)
+        runner.run("ping")
+        # vision() always sets vision=True via the builder regardless of
+        # caller args; either way the config should reflect it.
+        assert mock.last_config.vision is True
+
+
 class TestSimpleGraphSnippet:
     """Cover the full v0.1.2 release-note snippet end-to-end."""
 

--- a/quartermaster-graph/pyproject.toml
+++ b/quartermaster-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-graph"
-version = "0.1.2"
+version = "0.1.3"
 description = "Framework-agnostic agent graph schema for AI agent workflows as directed acyclic graphs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     # Enums

--- a/quartermaster-mcp-client/pyproject.toml
+++ b/quartermaster-mcp-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-mcp-client"
-version = "0.1.2"
+version = "0.1.3"
 description = "Lightweight MCP (Model Context Protocol) client with async/sync support, SSE and Streamable HTTP transports"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/quartermaster-nodes/pyproject.toml
+++ b/quartermaster-nodes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-nodes"
-version = "0.1.2"
+version = "0.1.3"
 description = "Library of composable node types for building AI agent graphs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1",
-    "quartermaster-graph>=0.1.2",
-    "quartermaster-providers>=0.1.2",
+    "quartermaster-graph>=0.1.3",
+    "quartermaster-providers>=0.1.3",
     "simpleeval>=1.0.5",
 ]
 

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     # Enums

--- a/quartermaster-providers/pyproject.toml
+++ b/quartermaster-providers/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-providers"
-version = "0.1.2"
+version = "0.1.3"
 description = "Unified multi-LLM provider abstraction supporting OpenAI, Anthropic, Google, Groq, xAI and more"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -33,6 +33,11 @@ dependencies = [
     # caused ``register_local("ollama")`` to fail for users who never asked for
     # cloud OpenAI access. See the 0.1.2 release notes for details.
     "openai>=1.0",
+    # ``httpx`` powers ``OllamaProvider.chat()`` — the synchronous
+    # native-``/api/chat`` shim downstream callers asked for so they can
+    # call Ollama from non-async stacks (Celery workers, Django views,
+    # CLI scripts) without ``asgiref.async_to_sync`` wrappers.
+    "httpx>=0.25",
 ]
 
 [project.optional-dependencies]

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -18,6 +18,7 @@ Example:
 
 from quartermaster_providers.base import AbstractLLMProvider
 from quartermaster_providers.config import LLMConfig
+from quartermaster_providers.providers.local import ChatResult
 from quartermaster_providers.exceptions import (
     AuthenticationError,
     ContentFilterError,
@@ -47,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __author__ = "MindMade"
 
 __all__ = [
@@ -80,4 +81,6 @@ __all__ = [
     "infer_provider",
     "get_default_registry",
     "register_local",
+    # Sync chat shim result type
+    "ChatResult",
 ]

--- a/quartermaster-providers/src/quartermaster_providers/providers/local.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/local.py
@@ -50,6 +50,12 @@ def _normalize_openai_compat_url(base_url: str) -> str:
     return f"{stripped}/v1"
 
 
+# Same set the engine's ``_build_llm_config`` validates against — kept
+# in sync by name (defining it here too rather than importing across
+# the engine→providers boundary, which would invert the dep direction).
+_VALID_THINKING_LEVELS: frozenset[str] = frozenset({"off", "low", "medium", "high"})
+
+
 # Hostnames / IPs that point at cloud-metadata or link-local services —
 # legitimate Ollama deployments never live here.  Operators *could* set
 # these intentionally for niche tunneling setups, so we warn rather than
@@ -176,6 +182,7 @@ class OllamaProvider(OpenAICompatibleProvider):
         self,
         base_url: str | None = None,
         api_key: str = "ollama",
+        default_model: str | None = None,
         **kwargs,
     ):
         resolved = base_url or os.environ.get("OLLAMA_HOST") or self.DEFAULT_BASE_URL
@@ -184,6 +191,12 @@ class OllamaProvider(OpenAICompatibleProvider):
         # legitimate tunnels; in multi-tenant setups it makes hostile
         # SSRF attempts visible in logs even if we don't outright block.
         _warn_if_suspicious_url(resolved)
+        # Stash the registration-time default model so ``chat()`` can use
+        # it when callers omit the per-call ``model=`` kwarg — without
+        # this the docstring's "Defaults to the provider's bound default
+        # model" claim was vacuously broken (the registry's default_model
+        # was stored on the registry, never reached the provider).
+        self._chat_default_model = default_model
         super().__init__(
             base_url=_normalize_openai_compat_url(resolved),
             api_key=api_key,
@@ -204,6 +217,12 @@ class OllamaProvider(OpenAICompatibleProvider):
     # ``reasoning`` text when ``message.content`` comes back empty, and
     # raises connection errors instead of swallowing them into a
     # ``success=True`` ``FlowResult``.
+    #
+    # NOTE for future maintainers: ``chat()`` is INTENTIONALLY synchronous
+    # alongside the inherited async ``generate_*`` methods.  Do not add a
+    # ``chat_async()`` cousin — if you need async on this provider, call
+    # ``generate_native_response`` (the OpenAI-compat path).  Two flavours
+    # of the same call are easier to maintain than three.
 
     def chat(
         self,
@@ -222,9 +241,10 @@ class OllamaProvider(OpenAICompatibleProvider):
             messages: OpenAI-style ``[{"role": "user", "content": "..."}]``
                 list.  ``system``/``user``/``assistant``/``tool`` roles
                 pass through verbatim.
-            model: Model id (e.g. ``"gemma4:26b"``).  Defaults to the
-                provider's bound default model.  Required when no default
-                is configured.
+            model: Model id (e.g. ``"gemma4:26b"``).  When omitted, the
+                provider's registration-time ``default_model`` is used
+                (set via ``register_local("ollama", default_model=...)``).
+                If neither is supplied the call raises ``ProviderError``.
             tools: Optional tool definitions in OpenAI function-calling
                 shape; passed through to Ollama unchanged.
             temperature: Sampling temperature (Ollama maps it to
@@ -235,8 +255,9 @@ class OllamaProvider(OpenAICompatibleProvider):
                 the default 2 048-token budget on internal thinking
                 before producing visible output.
             thinking_level: One of ``off``/``low``/``medium``/``high``,
-                or ``None`` to leave it to the model.  Forwarded as
-                Ollama's ``think`` parameter.
+                or ``None`` to leave it to the model.  Anything else
+                logs a warning and is treated as ``off``.  Forwarded as
+                Ollama's ``think`` boolean.
             timeout: HTTP timeout in seconds.  Connection / read errors
                 bubble up as :class:`ServiceUnavailableError`.
 
@@ -272,10 +293,21 @@ class OllamaProvider(OpenAICompatibleProvider):
         if tools:
             payload["tools"] = list(tools)
         if thinking_level is not None:
-            # Ollama's native parameter name is ``think`` (bool/string);
-            # we accept the higher-level enum so callers don't have to
-            # know which version of Ollama they're talking to.
-            payload["think"] = thinking_level not in ("off", False, None)
+            # Ollama's native parameter name is ``think`` (bool); we
+            # accept the higher-level enum so callers don't have to
+            # know which version of Ollama they're talking to.  Validate
+            # against the same set the engine's ``_build_llm_config``
+            # uses so a typo here can't silently flip ``think`` on.
+            if thinking_level not in _VALID_THINKING_LEVELS:
+                logger.warning(
+                    "Unknown thinking_level=%r for OllamaProvider.chat() "
+                    "(expected one of %s); falling back to 'off'.",
+                    thinking_level,
+                    sorted(_VALID_THINKING_LEVELS),
+                )
+                payload["think"] = False
+            else:
+                payload["think"] = thinking_level != "off"
 
         url = f"{_strip_v1(self.base_url)}/api/chat"
 
@@ -319,16 +351,16 @@ class OllamaProvider(OpenAICompatibleProvider):
         return _parse_native_chat(body)
 
     def _default_model_for_chat(self) -> str | None:
-        """Best-effort default model lookup for the sync chat shim.
+        """Default model for the sync ``chat()`` shim.
 
-        Ollama doesn't carry a default model on the connection itself —
-        the registry holds the engine-level default set via
-        ``register_local("ollama", default_model=...)``.  We don't have a
-        back-pointer to the registry from inside the provider, so this
-        hook just returns ``None`` and lets the caller pass ``model=``.
-        Subclasses (or registry-aware factories) may override it.
+        Set by :meth:`__init__` from the ``default_model`` constructor
+        kwarg, which :meth:`ProviderRegistry.register_local` forwards
+        through whenever ``register_local("ollama", default_model=...)``
+        was used.  Returns ``None`` for instances constructed by hand
+        without a default — in which case ``chat()`` will require an
+        explicit ``model=`` per call.
         """
-        return getattr(self, "_chat_default_model", None)
+        return self._chat_default_model
 
 
 def _parse_native_chat(body: dict[str, Any]) -> ChatResult:

--- a/quartermaster-providers/src/quartermaster_providers/providers/local.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/local.py
@@ -23,9 +23,16 @@ All of these expose an OpenAI-compatible ``/v1`` endpoint.
 
 from __future__ import annotations
 
+import logging
 import os
+from dataclasses import dataclass, field
+from typing import Any
 
+from quartermaster_providers.exceptions import ProviderError, ServiceUnavailableError
 from quartermaster_providers.providers.openai_compat import OpenAICompatibleProvider
+from quartermaster_providers.types import ToolCall
+
+logger = logging.getLogger(__name__)
 
 
 def _normalize_openai_compat_url(base_url: str) -> str:
@@ -41,6 +48,41 @@ def _normalize_openai_compat_url(base_url: str) -> str:
     if stripped.endswith("/v1") or "/v1/" in stripped:
         return stripped
     return f"{stripped}/v1"
+
+
+def _strip_v1(base_url: str) -> str:
+    """Drop a trailing ``/v1`` segment.
+
+    The OpenAI-compat path lives at ``/v1/chat/completions`` but the
+    native Ollama API lives at ``/api/chat``.  ``OllamaProvider`` stores
+    its base URL in the ``/v1`` form (so the openai SDK works), so the
+    sync ``chat()`` shim has to peel ``/v1`` back off before talking to
+    ``/api/chat``.
+    """
+    if not base_url:
+        return base_url
+    stripped = base_url.rstrip("/")
+    if stripped.endswith("/v1"):
+        return stripped[: -len("/v1")]
+    return stripped
+
+
+@dataclass
+class ChatResult:
+    """Result of a synchronous :meth:`OllamaProvider.chat` call.
+
+    Mirrors what downstream integrators were already building by hand on
+    top of raw ``requests.post`` against ``/v1/chat/completions``: a
+    populated ``content`` string (auto-promoted from a ``thinking``/
+    ``reasoning`` field when the model leaves ``content`` empty),
+    structured ``tool_calls``, and a usage breakdown.
+    """
+
+    content: str
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    usage: dict[str, int] = field(default_factory=dict)
+    stop_reason: str | None = None
+    raw: dict[str, Any] | None = None
 
 
 class OllamaProvider(OpenAICompatibleProvider):
@@ -77,6 +119,188 @@ class OllamaProvider(OpenAICompatibleProvider):
             provider_name="ollama",
             **kwargs,
         )
+
+    # ── Synchronous native /api/chat shim ────────────────────────────
+    #
+    # The async ``generate_*`` methods route through the OpenAI SDK against
+    # Ollama's ``/v1`` proxy, which is great for graph runs but painful
+    # for non-async callers (Celery, Django request-handlers, CLI scripts)
+    # — they need ``asgiref.sync.async_to_sync`` wrappers and they lose
+    # the reasoning-content surfacing from gemma4-style models.  ``chat()``
+    # is the small, sync, native replacement they actually want: hits
+    # ``POST {base}/api/chat`` directly via httpx, surfaces ``thinking`` /
+    # ``reasoning`` text when ``message.content`` comes back empty, and
+    # raises connection errors instead of swallowing them into a
+    # ``success=True`` ``FlowResult``.
+
+    def chat(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+        thinking_level: str | None = None,
+        timeout: float = 120.0,
+    ) -> ChatResult:
+        """Synchronous one-shot chat against Ollama's native ``/api/chat``.
+
+        Args:
+            messages: OpenAI-style ``[{"role": "user", "content": "..."}]``
+                list.  ``system``/``user``/``assistant``/``tool`` roles
+                pass through verbatim.
+            model: Model id (e.g. ``"gemma4:26b"``).  Defaults to the
+                provider's bound default model.  Required when no default
+                is configured.
+            tools: Optional tool definitions in OpenAI function-calling
+                shape; passed through to Ollama unchanged.
+            temperature: Sampling temperature (Ollama maps it to
+                ``options.temperature``).
+            max_output_tokens: Hard cap on generated tokens (mapped to
+                Ollama's ``options.num_predict``).  Critical for
+                reasoning models like ``gemma4:26b`` that otherwise burn
+                the default 2 048-token budget on internal thinking
+                before producing visible output.
+            thinking_level: One of ``off``/``low``/``medium``/``high``,
+                or ``None`` to leave it to the model.  Forwarded as
+                Ollama's ``think`` parameter.
+            timeout: HTTP timeout in seconds.  Connection / read errors
+                bubble up as :class:`ServiceUnavailableError`.
+
+        Returns:
+            A :class:`ChatResult` with ``content`` always populated when
+            the server returned anything visible — ``thinking`` /
+            ``reasoning`` fields are promoted to ``content`` when the
+            primary ``message.content`` field comes back empty.
+        """
+        import httpx
+
+        resolved_model = model or self._default_model_for_chat()
+        if not resolved_model:
+            raise ProviderError(
+                "OllamaProvider.chat() requires a model. Pass model=... "
+                "or register the provider with a default_model.",
+                provider=self.PROVIDER_NAME,
+            )
+
+        options: dict[str, Any] = {}
+        if temperature is not None:
+            options["temperature"] = float(temperature)
+        if max_output_tokens is not None:
+            options["num_predict"] = int(max_output_tokens)
+
+        payload: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": list(messages),
+            "stream": False,
+        }
+        if options:
+            payload["options"] = options
+        if tools:
+            payload["tools"] = list(tools)
+        if thinking_level is not None:
+            # Ollama's native parameter name is ``think`` (bool/string);
+            # we accept the higher-level enum so callers don't have to
+            # know which version of Ollama they're talking to.
+            payload["think"] = thinking_level not in ("off", False, None)
+
+        url = f"{_strip_v1(self.base_url)}/api/chat"
+
+        try:
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(url, json=payload)
+                response.raise_for_status()
+                body = response.json()
+        except httpx.HTTPStatusError as exc:
+            # Status-code errors carry useful body context; surface it.
+            raise ProviderError(
+                f"Ollama returned HTTP {exc.response.status_code}: {exc.response.text[:500]}",
+                provider=self.PROVIDER_NAME,
+                status_code=exc.response.status_code,
+            ) from exc
+        except (httpx.ConnectError, httpx.ReadError, httpx.ReadTimeout) as exc:
+            # Network unreachable / timed out — caller needs to know
+            # this didn't even hit the model, not a soft "no answer".
+            raise ServiceUnavailableError(
+                f"Could not reach Ollama at {url}: {exc}",
+                provider=self.PROVIDER_NAME,
+            ) from exc
+        except Exception as exc:  # pragma: no cover — defensive
+            raise ProviderError(
+                f"Unexpected error talking to Ollama: {exc}",
+                provider=self.PROVIDER_NAME,
+            ) from exc
+
+        return _parse_native_chat(body)
+
+    def _default_model_for_chat(self) -> str | None:
+        """Best-effort default model lookup for the sync chat shim.
+
+        Ollama doesn't carry a default model on the connection itself —
+        the registry holds the engine-level default set via
+        ``register_local("ollama", default_model=...)``.  We don't have a
+        back-pointer to the registry from inside the provider, so this
+        hook just returns ``None`` and lets the caller pass ``model=``.
+        Subclasses (or registry-aware factories) may override it.
+        """
+        return getattr(self, "_chat_default_model", None)
+
+
+def _parse_native_chat(body: dict[str, Any]) -> ChatResult:
+    """Translate Ollama's ``/api/chat`` JSON into a :class:`ChatResult`.
+
+    Handles three classes of model behaviour that downstream integrators
+    keep tripping over:
+
+    * Plain models — ``message.content`` is the answer.
+    * Reasoning models (``gemma4:26b`` and friends) — ``message.content``
+      may be empty while ``message.thinking`` (newer Ollama) or a
+      sibling ``reasoning`` field carries the user-visible text.
+    * Tool-calling — ``message.tool_calls`` is a list of
+      ``{function: {name, arguments}}`` dicts that we normalise into
+      :class:`ToolCall` instances.
+    """
+    message = body.get("message") or {}
+    content = (message.get("content") or "").strip()
+    if not content:
+        for fallback_key in ("thinking", "reasoning", "reasoning_content"):
+            value = message.get(fallback_key) or body.get(fallback_key)
+            if isinstance(value, str) and value.strip():
+                content = value.strip()
+                break
+
+    raw_tool_calls = message.get("tool_calls") or []
+    tool_calls: list[ToolCall] = []
+    for idx, call in enumerate(raw_tool_calls):
+        fn = call.get("function") or {}
+        name = fn.get("name") or call.get("name") or ""
+        arguments = fn.get("arguments") or call.get("arguments") or {}
+        tool_calls.append(
+            ToolCall(
+                tool_name=name,
+                tool_id=str(call.get("id") or f"call_{idx}"),
+                parameters=dict(arguments) if isinstance(arguments, dict) else {"raw": arguments},
+            )
+        )
+
+    usage: dict[str, int] = {}
+    if "prompt_eval_count" in body:
+        usage["prompt_tokens"] = int(body["prompt_eval_count"])
+    if "eval_count" in body:
+        usage["completion_tokens"] = int(body["eval_count"])
+    if usage:
+        usage["total_tokens"] = usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
+
+    stop_reason = body.get("done_reason") or ("stop" if body.get("done") else None)
+
+    return ChatResult(
+        content=content,
+        tool_calls=tool_calls,
+        usage=usage,
+        stop_reason=stop_reason,
+        raw=body,
+    )
 
 
 class VLLMProvider(OpenAICompatibleProvider):

--- a/quartermaster-providers/src/quartermaster_providers/providers/local.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/local.py
@@ -51,20 +51,32 @@ def _normalize_openai_compat_url(base_url: str) -> str:
 
 
 def _strip_v1(base_url: str) -> str:
-    """Drop a trailing ``/v1`` segment.
+    """Drop the ``/v1`` segment that ``_normalize_openai_compat_url`` adds.
 
     The OpenAI-compat path lives at ``/v1/chat/completions`` but the
     native Ollama API lives at ``/api/chat``.  ``OllamaProvider`` stores
     its base URL in the ``/v1`` form (so the openai SDK works), so the
     sync ``chat()`` shim has to peel ``/v1`` back off before talking to
     ``/api/chat``.
+
+    We only strip when ``/v1`` sits directly under the host root —
+    ``http://host:port/v1``.  A URL like ``http://gateway/api/v1`` is
+    likely a corporate proxy with its own path prefix (where stripping
+    would silently produce ``http://gateway/api`` and route ``/api/chat``
+    requests to ``/api/api/chat``).  In that case we leave the URL alone
+    and let the caller hit whatever they configured.
     """
     if not base_url:
         return base_url
-    stripped = base_url.rstrip("/")
-    if stripped.endswith("/v1"):
-        return stripped[: -len("/v1")]
-    return stripped
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(base_url)
+    path = parsed.path.rstrip("/")
+    if path == "/v1":
+        # Bare host + /v1 — strip it.
+        return urlunparse(parsed._replace(path=""))
+    # Anything else (deeper path, or no /v1 at all) is left untouched.
+    return base_url.rstrip("/")
 
 
 @dataclass
@@ -219,9 +231,21 @@ class OllamaProvider(OpenAICompatibleProvider):
                 provider=self.PROVIDER_NAME,
                 status_code=exc.response.status_code,
             ) from exc
-        except (httpx.ConnectError, httpx.ReadError, httpx.ReadTimeout) as exc:
-            # Network unreachable / timed out — caller needs to know
-            # this didn't even hit the model, not a soft "no answer".
+        except (
+            httpx.ConnectError,
+            httpx.ReadError,
+            httpx.WriteError,
+            httpx.TimeoutException,
+        ) as exc:
+            # Network unreachable, write failed, or any flavour of
+            # timeout — connect/read/write/pool — all mean the request
+            # didn't get a usable answer from Ollama.  ``TimeoutException``
+            # is the umbrella for ``ConnectTimeout`` (server up but slow
+            # to accept the socket — common during model load) plus
+            # ``ReadTimeout`` and ``WriteTimeout``.  Catching only
+            # ``ReadTimeout`` would let ``ConnectTimeout`` bubble out as
+            # a generic ``ProviderError`` and confuse callers about
+            # whether Ollama was reachable at all.
             raise ServiceUnavailableError(
                 f"Could not reach Ollama at {url}: {exc}",
                 provider=self.PROVIDER_NAME,

--- a/quartermaster-providers/src/quartermaster_providers/providers/local.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/local.py
@@ -50,6 +50,47 @@ def _normalize_openai_compat_url(base_url: str) -> str:
     return f"{stripped}/v1"
 
 
+# Hostnames / IPs that point at cloud-metadata or link-local services —
+# legitimate Ollama deployments never live here.  Operators *could* set
+# these intentionally for niche tunneling setups, so we warn rather than
+# block, but the warning makes it visible in logs when a misconfiguration
+# (or, in multi-tenant settings, a hostile end-user-supplied base_url)
+# would point an HTTP request at IMDS / link-local space.
+_SSRF_SUSPICIOUS_HOSTS: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",  # AWS / GCP / Azure / Oracle Cloud IMDS
+        "metadata.google.internal",
+        "metadata",
+        "fd00:ec2::254",  # AWS IPv6 IMDS
+        "100.100.100.200",  # Alibaba Cloud metadata
+    }
+)
+
+
+def _warn_if_suspicious_url(base_url: str) -> None:
+    """Log a warning when *base_url* points at a known SSRF-magnet host.
+
+    Operators set ``base_url`` at registration time, so this is at most
+    a misconfiguration alarm in single-tenant deployments.  In multi-
+    tenant setups where end users can supply their own provider URL it
+    becomes a soft SSRF gate — the warning lands in operator logs even
+    if the hostile request still goes through.
+    """
+    if not base_url:
+        return
+    from urllib.parse import urlparse
+
+    host = (urlparse(base_url).hostname or "").lower()
+    if host in _SSRF_SUSPICIOUS_HOSTS:
+        logger.warning(
+            "OllamaProvider base_url targets %r — this is a known cloud-"
+            "metadata / link-local address, not an Ollama instance. If you "
+            "intentionally tunnel Ollama through that host you can ignore "
+            "this; otherwise check your configuration.",
+            host,
+        )
+
+
 def _strip_v1(base_url: str) -> str:
     """Drop the ``/v1`` segment that ``_normalize_openai_compat_url`` adds.
 
@@ -59,12 +100,19 @@ def _strip_v1(base_url: str) -> str:
     sync ``chat()`` shim has to peel ``/v1`` back off before talking to
     ``/api/chat``.
 
-    We only strip when ``/v1`` sits directly under the host root —
+    Only strips when ``/v1`` sits directly under the host root —
     ``http://host:port/v1``.  A URL like ``http://gateway/api/v1`` is
     likely a corporate proxy with its own path prefix (where stripping
     would silently produce ``http://gateway/api`` and route ``/api/chat``
-    requests to ``/api/api/chat``).  In that case we leave the URL alone
-    and let the caller hit whatever they configured.
+    requests to ``/api/api/chat``).  In that case we leave the URL alone.
+
+    When stripping, the result is reconstructed from scheme + host (+
+    port) only — userinfo, query, and fragment from the input are
+    intentionally dropped.  This blunts the attack class where a
+    base_url like ``http://user:pass@host/v1`` would otherwise leak the
+    credentials into the outbound ``/api/chat`` request, and where a
+    ``http://host/v1?injected=...`` query string would silently mangle
+    the final URL.
     """
     if not base_url:
         return base_url
@@ -73,8 +121,15 @@ def _strip_v1(base_url: str) -> str:
     parsed = urlparse(base_url)
     path = parsed.path.rstrip("/")
     if path == "/v1":
-        # Bare host + /v1 — strip it.
-        return urlunparse(parsed._replace(path=""))
+        # Reconstruct from trusted components only — drop userinfo,
+        # query, and fragment so they can't ride along into the
+        # request URL.  hostname + port is what we actually need.
+        host = parsed.hostname or ""
+        if parsed.port is not None:
+            netloc = f"{host}:{parsed.port}"
+        else:
+            netloc = host
+        return urlunparse((parsed.scheme, netloc, "", "", "", ""))
     # Anything else (deeper path, or no /v1 at all) is left untouched.
     return base_url.rstrip("/")
 
@@ -124,6 +179,11 @@ class OllamaProvider(OpenAICompatibleProvider):
         **kwargs,
     ):
         resolved = base_url or os.environ.get("OLLAMA_HOST") or self.DEFAULT_BASE_URL
+        # Surface a warning if the configured URL points at a known
+        # cloud-metadata / link-local host.  Operators can ignore it for
+        # legitimate tunnels; in multi-tenant setups it makes hostile
+        # SSRF attempts visible in logs even if we don't outright block.
+        _warn_if_suspicious_url(resolved)
         super().__init__(
             base_url=_normalize_openai_compat_url(resolved),
             api_key=api_key,

--- a/quartermaster-providers/src/quartermaster_providers/registry.py
+++ b/quartermaster-providers/src/quartermaster_providers/registry.py
@@ -247,6 +247,13 @@ class ProviderRegistry:
                 ctor_kwargs["base_url"] = _normalize_openai_compat_url(base_url)
             if api_key:
                 ctor_kwargs["api_key"] = api_key
+            # Pass default_model through so providers that expose a sync
+            # facade (currently OllamaProvider.chat()) can fall back to
+            # it when callers omit ``model=`` per call.  Only forwarded
+            # when the provider class accepts it, to stay backwards-
+            # compatible with engines that don't.
+            if default_model and "default_model" in cls.__init__.__code__.co_varnames:
+                ctor_kwargs["default_model"] = default_model
             self._factories[provider_name] = (cls, ctor_kwargs)
         else:
             raise ProviderError(

--- a/quartermaster-providers/tests/test_ollama_chat.py
+++ b/quartermaster-providers/tests/test_ollama_chat.py
@@ -378,3 +378,64 @@ class TestArgValidation:
             thinking_level="high",
         )
         assert mock.last_payload["think"] is True
+
+    def test_unknown_thinking_level_warns_and_disables(self, patch_httpx_client, caplog):
+        """Regression for the v0.1.3 code-review HIGH #2: a typo'd
+        thinking_level (e.g. ``"meidum"``) used to silently flip
+        ``think=True`` because the old check was just
+        ``thinking_level not in ("off", False, None)``.  Now it warns
+        and falls back to ``off`` to match the engine-side validation."""
+        import logging
+
+        mock = patch_httpx_client(
+            lambda _r: httpx.Response(200, json={"message": {"content": "x"}, "done": True})
+        )
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        with caplog.at_level(logging.WARNING, logger="quartermaster_providers.providers.local"):
+            provider.chat(
+                messages=[{"role": "user", "content": "?"}],
+                model="gemma4:26b",
+                thinking_level="meidum",  # typo
+            )
+        assert mock.last_payload["think"] is False
+        assert any("Unknown thinking_level" in rec.message for rec in caplog.records)
+
+
+class TestDefaultModelFromConstructor:
+    """Regression for the v0.1.3 code-review HIGH #1: the registry's
+    ``default_model`` must reach ``OllamaProvider.chat()`` so callers
+    don't have to repeat the model name on every call."""
+
+    def test_constructor_default_model_used_when_call_omits_model(self, patch_httpx_client):
+        mock = patch_httpx_client(
+            lambda _r: httpx.Response(200, json={"message": {"content": "ok"}, "done": True})
+        )
+        provider = OllamaProvider(
+            base_url="http://localhost:11434/v1",
+            default_model="gemma4:26b",
+        )
+        result = provider.chat(messages=[{"role": "user", "content": "?"}])
+        assert result.content == "ok"
+        assert mock.last_payload["model"] == "gemma4:26b"
+
+    def test_call_model_overrides_default(self, patch_httpx_client):
+        mock = patch_httpx_client(
+            lambda _r: httpx.Response(200, json={"message": {"content": "ok"}, "done": True})
+        )
+        provider = OllamaProvider(
+            base_url="http://localhost:11434/v1",
+            default_model="gemma4:26b",
+        )
+        provider.chat(messages=[{"role": "user", "content": "?"}], model="other-model")
+        assert mock.last_payload["model"] == "other-model"
+
+    def test_register_local_threads_default_model_to_provider(self):
+        """End-to-end: register_local(default_model=...) must populate
+        OllamaProvider's _chat_default_model so chat() can use it."""
+        from quartermaster_providers import ProviderRegistry
+
+        reg = ProviderRegistry(auto_configure=False)
+        reg.register_local("ollama", default_model="gemma4:26b")
+        provider = reg.get("ollama")
+        assert isinstance(provider, OllamaProvider)
+        assert provider._default_model_for_chat() == "gemma4:26b"

--- a/quartermaster-providers/tests/test_ollama_chat.py
+++ b/quartermaster-providers/tests/test_ollama_chat.py
@@ -76,6 +76,19 @@ class TestStripV1:
     def test_leaves_bare_host_alone(self):
         assert _strip_v1("http://localhost:11434") == "http://localhost:11434"
 
+    def test_preserves_corporate_gateway_path(self):
+        """Regression: ``http://gateway/api/v1`` is a real-world prefix
+        for corporate Ollama proxies.  We must NOT strip ``/v1`` and
+        produce ``http://gateway/api`` (which would route ``/api/chat``
+        requests to ``/api/api/chat`` and 404)."""
+        assert _strip_v1("http://gateway.corp/api/v1") == "http://gateway.corp/api/v1"
+
+    def test_preserves_v1beta(self):
+        assert _strip_v1("http://api.example.com/v1beta") == "http://api.example.com/v1beta"
+
+    def test_preserves_path_segment_named_v1(self):
+        assert _strip_v1("http://h/v1/inner") == "http://h/v1/inner"
+
 
 # ── chat() happy path ──────────────────────────────────────────────────
 
@@ -253,6 +266,37 @@ class TestErrorBubbling:
         patch_httpx_client(lambda _r: httpx.Response(404, text='{"error":"model not found"}'))
         provider = OllamaProvider(base_url="http://localhost:11434/v1")
         with pytest.raises(ProviderError, match="HTTP 404"):
+            provider.chat(messages=[{"role": "user", "content": "?"}], model="gemma4:26b")
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [httpx.ConnectTimeout, httpx.ReadTimeout, httpx.WriteTimeout, httpx.PoolTimeout],
+        ids=["connect", "read", "write", "pool"],
+    )
+    def test_all_timeout_subclasses_raise_service_unavailable(self, monkeypatch, exc_cls):
+        """Regression for the v0.1.3 review: pre-fix only ``ReadTimeout``
+        was caught; ``ConnectTimeout`` (server up but slow to accept the
+        socket — common while a model is loading) escaped and surfaced as
+        a generic ``ProviderError`` instead.  All timeout subclasses must
+        now route through ``ServiceUnavailableError`` so callers can
+        distinguish "Ollama unreachable" from other failures."""
+
+        class _BoomClient:
+            def __init__(self, *_a, **_k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def post(self, *_a, **_k):
+                raise exc_cls("simulated timeout")
+
+        monkeypatch.setattr(httpx, "Client", _BoomClient)
+        provider = OllamaProvider(base_url="http://slow:11434/v1")
+        with pytest.raises(ServiceUnavailableError, match="Could not reach Ollama"):
             provider.chat(messages=[{"role": "user", "content": "?"}], model="gemma4:26b")
 
 

--- a/quartermaster-providers/tests/test_ollama_chat.py
+++ b/quartermaster-providers/tests/test_ollama_chat.py
@@ -1,0 +1,291 @@
+"""Tests for ``OllamaProvider.chat`` — the v0.1.3 sync native-``/api/chat`` shim.
+
+We don't depend on a running Ollama daemon: we monkeypatch ``httpx.Client`` to
+return canned responses and assert the request shape + result parsing.
+
+NOTE: ``openai`` is imported eagerly below so its ``_DefaultHttpxClient`` (a
+``httpx.Client`` subclass) is built before our fixture monkeypatches
+``httpx.Client``.  Without this, patching ``httpx.Client`` in a fixture and
+then constructing an ``OllamaProvider`` (which lazy-imports openai) hits a
+``TypeError: function() argument 'code' must be code, not str`` from openai
+trying to subclass our patched function.
+"""
+
+from __future__ import annotations
+
+import openai  # noqa: F401  — eager import; see module docstring above
+
+import httpx
+import pytest
+
+from quartermaster_providers import ChatResult
+from quartermaster_providers.exceptions import ProviderError, ServiceUnavailableError
+from quartermaster_providers.providers.local import OllamaProvider, _strip_v1
+
+
+class _MockTransport(httpx.MockTransport):
+    """Tiny httpx mock that records the last request for assertion."""
+
+    def __init__(self, responder):
+        self.last_request = None
+        self.last_payload: dict = {}
+        super().__init__(self._wrap(responder))
+
+    def _wrap(self, responder):
+        def handle(request: httpx.Request) -> httpx.Response:
+            self.last_request = request
+            import json as _json
+
+            self.last_payload = _json.loads(request.content) if request.content else {}
+            return responder(request)
+
+        return handle
+
+
+@pytest.fixture
+def patch_httpx_client(monkeypatch):
+    """Replace ``httpx.Client`` with one wired to a mock transport."""
+
+    transport_holder: dict[str, _MockTransport] = {}
+
+    def install(responder):
+        mock = _MockTransport(responder)
+        transport_holder["transport"] = mock
+        original = httpx.Client
+
+        def _factory(*args, **kwargs):
+            kwargs["transport"] = mock
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "Client", _factory)
+        return mock
+
+    return install
+
+
+# ── URL routing ────────────────────────────────────────────────────────
+
+
+class TestStripV1:
+    def test_strips_trailing_v1(self):
+        assert _strip_v1("http://localhost:11434/v1") == "http://localhost:11434"
+
+    def test_strips_v1_with_trailing_slash(self):
+        assert _strip_v1("http://localhost:11434/v1/") == "http://localhost:11434"
+
+    def test_leaves_bare_host_alone(self):
+        assert _strip_v1("http://localhost:11434") == "http://localhost:11434"
+
+
+# ── chat() happy path ──────────────────────────────────────────────────
+
+
+class TestChatHappyPath:
+    def test_basic_text_response(self, patch_httpx_client):
+        def responder(_req):
+            return httpx.Response(
+                200,
+                json={
+                    "model": "gemma4:26b",
+                    "message": {"role": "assistant", "content": "Pozdravljen!"},
+                    "done": True,
+                    "done_reason": "stop",
+                    "prompt_eval_count": 12,
+                    "eval_count": 4,
+                },
+            )
+
+        mock = patch_httpx_client(responder)
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        result = provider.chat(
+            messages=[{"role": "user", "content": "Pozdravljen, koliko je ura?"}],
+            model="gemma4:26b",
+            temperature=0.3,
+            max_output_tokens=128,
+        )
+
+        assert isinstance(result, ChatResult)
+        assert result.content == "Pozdravljen!"
+        assert result.tool_calls == []
+        assert result.usage == {
+            "prompt_tokens": 12,
+            "completion_tokens": 4,
+            "total_tokens": 16,
+        }
+        assert result.stop_reason == "stop"
+
+        # URL must be /api/chat (NOT /v1/chat/completions).
+        assert str(mock.last_request.url).endswith("/api/chat")
+        assert "/v1" not in str(mock.last_request.url)
+        # Payload must carry options the user asked for.
+        assert mock.last_payload["model"] == "gemma4:26b"
+        assert mock.last_payload["stream"] is False
+        assert mock.last_payload["options"] == {
+            "temperature": 0.3,
+            "num_predict": 128,
+        }
+
+
+class TestReasoningFallback:
+    """gemma4:26b empties ``content`` on short prompts and stuffs the
+    answer into ``thinking`` / ``reasoning``.  ``chat()`` must promote
+    the first non-empty fallback so callers don't see an empty string."""
+
+    def test_promotes_thinking_when_content_empty(self, patch_httpx_client):
+        patch_httpx_client(
+            lambda _r: httpx.Response(
+                200,
+                json={
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "thinking": "Trenutno je deset.",
+                    },
+                    "done": True,
+                },
+            )
+        )
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        result = provider.chat(messages=[{"role": "user", "content": "?"}], model="gemma4:26b")
+        assert result.content == "Trenutno je deset."
+
+    def test_promotes_reasoning_when_content_and_thinking_empty(self, patch_httpx_client):
+        patch_httpx_client(
+            lambda _r: httpx.Response(
+                200,
+                json={
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning": "Reasoning text here.",
+                    },
+                    "done": True,
+                },
+            )
+        )
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        result = provider.chat(messages=[{"role": "user", "content": "?"}], model="gemma4:26b")
+        assert result.content == "Reasoning text here."
+
+    def test_empty_when_nothing_present(self, patch_httpx_client):
+        patch_httpx_client(
+            lambda _r: httpx.Response(
+                200,
+                json={"message": {"role": "assistant", "content": ""}, "done": True},
+            )
+        )
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        result = provider.chat(messages=[{"role": "user", "content": "?"}], model="gemma4:26b")
+        assert result.content == ""
+
+
+class TestToolCalls:
+    def test_tool_calls_normalized(self, patch_httpx_client):
+        patch_httpx_client(
+            lambda _r: httpx.Response(
+                200,
+                json={
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": {"city": "Ljubljana"},
+                                }
+                            }
+                        ],
+                    },
+                    "done": True,
+                },
+            )
+        )
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        result = provider.chat(
+            messages=[{"role": "user", "content": "weather?"}],
+            model="gemma4:26b",
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].tool_name == "get_weather"
+        assert result.tool_calls[0].parameters == {"city": "Ljubljana"}
+
+
+# ── error bubbling ────────────────────────────────────────────────────
+
+
+class TestErrorBubbling:
+    """Connection failures must raise (not return success=True with empty content)."""
+
+    def test_connect_error_raises_service_unavailable(self, monkeypatch):
+        def explode(*_a, **_k):
+            raise httpx.ConnectError("connection refused")
+
+        class _BoomClient:
+            def __init__(self, *_a, **_k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def post(self, *_a, **_k):
+                explode()
+
+        monkeypatch.setattr(httpx, "Client", _BoomClient)
+        provider = OllamaProvider(base_url="http://wrong:11434/v1")
+        with pytest.raises(ServiceUnavailableError, match="Could not reach Ollama"):
+            provider.chat(messages=[{"role": "user", "content": "?"}], model="gemma4:26b")
+
+    def test_http_status_error_raises_provider_error(self, patch_httpx_client):
+        patch_httpx_client(lambda _r: httpx.Response(404, text='{"error":"model not found"}'))
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        with pytest.raises(ProviderError, match="HTTP 404"):
+            provider.chat(messages=[{"role": "user", "content": "?"}], model="gemma4:26b")
+
+
+# ── argument validation ───────────────────────────────────────────────
+
+
+class TestArgValidation:
+    def test_no_model_raises(self, patch_httpx_client):
+        patch_httpx_client(lambda _r: httpx.Response(200, json={"message": {"content": "x"}}))
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        with pytest.raises(ProviderError, match="requires a model"):
+            provider.chat(messages=[{"role": "user", "content": "?"}])
+
+    def test_thinking_level_off_emits_false(self, patch_httpx_client):
+        mock = patch_httpx_client(
+            lambda _r: httpx.Response(200, json={"message": {"content": "x"}, "done": True})
+        )
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        provider.chat(
+            messages=[{"role": "user", "content": "?"}],
+            model="gemma4:26b",
+            thinking_level="off",
+        )
+        assert mock.last_payload["think"] is False
+
+    def test_thinking_level_high_emits_true(self, patch_httpx_client):
+        mock = patch_httpx_client(
+            lambda _r: httpx.Response(200, json={"message": {"content": "x"}, "done": True})
+        )
+        provider = OllamaProvider(base_url="http://localhost:11434/v1")
+        provider.chat(
+            messages=[{"role": "user", "content": "?"}],
+            model="gemma4:26b",
+            thinking_level="high",
+        )
+        assert mock.last_payload["think"] is True

--- a/quartermaster-providers/tests/test_ollama_chat.py
+++ b/quartermaster-providers/tests/test_ollama_chat.py
@@ -89,6 +89,51 @@ class TestStripV1:
     def test_preserves_path_segment_named_v1(self):
         assert _strip_v1("http://h/v1/inner") == "http://h/v1/inner"
 
+    def test_drops_userinfo_when_stripping(self):
+        """Security regression — credentials embedded in base_url must
+        NOT ride along into the stripped output (which becomes the prefix
+        for /api/chat requests)."""
+        assert _strip_v1("http://user:pass@localhost:11434/v1") == "http://localhost:11434"
+
+    def test_drops_query_string_when_stripping(self):
+        """A query string on base_url cannot mangle the final URL."""
+        assert _strip_v1("http://localhost:11434/v1?injected=evil") == "http://localhost:11434"
+
+    def test_drops_fragment_when_stripping(self):
+        assert _strip_v1("http://localhost:11434/v1#section") == "http://localhost:11434"
+
+
+class TestSSRFWarning:
+    """``OllamaProvider.__init__`` must log a warning when base_url
+    points at a known cloud-metadata / link-local host — operators see
+    misconfigured URLs immediately, multi-tenant deployments get a
+    visible SSRF-attempt audit trail."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "169.254.169.254",
+            "metadata.google.internal",
+            "100.100.100.200",
+        ],
+    )
+    def test_warns_on_metadata_host(self, host, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="quartermaster_providers.providers.local"):
+            OllamaProvider(base_url=f"http://{host}/v1")
+        assert any(
+            "cloud-metadata" in rec.message and host in rec.message for rec in caplog.records
+        ), f"expected SSRF warning for {host}, got: {[r.message for r in caplog.records]}"
+
+    def test_no_warning_for_normal_host(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="quartermaster_providers.providers.local"):
+            OllamaProvider(base_url="http://localhost:11434/v1")
+            OllamaProvider(base_url="http://host.docker.internal:11434/v1")
+        assert not any("cloud-metadata" in rec.message for rec in caplog.records)
+
 
 # ── chat() happy path ──────────────────────────────────────────────────
 

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Quartermaster — modular AI agent orchestration framework. Install this to get all packages."
 readme = "README.md"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "quartermaster-graph>=0.1.2",
-    "quartermaster-providers>=0.1.2",
-    "quartermaster-tools>=0.1.2",
-    "quartermaster-nodes>=0.1.2",
-    "quartermaster-engine>=0.1.2",
+    "quartermaster-graph>=0.1.3",
+    "quartermaster-providers>=0.1.3",
+    "quartermaster-tools>=0.1.3",
+    "quartermaster-nodes>=0.1.3",
+    "quartermaster-engine>=0.1.3",
 ]
 
 [project.optional-dependencies]
@@ -54,8 +54,8 @@ observability = ["quartermaster-tools[observability]"]
 tools-all = ["quartermaster-tools[all]"]
 
 # Standalone packages (not included by default)
-mcp = ["quartermaster-mcp-client>=0.1.2"]
-code-runner = ["quartermaster-code-runner>=0.1.2"]
+mcp = ["quartermaster-mcp-client>=0.1.3"]
+code-runner = ["quartermaster-code-runner>=0.1.3"]
 
 # Everything
 all = [

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -18,7 +18,7 @@ Optional extras:
 - pip install quartermaster-sdk[all]           — Everything
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # Re-export the most common entry points for convenience
 from quartermaster_graph import (  # noqa: F401

--- a/quartermaster-tools/pyproject.toml
+++ b/quartermaster-tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-tools"
-version = "0.1.2"
+version = "0.1.3"
 description = "Tool abstraction framework and chain-of-responsibility handler pattern for AI agent orchestration"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 web = ["httpx>=0.25.0"]
-llm = ["quartermaster-providers>=0.1.2"]
+llm = ["quartermaster-providers>=0.1.3"]
 database = ["sqlalchemy>=2.0"]
 vector = ["chromadb>=0.4", "sentence-transformers>=2.2"]
 privacy = ["presidio-analyzer>=2.2"]

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,9 +3143,10 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-providers" }
 dependencies = [
+    { name = "httpx" },
     { name = "openai" },
 ]
 
@@ -3183,6 +3184,7 @@ requires-dist = [
     { name = "google-generativeai", marker = "extra == 'google'", specifier = ">=0.5" },
     { name = "groq", marker = "extra == 'all'", specifier = ">=0.5" },
     { name = "groq", marker = "extra == 'groq'", specifier = ">=0.5" },
+    { name = "httpx", specifier = ">=0.25" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "openai", specifier = ">=1.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
@@ -3195,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3294,7 +3296,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "we
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3368,7 +3370,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.1.2"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why this PR exists

A downstream integrator's retest report against v0.1.2 surfaced two real gaps in PR #5 that survived review (and a release-process trap that produced an empty PyPI release for v0.1.2 — see PR #6 + RELEASING.md):

1. **Every LLM metadata knob was dropped.** Executors built `LLMConfig` with only model/provider/system_message/temperature/stream — `llm_max_output_tokens`, `llm_max_input_tokens`, `llm_thinking_level`, `llm_vision` were silently ignored. Setting `llm_max_output_tokens=50` and watching the provider burn 2000 tokens was their main blocker for `gemma4:26b`.

2. **No sync API for non-graph callers.** Their Celery workers, Django views, and CLI scripts had to wrap `OllamaProvider.generate_*` in `asgiref.async_to_sync`. They explicitly asked for `OllamaProvider.chat(messages, tools=..., temperature=..., thinking_level=...)` that returns a dataclass synchronously.

## Changes by commit

- **`937d599` engine**: `_build_llm_config()` helper extracts every metadata field from the node and propagates it to `LLMConfig` (incl. mapping `thinking_level` → `thinking_enabled`/`thinking_budget` like the canonical Quartermaster `AbstractLLMAssistantNode`). All three executors (LLM/Agent/Decision) use it. Replaces `print()` error logging with `logger.warning()`. 5 new propagation tests.
- **`c3e6d87` providers**: `OllamaProvider.chat(...)` synchronous shim hitting native `POST /api/chat` via httpx. Returns `ChatResult(content, tool_calls, usage, stop_reason, raw)`. Reasoning fallback (promotes `thinking`/`reasoning` into `content` when `message.content` is empty — fixes gemma4:26b empty-content case for sync callers too). Connection errors raise `ServiceUnavailableError`, HTTP errors raise `ProviderError`. 13 new tests covering URL routing, happy path, reasoning fallback, tool calls, error bubbling, arg validation. httpx is now a hard dep (was transitive).
- **`25dd5ee` chore**: bump everything to 0.1.3 + cross-deps. Adds `RELEASING.md` documenting the four-step develop→master flow that we missed for v0.1.2 (causing the empty-package release). Adds a ⚠️ banner to `publish.yml` so the trap is impossible to miss when hovering over the workflow.

## Test plan

- [x] Engine tests: 432 passed (5 new in `TestLLMConfigPropagation`)
- [x] Providers tests: 223 passed / 9 skipped (13 new in `test_ollama_chat.py`)
- [ ] After this merges to develop, open release PR develop → master, then click Publish — and **don't repeat the v0.1.2 mistake** (clicking Publish before the develop→master merge).

## What lands for downstream integrators

Their minimum-viable retest from the report:

```python
provider = OllamaProvider()  # honours OLLAMA_HOST
result = provider.chat(
    messages=[
        {"role": "system", "content": "Respond in Slovenian. Keep it short."},
        {"role": "user", "content": "Pozdravljen, koliko je ura?"},
    ],
    model="gemma4:26b",
    max_output_tokens=128,         # <-- now actually honoured
    thinking_level="off",
)
assert result.content              # <-- gemma4:26b's reasoning is promoted if content is empty
```

Sync, native, no async-to-sync wrapper, no graph required. Their email-classification / bill-OCR / customer-enrichment call sites can drop `requests.post` in a single transport swap.

For graph users, `Graph.agent(max_output_tokens=128, thinking_level="off")` now actually does what the kwargs say.