### PR TITLE
Audit: align stale __version__, expand SDK exports, fix README badges + MindMade links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           - quartermaster-engine
           - quartermaster-mcp-client
           - quartermaster-code-runner
+          # SDK has its own tests (public-surface guard) since v0.1.4 —
+          # added so a missing re-export or version drift fails CI.
+          - quartermaster-sdk
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +82,10 @@ jobs:
     needs: test
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        # Match the main test matrix — drift here was caught in the v0.1.4
+        # audit (SDK was tested only on 3.11/3.12 while everything else
+        # had 3.13 too).
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,9 +124,33 @@ jobs:
             fi
           done
 
-          # Update SDK __init__.py
-          sed -i "s/^__version__ = \".*\"/__version__ = \"$NEW_VERSION\"/" \
+          # Update the workspace root pyproject.toml too — it's not in
+          # the publishable package list but it carries its own version
+          # field that drifts otherwise (caught in the v0.1.4 audit).
+          sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
+          echo "  Updated pyproject.toml -> $NEW_VERSION"
+
+          # Update every package's __init__.py __version__ string.  The
+          # publish workflow used to update only the SDK's, leaving the
+          # other 7 packages stale at the previous release — caught in
+          # the v0.1.4 audit (see PR #9).  This keeps ``import quartermaster_X;
+          # quartermaster_X.__version__`` honest for every sub-package.
+          INIT_PATHS=(
+            quartermaster-providers/src/quartermaster_providers/__init__.py
+            quartermaster-graph/src/quartermaster_graph/__init__.py
+            quartermaster-tools/src/quartermaster_tools/__init__.py
+            quartermaster-nodes/quartermaster_nodes/__init__.py
+            quartermaster-engine/src/quartermaster_engine/__init__.py
+            quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+            quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
             quartermaster-sdk/src/quartermaster_sdk/__init__.py
+          )
+          for INIT in "${INIT_PATHS[@]}"; do
+            if [ -f "$INIT" ]; then
+              sed -i "s/^__version__ = \".*\"/__version__ = \"$NEW_VERSION\"/" "$INIT"
+              echo "  Updated $INIT -> $NEW_VERSION"
+            fi
+          done
 
           # Update cross-package dependency pins (>=X.Y.Z)
           for pkg in "${PACKAGES[@]}"; do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Thank you for considering a contribution to Quartermaster! This document explain
 ### Clone the repository
 
 ```bash
-git clone https://github.com/MindMade/quartermaster.git
-cd quartermaster
+git clone https://github.com/MindMadeLab/quartermaster-sdk-py.git
+cd quartermaster-sdk-py
 ```
 
 ### Install with uv (recommended)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Quartermaster
 
-[![CI](https://github.com/MindMade/quartermaster/actions/workflows/ci.yml/badge.svg)](https://github.com/MindMade/quartermaster/actions/workflows/ci.yml)
+[![CI](https://github.com/MindMadeLab/quartermaster-sdk-py/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MindMadeLab/quartermaster-sdk-py/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/quartermaster-sdk.svg)](https://pypi.org/project/quartermaster-sdk/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 
 Modular AI agent orchestration framework. Build agent workflows as directed graphs, wire them with a fluent Python API, and run them with any LLM provider.
 
-Built by [MindMade](https://mindmade.si) in Slovenia.
+Built by [MindMade](https://mindmade.io) in Slovenia.
 
 ## Install
 
@@ -26,9 +27,27 @@ uv sync
 
 ## Quick Start
 
-```python
-from quartermaster_sdk import Graph
+The simplest possible graph — `start → user → agent → end` — running against a
+local Ollama in three lines:
 
+```python
+from quartermaster_sdk import Graph, FlowRunner, register_local
+
+provider_registry = register_local(
+    "ollama",
+    base_url="http://localhost:11434",   # or set $OLLAMA_HOST
+    default_model="gemma4:26b",
+)
+
+graph = Graph("chat").start().user().agent().end().build()
+runner = FlowRunner(graph=graph, provider_registry=provider_registry)
+result = runner.run("Pozdravljen, koliko je ura?")
+print(result.final_output)
+```
+
+For richer flows you keep the explicit per-node configuration:
+
+```python
 agent = (
     Graph("My Agent")
     .start()
@@ -37,6 +56,33 @@ agent = (
     .end()
 )
 ```
+
+### Sync `OllamaProvider.chat()` for non-graph callers
+
+For email classification, OCR pipelines, Celery workers, Django views — anything
+where you'd rather call an LLM than build a graph — use the synchronous native
+shim. Talks Ollama's `/api/chat` directly via `httpx`, no `async_to_sync` wrapper:
+
+```python
+from quartermaster_providers.providers.local import OllamaProvider
+
+provider = OllamaProvider(default_model="gemma4:26b")  # honours $OLLAMA_HOST
+result = provider.chat(
+    messages=[
+        {"role": "system", "content": "Respond in Slovenian. Keep it short."},
+        {"role": "user", "content": "Pozdravljen, koliko je ura?"},
+    ],
+    max_output_tokens=128,        # honoured — capped at Ollama's `num_predict`
+    thinking_level="off",         # off / low / medium / high
+)
+print(result.content)             # promoted from `reasoning` if `content` is empty
+print(result.tool_calls)          # list[ToolCall]
+print(result.usage)               # {prompt_tokens, completion_tokens, total_tokens}
+```
+
+`ServiceUnavailableError` raises on connection failures (instead of silently
+returning an empty result), and `ProviderError` on HTTP errors with status code
+attached.
 
 ### Decision Routing
 
@@ -252,4 +298,4 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development guide.
 
 ## License
 
-[Apache 2.0](./LICENSE) -- Built by [MindMade](https://mindmade.si) in Slovenia.
+[Apache 2.0](./LICENSE) -- Built by [MindMade](https://mindmade.io) in Slovenia.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,8 +46,8 @@ pip install quartermaster-code-runner
 ### From Source
 
 ```bash
-git clone https://github.com/MindMade/quartermaster-opensource.git
-cd quartermaster-opensource
+git clone https://github.com/MindMadeLab/quartermaster-sdk-py.git
+cd quartermaster-sdk-py
 
 # Install a specific package in development mode
 pip install -e ./quartermaster-graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.1.3"
+version = "0.1.4"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = [
     # Enums

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = [
     # Enums

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -48,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __author__ = "MindMade"
 
 __all__ = [

--- a/quartermaster-sdk/README.md
+++ b/quartermaster-sdk/README.md
@@ -45,7 +45,7 @@ agent = (
 
 ## Documentation
 
-See the [docs/](https://github.com/MindMade/quartermaster/tree/master/docs) directory:
+See the [docs/](https://github.com/MindMadeLab/quartermaster-sdk-py/tree/master/docs) directory:
 
 - [Getting Started](../docs/getting-started.md)
 - [Graph Building](../docs/graph-building.md)

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -78,3 +78,7 @@ Issues = "https://github.com/MindMadeLab/quartermaster-sdk-py/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/quartermaster_sdk"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -20,7 +20,24 @@ Optional extras:
 
 __version__ = "0.1.4"
 
-# Re-export the most common entry points for convenience
+# Re-export the most common entry points for convenience.  Pre-0.1.4 the SDK
+# re-exported only the graph-builder surface, forcing downstream callers to
+# `from quartermaster_engine import FlowRunner` and `from quartermaster_providers
+# import register_local` separately even though the SDK is the recommended
+# install.  These re-exports cover the v0.1.4 release-notes snippet so a single
+# `from quartermaster_sdk import …` line is enough to wire up the simplest graph.
+from quartermaster_engine import (  # noqa: F401
+    AgentExecutor,
+    FlowResult,
+    FlowRunner,
+    LLMExecutor,
+    NodeExecutor,
+    NodeRegistry,
+    NodeResult,
+    SimpleNodeRegistry,
+    build_default_registry,
+    run_graph,
+)
 from quartermaster_graph import (  # noqa: F401
     AgentGraph,  # deprecated alias for GraphSpec — kept for backward compat
     Graph,
@@ -28,3 +45,37 @@ from quartermaster_graph import (  # noqa: F401
     GraphSpec,
 )
 from quartermaster_graph.enums import NodeType  # noqa: F401
+from quartermaster_providers import (  # noqa: F401
+    ChatResult,
+    LLMConfig,
+    ProviderRegistry,
+    register_local,
+)
+
+
+__all__ = [
+    # Version
+    "__version__",
+    # Graph builder + spec
+    "Graph",
+    "GraphBuilder",
+    "GraphSpec",
+    "AgentGraph",  # deprecated
+    "NodeType",
+    # Engine — runner + node-registry surface
+    "FlowRunner",
+    "FlowResult",
+    "NodeRegistry",
+    "NodeExecutor",
+    "NodeResult",
+    "SimpleNodeRegistry",
+    "LLMExecutor",
+    "AgentExecutor",
+    "build_default_registry",
+    "run_graph",
+    # Providers — config, sync chat result, registry helpers
+    "LLMConfig",
+    "ChatResult",
+    "ProviderRegistry",
+    "register_local",
+]

--- a/quartermaster-sdk/tests/test_public_surface.py
+++ b/quartermaster-sdk/tests/test_public_surface.py
@@ -1,0 +1,111 @@
+"""Guard tests for the SDK's public surface.
+
+The SDK is a meta-package that re-exports the curated subset of names the
+canonical onboarding snippet uses.  These tests fail loudly if anyone
+accidentally drops an export or version-skews ``__version__`` against the
+sub-packages — that drift was caught manually in the v0.1.4 audit and is the
+kind of thing we want a CI-runnable test for from now on.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import quartermaster_sdk
+
+# Names that v0.1.4 onwards must be importable from ``quartermaster_sdk``.
+# Update this list when adding a new public re-export — the test will tell
+# you in CI if you forgot.
+_REQUIRED_PUBLIC_NAMES: tuple[str, ...] = (
+    # Graph builder + spec
+    "Graph",
+    "GraphBuilder",
+    "GraphSpec",
+    "AgentGraph",  # deprecated alias kept for back-compat
+    "NodeType",
+    # Engine — runner + node-registry surface
+    "FlowRunner",
+    "FlowResult",
+    "NodeRegistry",
+    "NodeExecutor",
+    "NodeResult",
+    "SimpleNodeRegistry",
+    "LLMExecutor",
+    "AgentExecutor",
+    "build_default_registry",
+    "run_graph",
+    # Providers — config, sync chat result, registry helpers
+    "LLMConfig",
+    "ChatResult",
+    "ProviderRegistry",
+    "register_local",
+)
+
+
+class TestPublicSurface:
+    """Every name in ``_REQUIRED_PUBLIC_NAMES`` must resolve and be in ``__all__``."""
+
+    @pytest.mark.parametrize("name", _REQUIRED_PUBLIC_NAMES)
+    def test_attribute_resolves(self, name: str) -> None:
+        assert hasattr(quartermaster_sdk, name), (
+            f"quartermaster_sdk.{name} disappeared — check the re-exports "
+            "in src/quartermaster_sdk/__init__.py."
+        )
+
+    @pytest.mark.parametrize("name", _REQUIRED_PUBLIC_NAMES)
+    def test_in_dunder_all(self, name: str) -> None:
+        assert name in quartermaster_sdk.__all__, (
+            f"{name!r} is importable but missing from __all__; star-imports "
+            "(``from quartermaster_sdk import *``) won't pick it up."
+        )
+
+    def test_dunder_all_contains_no_dead_names(self) -> None:
+        """Every name in ``__all__`` must actually resolve on the module."""
+        dead = [
+            n for n in quartermaster_sdk.__all__ if not hasattr(quartermaster_sdk, n)
+        ]
+        assert not dead, f"__all__ lists names that don't exist: {dead}"
+
+
+class TestVersionAlignment:
+    """``quartermaster_sdk.__version__`` must match every sub-package's
+    ``__version__``.  The publish workflow seds them all to the same
+    value at release time — drift here means either someone hand-edited
+    a version string, or the workflow's sed list missed a package."""
+
+    @pytest.mark.parametrize(
+        "subpackage",
+        [
+            "quartermaster_engine",
+            "quartermaster_graph",
+            "quartermaster_providers",
+            "quartermaster_tools",
+            "quartermaster_nodes",
+        ],
+    )
+    def test_subpackage_version_matches_sdk(self, subpackage: str) -> None:
+        sdk_version = quartermaster_sdk.__version__
+        sub = importlib.import_module(subpackage)
+        assert sub.__version__ == sdk_version, (
+            f"{subpackage}.__version__ = {sub.__version__!r} but "
+            f"quartermaster_sdk.__version__ = {sdk_version!r}. "
+            "The publish workflow should keep these in lock-step — "
+            "see RELEASING.md."
+        )
+
+
+class TestSnippetCompiles:
+    """The v0.1.4 release-note snippet must at least import + parse cleanly."""
+
+    def test_snippet_imports(self) -> None:
+        # No execution — just prove the symbols exist.  Actual end-to-end
+        # behaviour against a mock is in
+        # quartermaster-engine/tests/test_smoke_simple_graph.py.
+        from quartermaster_sdk import (
+            ChatResult,  # noqa: F401
+            FlowRunner,  # noqa: F401
+            Graph,  # noqa: F401
+            register_local,  # noqa: F401
+        )

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,7 +3143,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-providers" }
 dependencies = [
     { name = "httpx" },
@@ -3197,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3296,7 +3296,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "we
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3370,7 +3370,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.1.3"
+version = "0.1.4"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why this PR exists

User asked for a hardcore sweep of the repo to catch misalignments after
v0.1.4 shipped.  Three classes of issues found:

### Version drift

The publish workflow's auto-bumper updated only \`pyproject.toml\` files plus
the SDK's \`__init__.py\`.  Every other sub-package's \`__version__\` string
stayed at \`0.1.3\` even though PyPI shipped \`0.1.4\`.  Workspace root
\`pyproject.toml\` was also stuck at \`0.1.3\`.  Fixed all 8, then patched
\`publish.yml\` so this can't recur.

### Missing SDK re-exports

\`quartermaster_sdk\` only re-exported the graph builder.  The headline v0.1.4
features (\`FlowRunner\`, \`AgentExecutor\`, \`build_default_registry\`,
\`register_local\`, \`ChatResult\`) lived only in their sub-packages, forcing
downstream callers to import from 4 different namespaces to wire up the
release-note snippet.  Added explicit \`__all__\` and re-exports.

### Broken README

* CI badge URL pointed at \`MindMade/quartermaster\` — wrong org AND wrong
  repo name.  Image returned 404 so README rendered the broken-image icon.
* MindMade link was \`mindmade.si\` (dead).  Per the team's contact emails
  (\`info@mindmade.io\`) the canonical TLD is \`.io\`.  Fixed in both header
  and footer of README + the same dead URL appearing in
  \`docs/getting-started.md\`, \`CONTRIBUTING.md\`, \`quartermaster-sdk/README.md\`.
* No mention of v0.1.4 headline features.  Added two new Quick Start
  blocks: the \`register_local() + FlowRunner(provider_registry=...)\`
  three-line snippet, and a stand-alone section for the synchronous
  \`OllamaProvider.chat()\` shim.

## What lands

| Commit | What |
|---|---|
| \`9b84941\` | Bump 7 stale \`__version__\` strings + workspace pyproject to 0.1.4 |
| \`a86bf16\` | SDK re-exports + \`tests/test_public_surface.py\` (45 parametrised guard tests for export/version drift) |
| \`8a3dfe0\` | publish.yml updates per-package \`__init__.py\` + workspace pyproject; ci.yml tests SDK on 3.13 + adds SDK to per-package matrix |
| \`c8f6b57\` | README CI badge URL + MindMade link + v0.1.4 sections; same MindMade fixes in docs / CONTRIBUTING / sdk-README |

## Test plan

- [x] All 8 packages at \`__version__ == "0.1.4"\` (and matching pyproject)
- [x] \`from quartermaster_sdk import Graph, FlowRunner, register_local, ChatResult\` resolves
- [x] 45 SDK guard tests pass
- [x] 432 engine tests pass
- [x] 241 providers tests pass
- [x] 231 graph tests pass
- [x] 794 tools tests pass
- [x] 466 nodes tests pass
- [x] No remaining \`MindMade/quartermaster*\` URLs in any tracked file
- [x] No remaining \`mindmade.si\` references

## Future-proofing

The new \`test_public_surface.py\` will fail loudly in CI if anyone:
* drops a re-export from \`quartermaster_sdk.__all__\`
* lets \`__version__\` drift between SDK and a sub-package
* ships a star-import-broken \`__all__\` (names declared but not resolvable)