### PR TITLE
examples: fix 17_streaming_events silent-failure + smoke-test guard against future regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           - quartermaster-engine
           - quartermaster-mcp-client
           - quartermaster-code-runner
+          # SDK has its own tests (public-surface guard) since v0.1.4 —
+          # added so a missing re-export or version drift fails CI.
+          - quartermaster-sdk
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +82,10 @@ jobs:
     needs: test
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        # Match the main test matrix — drift here was caught in the v0.1.4
+        # audit (SDK was tested only on 3.11/3.12 while everything else
+        # had 3.13 too).
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,9 +124,33 @@ jobs:
             fi
           done
 
-          # Update SDK __init__.py
-          sed -i "s/^__version__ = \".*\"/__version__ = \"$NEW_VERSION\"/" \
+          # Update the workspace root pyproject.toml too — it's not in
+          # the publishable package list but it carries its own version
+          # field that drifts otherwise (caught in the v0.1.4 audit).
+          sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
+          echo "  Updated pyproject.toml -> $NEW_VERSION"
+
+          # Update every package's __init__.py __version__ string.  The
+          # publish workflow used to update only the SDK's, leaving the
+          # other 7 packages stale at the previous release — caught in
+          # the v0.1.4 audit (see PR #9).  This keeps ``import quartermaster_X;
+          # quartermaster_X.__version__`` honest for every sub-package.
+          INIT_PATHS=(
+            quartermaster-providers/src/quartermaster_providers/__init__.py
+            quartermaster-graph/src/quartermaster_graph/__init__.py
+            quartermaster-tools/src/quartermaster_tools/__init__.py
+            quartermaster-nodes/quartermaster_nodes/__init__.py
+            quartermaster-engine/src/quartermaster_engine/__init__.py
+            quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+            quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
             quartermaster-sdk/src/quartermaster_sdk/__init__.py
+          )
+          for INIT in "${INIT_PATHS[@]}"; do
+            if [ -f "$INIT" ]; then
+              sed -i "s/^__version__ = \".*\"/__version__ = \"$NEW_VERSION\"/" "$INIT"
+              echo "  Updated $INIT -> $NEW_VERSION"
+            fi
+          done
 
           # Update cross-package dependency pins (>=X.Y.Z)
           for pkg in "${PACKAGES[@]}"; do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Thank you for considering a contribution to Quartermaster! This document explain
 ### Clone the repository
 
 ```bash
-git clone https://github.com/MindMade/quartermaster.git
-cd quartermaster
+git clone https://github.com/MindMadeLab/quartermaster-sdk-py.git
+cd quartermaster-sdk-py
 ```
 
 ### Install with uv (recommended)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Quartermaster
 
-[![CI](https://github.com/MindMade/quartermaster/actions/workflows/ci.yml/badge.svg)](https://github.com/MindMade/quartermaster/actions/workflows/ci.yml)
+[![CI](https://github.com/MindMadeLab/quartermaster-sdk-py/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MindMadeLab/quartermaster-sdk-py/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/quartermaster-sdk.svg)](https://pypi.org/project/quartermaster-sdk/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 
 Modular AI agent orchestration framework. Build agent workflows as directed graphs, wire them with a fluent Python API, and run them with any LLM provider.
 
-Built by [MindMade](https://mindmade.si) in Slovenia.
+Built by [MindMade](https://mindmade.io) in Slovenia.
 
 ## Install
 
@@ -26,9 +27,27 @@ uv sync
 
 ## Quick Start
 
-```python
-from quartermaster_sdk import Graph
+The simplest possible graph — `start → user → agent → end` — running against a
+local Ollama in three lines:
 
+```python
+from quartermaster_sdk import Graph, FlowRunner, register_local
+
+provider_registry = register_local(
+    "ollama",
+    base_url="http://localhost:11434",   # or set $OLLAMA_HOST
+    default_model="gemma4:26b",
+)
+
+graph = Graph("chat").start().user().agent().end().build()
+runner = FlowRunner(graph=graph, provider_registry=provider_registry)
+result = runner.run("Pozdravljen, koliko je ura?")
+print(result.final_output)
+```
+
+For richer flows you keep the explicit per-node configuration:
+
+```python
 agent = (
     Graph("My Agent")
     .start()
@@ -37,6 +56,33 @@ agent = (
     .end()
 )
 ```
+
+### Sync `OllamaProvider.chat()` for non-graph callers
+
+For email classification, OCR pipelines, Celery workers, Django views — anything
+where you'd rather call an LLM than build a graph — use the synchronous native
+shim. Talks Ollama's `/api/chat` directly via `httpx`, no `async_to_sync` wrapper:
+
+```python
+from quartermaster_providers.providers.local import OllamaProvider
+
+provider = OllamaProvider(default_model="gemma4:26b")  # honours $OLLAMA_HOST
+result = provider.chat(
+    messages=[
+        {"role": "system", "content": "Respond in Slovenian. Keep it short."},
+        {"role": "user", "content": "Pozdravljen, koliko je ura?"},
+    ],
+    max_output_tokens=128,        # honoured — capped at Ollama's `num_predict`
+    thinking_level="off",         # off / low / medium / high
+)
+print(result.content)             # promoted from `reasoning` if `content` is empty
+print(result.tool_calls)          # list[ToolCall]
+print(result.usage)               # {prompt_tokens, completion_tokens, total_tokens}
+```
+
+`ServiceUnavailableError` raises on connection failures (instead of silently
+returning an empty result), and `ProviderError` on HTTP errors with status code
+attached.
 
 ### Decision Routing
 
@@ -252,4 +298,4 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development guide.
 
 ## License
 
-[Apache 2.0](./LICENSE) -- Built by [MindMade](https://mindmade.si) in Slovenia.
+[Apache 2.0](./LICENSE) -- Built by [MindMade](https://mindmade.io) in Slovenia.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,8 +46,8 @@ pip install quartermaster-code-runner
 ### From Source
 
 ```bash
-git clone https://github.com/MindMade/quartermaster-opensource.git
-cd quartermaster-opensource
+git clone https://github.com/MindMadeLab/quartermaster-sdk-py.git
+cd quartermaster-sdk-py
 
 # Install a specific package in development mode
 pip install -e ./quartermaster-graph

--- a/examples/17_streaming_events.py
+++ b/examples/17_streaming_events.py
@@ -1,4 +1,4 @@
-"""Example 18 -- FlowRunner with event streaming.
+"""Example 17 -- FlowRunner with event streaming.
 
 Demonstrates using FlowRunner directly (not run_graph()) with custom event
 handling, showing the production-grade API. Uses a mock executor so no API
@@ -11,37 +11,41 @@ Event types shown:
   - FlowFinished  -- the entire flow completes
 
 Usage:
-    uv run examples/18_streaming_events.py
+    uv run examples/17_streaming_events.py
 """
 
 from __future__ import annotations
 
 import asyncio
 import time
-from datetime import datetime
 
 from quartermaster_engine import (
+    ExecutionContext,
     FlowEvent,
     FlowFinished,
+    FlowRunner,
     InMemoryStore,
     NodeFinished,
+    NodeResult,
     NodeStarted,
+    SimpleNodeRegistry,
     TokenGenerated,
 )
-from quartermaster_engine.nodes import NodeResult, SimpleNodeRegistry
-from quartermaster_engine.context.execution_context import ExecutionContext
-from quartermaster_engine.runner.flow_runner import FlowRunner
 from quartermaster_graph import Graph
+from quartermaster_graph.enums import NodeType
 
 
 # ---------------------------------------------------------------------------
 # 1. Mock executor -- no LLM needed
 # ---------------------------------------------------------------------------
 
+
 class MockLLMExecutor:
     """A mock node executor that simulates streaming token output."""
 
-    def __init__(self, response: str = "This is a mock response showing event streaming.") -> None:
+    def __init__(
+        self, response: str = "This is a mock response showing event streaming."
+    ) -> None:
         self._response = response
 
     async def execute(self, context: ExecutionContext) -> NodeResult:
@@ -87,11 +91,17 @@ registry = SimpleNodeRegistry()
 passthrough = PassthroughExecutor()
 mock_llm = MockLLMExecutor()
 
-# Register executors for each node type the graph uses
-registry.register("Start", passthrough)
-registry.register("End", passthrough)
-registry.register("UserInput", passthrough)
-registry.register("Instruction1", mock_llm)
+# Register executors for each node type the graph uses.  Use NodeType
+# enum values rather than magic strings — the actual enum values are
+# "User1" / "Instruction1" / etc. (the magic-string version below used
+# to ship "UserInput" / "Start" / "End" which silently never matched,
+# producing a "No executor registered for node type: User1" error at
+# runtime).  Start/End are handled by the runner internally so we don't
+# strictly need to register them, but doing so is harmless.
+registry.register(NodeType.START.value, passthrough)
+registry.register(NodeType.END.value, passthrough)
+registry.register(NodeType.USER.value, passthrough)
+registry.register(NodeType.INSTRUCTION.value, mock_llm)
 
 # ---------------------------------------------------------------------------
 # 4. Custom event handler with timestamps
@@ -116,7 +126,11 @@ def on_event(event: FlowEvent) -> None:
         output = event.result[:60] + "..." if len(event.result) > 60 else event.result
         print(f"{ts}  NODE FINISHED  | output={output!r}")
     elif isinstance(event, FlowFinished):
-        output = event.final_output[:60] + "..." if len(event.final_output) > 60 else event.final_output
+        output = (
+            event.final_output[:60] + "..."
+            if len(event.final_output) > 60
+            else event.final_output
+        )
         print(f"{ts}  FLOW FINISHED  | final={output!r}")
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ from the simplest agent to a full enterprise-grade multi-department assistant.
 
 ```bash
 # Clone the repo
-git clone git@github.com:MindMadeLab/quartermaster-sdk-py.git
+git clone https://github.com/MindMadeLab/quartermaster-sdk-py.git
 cd quartermaster-sdk-py
 
 # Install uv (if you don't have it)
@@ -20,8 +20,21 @@ uv sync
 uv run examples/01_hello_agent.py
 ```
 
-All examples (except `run_interactive.py`) build and validate graphs offline
--- no API keys or LLM calls needed.
+### Which examples need API keys?
+
+Most examples hardcode a cloud provider in their node metadata, so they need a
+real API key to actually demonstrate anything end-to-end. The exceptions:
+
+| Example | Why it runs without an API key |
+|---|---|
+| `06_tool_decorator.py` | Tool registry + JSON schema export — no LLM call |
+| `09_parallel_agents.py` | `SessionManager` simulation, no LLM call |
+| `17_streaming_events.py` | Uses a mock executor for the LLM node |
+| `20_ollama_local.py` | Hits a local Ollama instance (start `ollama serve` and pull `gemma4:26b`) |
+
+The remaining 16 examples need at least one of `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, `GROQ_API_KEY`, or `XAI_API_KEY` set — without keys, the
+graph still builds and validates but the LLM nodes return failures.
 
 ### API Keys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.1.4"
+version = "0.1.5"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.1.3"
+version = "0.1.4"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/quartermaster-code-runner/pyproject.toml
+++ b/quartermaster-code-runner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-code-runner"
-version = "0.1.4"
+version = "0.1.5"
 description = "Secure sandboxed code execution service supporting Python, Node.js, Go, Rust, Deno, and Bun via Docker containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/quartermaster-engine/README.md
+++ b/quartermaster-engine/README.md
@@ -28,7 +28,41 @@ pip install quartermaster-engine[sqlite]
 
 ## Quick Start
 
-### Run a Simple Graph
+### High-level path — `provider_registry`
+
+The simplest way to run a graph: hand `FlowRunner` a provider registry and let
+it build the default node registry (covering every node type the bundled DSL
+emits — including `AgentExecutor` for `agent()` nodes with the canonical
+Quartermaster tool loop):
+
+```python
+from quartermaster_engine import FlowRunner
+from quartermaster_graph import Graph
+from quartermaster_providers import register_local
+
+provider_registry = register_local(
+    "ollama",
+    base_url="http://localhost:11434",   # or set $OLLAMA_HOST
+    default_model="gemma4:26b",
+)
+
+graph = Graph("chat").start().user().agent().end().build()
+runner = FlowRunner(graph=graph, provider_registry=provider_registry)
+result = runner.run("Pozdravljen!")
+print(result.success, result.final_output)
+```
+
+If you have a `quartermaster_tools.ToolRegistry`, pass it as
+`tool_registry=` so `AgentExecutor` can actually execute the tools your
+graph's `.agent(tools=[...])` nodes request.
+
+### Low-level path — bring your own `node_registry`
+
+For full control over which executor handles each node type (custom
+executors, alternative storage, etc.) hand `FlowRunner` a
+`SimpleNodeRegistry` directly. Use the helper
+`build_default_registry(provider_registry)` if you only want to swap one
+executor; pass the result back into `FlowRunner(node_registry=...)`.
 
 ```python
 from uuid import uuid4

--- a/quartermaster-engine/pyproject.toml
+++ b/quartermaster-engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-engine"
-version = "0.1.4"
+version = "0.1.5"
 description = "Execution engine for AI agent graphs — traversal, branching, merging, memory, message passing, and error handling"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,13 +25,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "quartermaster-graph>=0.1.4",
-    "quartermaster-providers>=0.1.4",
+    "quartermaster-graph>=0.1.5",
+    "quartermaster-providers>=0.1.5",
     # ``quartermaster-nodes`` ships ``safe_eval`` (a simpleeval sandbox)
     # which the example runner uses for ``Var``/``If``/``Switch`` node
     # expression evaluation.  Pre-0.1.2 this was an implicit workspace
     # dep — it would ImportError when installed standalone.
-    "quartermaster-nodes>=0.1.4",
+    "quartermaster-nodes>=0.1.5",
 ]
 
 [project.optional-dependencies]

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/quartermaster-graph/pyproject.toml
+++ b/quartermaster-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-graph"
-version = "0.1.4"
+version = "0.1.5"
 description = "Framework-agnostic agent graph schema for AI agent workflows as directed acyclic graphs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = [
     # Enums

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = [
     # Enums

--- a/quartermaster-mcp-client/pyproject.toml
+++ b/quartermaster-mcp-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-mcp-client"
-version = "0.1.4"
+version = "0.1.5"
 description = "Lightweight MCP (Model Context Protocol) client with async/sync support, SSE and Streamable HTTP transports"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/quartermaster-nodes/pyproject.toml
+++ b/quartermaster-nodes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-nodes"
-version = "0.1.4"
+version = "0.1.5"
 description = "Library of composable node types for building AI agent graphs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1",
-    "quartermaster-graph>=0.1.4",
-    "quartermaster-providers>=0.1.4",
+    "quartermaster-graph>=0.1.5",
+    "quartermaster-providers>=0.1.5",
     "simpleeval>=1.0.5",
 ]
 

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = [
     # Enums

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = [
     # Enums

--- a/quartermaster-providers/README.md
+++ b/quartermaster-providers/README.md
@@ -58,12 +58,50 @@ pip install quartermaster-providers[all]
 | LocalAI | `LocalAIProvider` | OpenAI-compatible local server |
 | llama.cpp | `LlamaCppProvider` | llama.cpp HTTP server |
 
-Register local providers with one line:
+Register local providers with one line — the module-level helper builds a
+registry, normalises `base_url` (auto-appends `/v1` if missing), honours the
+`OLLAMA_HOST` env var, and remembers the default model so callers don't have
+to repeat it:
 
 ```python
-registry = ProviderRegistry()
-registry.register_local("ollama")  # Auto-discovers models
+from quartermaster_providers import register_local
+
+provider_registry = register_local(
+    "ollama",
+    base_url="http://localhost:11434",   # or set $OLLAMA_HOST
+    default_model="gemma4:26b",
+)
+provider = provider_registry.get("ollama")
 ```
+
+### Sync `OllamaProvider.chat()` shim
+
+For one-shot calls from sync code (Celery workers, Django views, CLI scripts)
+the `OllamaProvider` exposes a synchronous native `/api/chat` shim — no
+`asgiref.async_to_sync` wrapper required, and `thinking` / `reasoning` text is
+auto-promoted into `content` so reasoning models like `gemma4:26b` never
+return an empty result on short prompts:
+
+```python
+from quartermaster_providers.providers.local import OllamaProvider
+
+provider = OllamaProvider(default_model="gemma4:26b")  # honours $OLLAMA_HOST
+result = provider.chat(
+    messages=[
+        {"role": "system", "content": "Respond in Slovenian."},
+        {"role": "user", "content": "Pozdravljen!"},
+    ],
+    max_output_tokens=128,    # honoured — capped at Ollama's `num_predict`
+    thinking_level="off",     # off / low / medium / high
+)
+print(result.content)         # str — promoted from `reasoning` if `content` empty
+print(result.tool_calls)      # list[ToolCall]
+print(result.usage)           # {prompt_tokens, completion_tokens, total_tokens}
+```
+
+Connection errors raise `ServiceUnavailableError`; HTTP errors raise
+`ProviderError` with `status_code` attached. Neither swallows into a soft
+"no answer" result the way the OpenAI-compat path used to.
 
 ## Quick Start
 

--- a/quartermaster-providers/pyproject.toml
+++ b/quartermaster-providers/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-providers"
-version = "0.1.4"
+version = "0.1.5"
 description = "Unified multi-LLM provider abstraction supporting OpenAI, Anthropic, Google, Groq, xAI and more"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -48,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __author__ = "MindMade"
 
 __all__ = [

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -48,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __author__ = "MindMade"
 
 __all__ = [

--- a/quartermaster-sdk/README.md
+++ b/quartermaster-sdk/README.md
@@ -45,7 +45,7 @@ agent = (
 
 ## Documentation
 
-See the [docs/](https://github.com/MindMade/quartermaster/tree/master/docs) directory:
+See the [docs/](https://github.com/MindMadeLab/quartermaster-sdk-py/tree/master/docs) directory:
 
 - [Getting Started](../docs/getting-started.md)
 - [Graph Building](../docs/graph-building.md)

--- a/quartermaster-sdk/README.md
+++ b/quartermaster-sdk/README.md
@@ -17,7 +17,28 @@ pip install quartermaster-sdk[openai]
 pip install quartermaster-sdk[all]
 ```
 
-## Quick Start
+## Quick Start (local Ollama, zero config)
+
+```bash
+ollama pull gemma4:26b      # or any model you've pulled
+```
+
+```python
+from quartermaster_sdk import Graph, FlowRunner, register_local
+
+provider_registry = register_local(
+    "ollama",
+    base_url="http://localhost:11434",   # or set $OLLAMA_HOST
+    default_model="gemma4:26b",
+)
+
+graph = Graph("chat").start().user().agent().end().build()
+runner = FlowRunner(graph=graph, provider_registry=provider_registry)
+result = runner.run("Pozdravljen, koliko je ura?")
+print(result.final_output)
+```
+
+## Quick Start (cloud provider)
 
 ```python
 from quartermaster_sdk import Graph
@@ -29,6 +50,24 @@ agent = (
     .instruction("Respond", model="gpt-4o", system_instruction="You are a helpful assistant.")
     .end()
 )
+```
+
+## Sync chat shim (no graph needed)
+
+For one-shot LLM calls from sync code (Celery workers, Django views, CLI scripts) —
+no `asgiref.async_to_sync` wrapper required:
+
+```python
+from quartermaster_providers.providers.local import OllamaProvider
+
+provider = OllamaProvider(default_model="gemma4:26b")
+result = provider.chat(
+    messages=[{"role": "user", "content": "Pozdravljen!"}],
+    max_output_tokens=128,
+    thinking_level="off",
+)
+print(result.content)        # promoted from `reasoning` if `content` is empty
+print(result.usage)          # {prompt_tokens, completion_tokens, total_tokens}
 ```
 
 ## Packages

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-sdk"
-version = "0.1.4"
+version = "0.1.5"
 description = "Quartermaster — modular AI agent orchestration framework. Install this to get all packages."
 readme = "README.md"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "quartermaster-graph>=0.1.4",
-    "quartermaster-providers>=0.1.4",
-    "quartermaster-tools>=0.1.4",
-    "quartermaster-nodes>=0.1.4",
-    "quartermaster-engine>=0.1.4",
+    "quartermaster-graph>=0.1.5",
+    "quartermaster-providers>=0.1.5",
+    "quartermaster-tools>=0.1.5",
+    "quartermaster-nodes>=0.1.5",
+    "quartermaster-engine>=0.1.5",
 ]
 
 [project.optional-dependencies]
@@ -54,8 +54,8 @@ observability = ["quartermaster-tools[observability]"]
 tools-all = ["quartermaster-tools[all]"]
 
 # Standalone packages (not included by default)
-mcp = ["quartermaster-mcp-client>=0.1.4"]
-code-runner = ["quartermaster-code-runner>=0.1.4"]
+mcp = ["quartermaster-mcp-client>=0.1.5"]
+code-runner = ["quartermaster-code-runner>=0.1.5"]
 
 # Everything
 all = [

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -78,3 +78,7 @@ Issues = "https://github.com/MindMadeLab/quartermaster-sdk-py/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/quartermaster_sdk"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -20,7 +20,24 @@ Optional extras:
 
 __version__ = "0.1.4"
 
-# Re-export the most common entry points for convenience
+# Re-export the most common entry points for convenience.  Pre-0.1.4 the SDK
+# re-exported only the graph-builder surface, forcing downstream callers to
+# `from quartermaster_engine import FlowRunner` and `from quartermaster_providers
+# import register_local` separately even though the SDK is the recommended
+# install.  These re-exports cover the v0.1.4 release-notes snippet so a single
+# `from quartermaster_sdk import …` line is enough to wire up the simplest graph.
+from quartermaster_engine import (  # noqa: F401
+    AgentExecutor,
+    FlowResult,
+    FlowRunner,
+    LLMExecutor,
+    NodeExecutor,
+    NodeRegistry,
+    NodeResult,
+    SimpleNodeRegistry,
+    build_default_registry,
+    run_graph,
+)
 from quartermaster_graph import (  # noqa: F401
     AgentGraph,  # deprecated alias for GraphSpec — kept for backward compat
     Graph,
@@ -28,3 +45,37 @@ from quartermaster_graph import (  # noqa: F401
     GraphSpec,
 )
 from quartermaster_graph.enums import NodeType  # noqa: F401
+from quartermaster_providers import (  # noqa: F401
+    ChatResult,
+    LLMConfig,
+    ProviderRegistry,
+    register_local,
+)
+
+
+__all__ = [
+    # Version
+    "__version__",
+    # Graph builder + spec
+    "Graph",
+    "GraphBuilder",
+    "GraphSpec",
+    "AgentGraph",  # deprecated
+    "NodeType",
+    # Engine — runner + node-registry surface
+    "FlowRunner",
+    "FlowResult",
+    "NodeRegistry",
+    "NodeExecutor",
+    "NodeResult",
+    "SimpleNodeRegistry",
+    "LLMExecutor",
+    "AgentExecutor",
+    "build_default_registry",
+    "run_graph",
+    # Providers — config, sync chat result, registry helpers
+    "LLMConfig",
+    "ChatResult",
+    "ProviderRegistry",
+    "register_local",
+]

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -18,7 +18,7 @@ Optional extras:
 - pip install quartermaster-sdk[all]           — Everything
 """
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 # Re-export the most common entry points for convenience.  Pre-0.1.4 the SDK
 # re-exported only the graph-builder surface, forcing downstream callers to

--- a/quartermaster-sdk/tests/test_examples_smoke.py
+++ b/quartermaster-sdk/tests/test_examples_smoke.py
@@ -1,0 +1,112 @@
+"""Smoke-tests for the examples that don't need an LLM API key.
+
+The previous CI "examples" job was removed because it false-passed on
+LLM-using scripts (no API keys → ``run_graph()`` silently degrades).
+The fix the inline comment in ``.github/workflows/ci.yml`` suggested
+was to port the API-key-free examples into proper pytest cases — that's
+what this file is.
+
+Catches regressions like the v0.1.5 audit's discovery that
+``17_streaming_events.py`` was registering executors against magic
+strings (``"UserInput"`` / ``"Start"`` / ``"End"``) that didn't match
+the actual ``NodeType`` enum values (``"User1"`` / ``"Start1"`` /
+``"End1"``) — the script ran to completion but its only LLM node
+``error: No executor registered for node type: User1``-ed silently.
+
+Each test ``subprocess``-runs the script with no API-key env vars set
+and asserts non-zero exit means failure.  Stdout is captured for
+better failure messages.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo root: this file lives at <repo>/quartermaster-sdk/tests/.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+
+# Examples that genuinely require zero LLM credentials to run end-to-end.
+# Add new entries here as you write API-key-free examples; this is the
+# allowlist the smoke test iterates over.
+_NO_API_KEY_EXAMPLES: tuple[str, ...] = (
+    "06_tool_decorator.py",  # tool registry + JSON schema export, no LLM call
+    "09_parallel_agents.py",  # SessionManager simulation, no LLM call
+    "17_streaming_events.py",  # FlowRunner with a mock executor, no LLM call
+)
+
+
+@pytest.fixture
+def clean_env() -> dict[str, str]:
+    """Strip every LLM API key env var so the example can't accidentally
+    succeed by hitting a real provider.  We want pure no-LLM smoke tests."""
+    env = os.environ.copy()
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GROQ_API_KEY",
+        "XAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "QUARTERMASTER_API_KEY",
+    ):
+        env.pop(key, None)
+    return env
+
+
+@pytest.mark.parametrize("example_name", _NO_API_KEY_EXAMPLES)
+def test_example_runs_without_api_keys(
+    example_name: str, clean_env: dict[str, str]
+) -> None:
+    """Each listed example must exit 0 with no API keys set in the env."""
+    script = _EXAMPLES_DIR / example_name
+    assert script.exists(), f"example file missing: {script}"
+
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=clean_env,
+        cwd=_REPO_ROOT,
+    )
+
+    if result.returncode != 0:
+        # Surface stdout + stderr in the failure message — much easier
+        # to diagnose than a bare assertion.
+        pytest.fail(
+            f"{example_name} exited {result.returncode}.\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+
+
+def test_example_17_no_silent_executor_misses(clean_env: dict[str, str]) -> None:
+    """Targeted regression for the v0.1.5 audit finding.
+
+    Example 17 is allowed to print streaming events but its
+    ``FlowResult`` summary must NOT contain
+    "No executor registered for node type" — that string is the silent-
+    failure signature the magic-string registration produced before the
+    fix.  This guard makes sure nobody re-introduces the bug by tweaking
+    the example to use string literals again.
+    """
+    result = subprocess.run(
+        [sys.executable, str(_EXAMPLES_DIR / "17_streaming_events.py")],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=clean_env,
+        cwd=_REPO_ROOT,
+    )
+    combined = result.stdout + result.stderr
+    assert "No executor registered" not in combined, (
+        "Example 17 silently dropped a node — the magic-string vs. NodeType.X.value "
+        "regression is back. Check examples/17_streaming_events.py."
+    )
+    # Positive assertion: the mock LLM streamed at least one token.
+    assert "TOKEN" in combined, "Expected token-streaming events in the output"

--- a/quartermaster-sdk/tests/test_public_surface.py
+++ b/quartermaster-sdk/tests/test_public_surface.py
@@ -1,0 +1,111 @@
+"""Guard tests for the SDK's public surface.
+
+The SDK is a meta-package that re-exports the curated subset of names the
+canonical onboarding snippet uses.  These tests fail loudly if anyone
+accidentally drops an export or version-skews ``__version__`` against the
+sub-packages — that drift was caught manually in the v0.1.4 audit and is the
+kind of thing we want a CI-runnable test for from now on.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import quartermaster_sdk
+
+# Names that v0.1.4 onwards must be importable from ``quartermaster_sdk``.
+# Update this list when adding a new public re-export — the test will tell
+# you in CI if you forgot.
+_REQUIRED_PUBLIC_NAMES: tuple[str, ...] = (
+    # Graph builder + spec
+    "Graph",
+    "GraphBuilder",
+    "GraphSpec",
+    "AgentGraph",  # deprecated alias kept for back-compat
+    "NodeType",
+    # Engine — runner + node-registry surface
+    "FlowRunner",
+    "FlowResult",
+    "NodeRegistry",
+    "NodeExecutor",
+    "NodeResult",
+    "SimpleNodeRegistry",
+    "LLMExecutor",
+    "AgentExecutor",
+    "build_default_registry",
+    "run_graph",
+    # Providers — config, sync chat result, registry helpers
+    "LLMConfig",
+    "ChatResult",
+    "ProviderRegistry",
+    "register_local",
+)
+
+
+class TestPublicSurface:
+    """Every name in ``_REQUIRED_PUBLIC_NAMES`` must resolve and be in ``__all__``."""
+
+    @pytest.mark.parametrize("name", _REQUIRED_PUBLIC_NAMES)
+    def test_attribute_resolves(self, name: str) -> None:
+        assert hasattr(quartermaster_sdk, name), (
+            f"quartermaster_sdk.{name} disappeared — check the re-exports "
+            "in src/quartermaster_sdk/__init__.py."
+        )
+
+    @pytest.mark.parametrize("name", _REQUIRED_PUBLIC_NAMES)
+    def test_in_dunder_all(self, name: str) -> None:
+        assert name in quartermaster_sdk.__all__, (
+            f"{name!r} is importable but missing from __all__; star-imports "
+            "(``from quartermaster_sdk import *``) won't pick it up."
+        )
+
+    def test_dunder_all_contains_no_dead_names(self) -> None:
+        """Every name in ``__all__`` must actually resolve on the module."""
+        dead = [
+            n for n in quartermaster_sdk.__all__ if not hasattr(quartermaster_sdk, n)
+        ]
+        assert not dead, f"__all__ lists names that don't exist: {dead}"
+
+
+class TestVersionAlignment:
+    """``quartermaster_sdk.__version__`` must match every sub-package's
+    ``__version__``.  The publish workflow seds them all to the same
+    value at release time — drift here means either someone hand-edited
+    a version string, or the workflow's sed list missed a package."""
+
+    @pytest.mark.parametrize(
+        "subpackage",
+        [
+            "quartermaster_engine",
+            "quartermaster_graph",
+            "quartermaster_providers",
+            "quartermaster_tools",
+            "quartermaster_nodes",
+        ],
+    )
+    def test_subpackage_version_matches_sdk(self, subpackage: str) -> None:
+        sdk_version = quartermaster_sdk.__version__
+        sub = importlib.import_module(subpackage)
+        assert sub.__version__ == sdk_version, (
+            f"{subpackage}.__version__ = {sub.__version__!r} but "
+            f"quartermaster_sdk.__version__ = {sdk_version!r}. "
+            "The publish workflow should keep these in lock-step — "
+            "see RELEASING.md."
+        )
+
+
+class TestSnippetCompiles:
+    """The v0.1.4 release-note snippet must at least import + parse cleanly."""
+
+    def test_snippet_imports(self) -> None:
+        # No execution — just prove the symbols exist.  Actual end-to-end
+        # behaviour against a mock is in
+        # quartermaster-engine/tests/test_smoke_simple_graph.py.
+        from quartermaster_sdk import (
+            ChatResult,  # noqa: F401
+            FlowRunner,  # noqa: F401
+            Graph,  # noqa: F401
+            register_local,  # noqa: F401
+        )

--- a/quartermaster-tools/pyproject.toml
+++ b/quartermaster-tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-tools"
-version = "0.1.4"
+version = "0.1.5"
 description = "Tool abstraction framework and chain-of-responsibility handler pattern for AI agent orchestration"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 web = ["httpx>=0.25.0"]
-llm = ["quartermaster-providers>=0.1.4"]
+llm = ["quartermaster-providers>=0.1.5"]
 database = ["sqlalchemy>=2.0"]
 vector = ["chromadb>=0.4", "sentence-transformers>=2.2"]
 privacy = ["presidio-analyzer>=2.2"]

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,7 +3143,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-providers" }
 dependencies = [
     { name = "httpx" },
@@ -3197,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3296,7 +3296,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "we
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3370,7 +3370,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.1.4"
+version = "0.1.5"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,7 +3143,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-providers" }
 dependencies = [
     { name = "httpx" },
@@ -3197,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3296,7 +3296,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "we
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3370,7 +3370,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.1.3"
+version = "0.1.4"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What I found

\"Make sure examples work\" — turned up one real bug + verified everything else.

### Real bug: example 17 was silently broken

\`examples/17_streaming_events.py\` registered executors against magic strings that didn't match the actual NodeType enum values:

| Example registered | Actual NodeType value |
|---|---|
| \`\"Start\"\` | \`\"Start1\"\` |
| \`\"End\"\` | \`\"End1\"\` |
| \`\"UserInput\"\` | \`\"User1\"\` |
| \`\"Instruction1\"\` | \`\"Instruction1\"\` ✓ (only one that matched) |

Result: the User node had no executor → runner returned \`error: No executor registered for node type: User1\` → \`FlowResult.final_output\` was just the echoed input \`\"Hello, show me how event streaming works!\"\` instead of the mock LLM's response. The example printed events and \"succeeded\" but demonstrated nothing.

Fix: use \`NodeType.X.value\` instead of magic strings (same pattern \`build_default_registry\` uses, so enum renames can't silently break this again). Also cleaned up imports to use the top-level \`quartermaster_engine\` namespace, and fixed the \"Example 18\" docstring header.

### Real bug: README snippet against real Ollama

Ran the v0.1.5 README's headline snippet end-to-end against real \`gemma4:26b\` via Ollama:

\`\`\`python
from quartermaster_sdk import Graph, FlowRunner, register_local
provider_registry = register_local(\"ollama\", base_url=\"http://localhost:11434\", default_model=\"gemma4:26b\")
graph = Graph(\"chat\").start().user().agent().end().build()
runner = FlowRunner(graph=graph, provider_registry=provider_registry)
result = runner.run(\"Reply with exactly: hi\")
# success=True, final_output='hi'
\`\`\`

✅ Works. And the sync \`OllamaProvider.chat()\` shim too:

\`\`\`python
provider = OllamaProvider(default_model='gemma4:26b')
result = provider.chat(messages=[{\"role\": \"system\", \"content\": \"Respond with EXACTLY one word in Slovenian.\"}, {\"role\": \"user\", \"content\": \"Pozdravi.\"}], max_output_tokens=64, thinking_level=\"off\")
# content='Zdravo.', usage={'prompt_tokens': 27, 'completion_tokens': 8, 'total_tokens': 35}, stop_reason='stop'
\`\`\`

### Static + smoke audit of all 20 example files

* No import errors
* No method-signature mismatches against v0.1.5
* No deprecated patterns (every example uses top-level imports, none reach into \`quartermaster_engine.example_runner\` internals)
* Most examples hardcode cloud LLM providers (Anthropic / OpenAI / Groq / xAI) so they need real API keys to demonstrate end-to-end — but that's a runtime requirement, not a code defect
* Examples 06 / 09 / 17 / 20 run without cloud keys (06+09 are pure-graph or simulation, 17 uses a mock executor, 20 hits Ollama)

## Regression net

New \`quartermaster-sdk/tests/test_examples_smoke.py\` is the proper pytest port of the API-key-free examples that the inline comment in \`ci.yml\` already pointed to as a follow-up:

* Subprocess-runs each script with **every** LLM API key stripped from the environment
* Asserts exit-code 0
* Targeted regression test greps for \`\"No executor registered\"\` in combined stdout/stderr — the silent-failure signature of the magic-string bug. Anyone who re-introduces it will get a CI failure with a pointer to \`examples/17_streaming_events.py\`.

Adding new no-LLM examples? Append the filename to \`_NO_API_KEY_EXAMPLES\` and the smoke test picks them up automatically.

## Test plan

- [x] 4 new example smoke tests pass
- [x] 49 SDK tests pass total (was 45 public-surface guards + 4 new smokes)
- [x] Manually verified README snippet + chat() shim against real Ollama gemma4:26b

## After this merges → ship as v0.1.6

Standard flow:
1. Squash-merge this PR to develop
2. Open develop → master release PR
3. Click Publish → v0.1.6