### PR TITLE
chore: back-merge v0.2.1 release commit into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,34 +27,64 @@ uv sync
 
 ## Quick Start
 
-The simplest possible graph — `start → user → agent → end` — running against a
-local Ollama in three lines:
+The simplest possible graph — running against a local Ollama in four lines
+(no `.start()`, no `.end()`, no `.build()`, no `FlowRunner` import):
 
 ```python
-from quartermaster_sdk import Graph, FlowRunner, register_local
+import quartermaster_sdk as qm
 
-provider_registry = register_local(
-    "ollama",
-    base_url="http://localhost:11434",   # or set $OLLAMA_HOST
-    default_model="gemma4:26b",
-)
+qm.configure(provider="ollama", base_url="http://localhost:11434", default_model="gemma4:26b")
 
-graph = Graph("chat").start().user().agent().end().build()
-runner = FlowRunner(graph=graph, provider_registry=provider_registry)
-result = runner.run("Pozdravljen, koliko je ura?")
-print(result.final_output)
+result = qm.run(qm.Graph("chat").user().agent(), "Pozdravljen, koliko je ura?")
+print(result.text)
+```
+
+`qm.run()` accepts the builder directly and finalises it internally —
+`.build()` is only needed when you want the validated `GraphSpec` for
+serialisation or inspection. For single-shot calls skip the graph entirely:
+
+```python
+reply = qm.instruction(system="Respond in Slovenian.", user="Pozdravljen!")
+# reply is a str.
+```
+
+For typed JSON extraction:
+
+```python
+from pydantic import BaseModel
+
+class Classification(BaseModel):
+    category: str
+    priority: str
+
+data = qm.instruction_form(Classification, system="Classify.", user=email_body)
+# data is a Classification instance.
 ```
 
 For richer flows you keep the explicit per-node configuration:
 
 ```python
 agent = (
-    Graph("My Agent")
-    .start()
+    qm.Graph("My Agent")
     .user("What can I help you with?")
     .instruction("Respond", model="gpt-4o", system_instruction="You are a helpful assistant.")
-    .end()
 )
+result = qm.run(agent, "...")
+```
+
+### Reading specific node outputs with `capture_as=`
+
+Attach a name to any node and read its output from `result.captures`:
+
+```python
+graph = (
+    qm.Graph("enrich")
+    .agent("Research", tools=[...], capture_as="notes")
+    .instruction_form(CustomerData, system="Extract.", capture_as="data")
+)
+result = qm.run(graph, "VT-Treyd Slovenija")
+result["notes"].output_text    # agent's free-text research
+result["data"].output_text     # form-parsed JSON
 ```
 
 ### Sync `OllamaProvider.chat()` for non-graph callers
@@ -239,7 +269,7 @@ quartermaster-code-runner   Standalone Docker code execution
 ## Key Concepts
 
 - **Graph** -- A directed graph (supports cycles via `connect()` for loops) of nodes and edges. Built with the fluent `Graph("name").start().user("Input")...end()` API.
-- **GraphSpec** -- The serializable graph model (`GraphSpec` in quartermaster-graph) returned by `Graph.build()`. `AgentGraph` remains as a deprecated backward-compat alias.
+- **GraphSpec** -- The serializable graph model (`GraphSpec` in quartermaster-graph). `qm.run(graph, ...)` finalises the builder for you; explicit `Graph.build()` only matters when you want the validated spec to serialise / inspect. `AgentGraph` remains as a deprecated backward-compat alias.
 - **User Node** -- Every graph starts with `.user()` after `.start()` to collect user input.
 - **Nodes** -- Units of work: LLM calls, decisions, user input, memory, tools, templates.
 - **Edges** -- Directed connections between nodes. Decision/IF/Switch edges carry labels.

--- a/examples/01_hello_agent.py
+++ b/examples/01_hello_agent.py
@@ -1,26 +1,46 @@
 """The simplest possible agent: user asks, LLM responds.
 
-Demonstrates the minimal Graph API -- three nodes chained together
-with the fluent builder, then executed with a real LLM.
+Canonical v0.2.0 ergonomic demo — four imports, four lines, no
+``.start()`` / ``.end()`` / ``.build()`` / ``FlowRunner`` boilerplate.
 
 Usage:
-    export ANTHROPIC_API_KEY="sk-ant-..."   # or OPENAI_API_KEY
+    # Either set an API key...
+    export ANTHROPIC_API_KEY="sk-ant-..."      # or OPENAI_API_KEY
+    uv run examples/01_hello_agent.py
+
+    # ...or run against a local Ollama:
+    ollama serve && ollama pull gemma4:26b
+    export OLLAMA_HOST=http://localhost:11434
+    export QM_DEFAULT_MODEL=gemma4:26b
     uv run examples/01_hello_agent.py
 """
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
-# The simplest agent: ask user -> LLM responds
-agent = (
-    Graph("Hello Agent")
-    .start()
-    .user("Ask me anything")
-    .instruction("Respond", model="claude-haiku-4-5-20251001", system_instruction="You are a helpful assistant. Be concise.")
-    .end()
+# Single-shot: no graph visible.  `qm.instruction(...)` builds a
+# one-node graph internally, runs it, and returns the assistant text.
+# Uses the default provider from `qm.configure(...)` or $OLLAMA_HOST /
+# $QM_DEFAULT_MODEL — no boilerplate.
+reply = qm.instruction(
+    system="You are a helpful assistant. Be concise.",
+    user="What is the capital of Slovenia?",
+    model="claude-haiku-4-5-20251001",
 )
+print("Single-shot:", reply)
 
-# Execute with a real LLM
-run_graph(agent, user_input="What is the capital of Slovenia?")
+# Full graph path: same semantics as the cloud-auto-detecting v0.1.x
+# `run_graph()`, but now without the `.start().end().build()` dance.
+# `qm.run_graph()` finalises the builder internally and prints as it
+# streams.
+agent = (
+    qm.Graph("Hello Agent")
+    .user("Ask me anything")
+    .instruction(
+        "Respond",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="You are a helpful assistant. Be concise.",
+    )
+)
+qm.run_graph(agent, user_input="What is the capital of Slovenia?")

--- a/examples/02_decision_flow.py
+++ b/examples/02_decision_flow.py
@@ -11,25 +11,38 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Sentiment Analyzer")
-    .start()
+    qm.Graph("Sentiment Analyzer")
     .user("Enter text to analyze")
-    .instruction("Analyze sentiment", model="claude-haiku-4-5-20251001", system_instruction="Classify as positive or negative")
+    .instruction(
+        "Analyze sentiment",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Classify as positive or negative",
+    )
     .decision("Sentiment?", options=["positive", "negative"])
     .on("positive")
-        .instruction("Positive response", model="claude-haiku-4-5-20251001", system_instruction="Generate an enthusiastic response")
+    .instruction(
+        "Positive response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Generate an enthusiastic response",
+    )
     .end()
     .on("negative")
-        .instruction("Negative response", model="claude-haiku-4-5-20251001", system_instruction="Generate an empathetic response")
+    .instruction(
+        "Negative response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Generate an empathetic response",
+    )
     .end()
     # No merge needed -- decision picks ONE branch, so branches converge
     # directly on the next node.
-    .instruction("Final summary", model="claude-haiku-4-5-20251001", system_instruction="Summarize the analysis")
-    .end()
+    .instruction(
+        "Final summary",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Summarize the analysis",
+    )
 )
 
-run_graph(agent, user_input="I absolutely love this product, it changed my life!")
+qm.run_graph(agent, user_input="I absolutely love this product, it changed my life!")

--- a/examples/03_multi_decision.py
+++ b/examples/03_multi_decision.py
@@ -12,47 +12,72 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Multi-Stage Classifier")
-    .start()
+    qm.Graph("Multi-Stage Classifier")
     .user("Describe your issue")
-
     # First decision: categorize the request
     .decision("Category?", options=["technical", "billing", "general"])
     .on("technical")
-        .instruction("Tech triage", model="claude-haiku-4-5-20251001", system_instruction="Assess technical severity")
+    .instruction(
+        "Tech triage",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Assess technical severity",
+    )
     .end()
     .on("billing")
-        .instruction("Billing check", model="claude-haiku-4-5-20251001", system_instruction="Look up account status")
+    .instruction(
+        "Billing check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Look up account status",
+    )
     .end()
     .on("general")
-        .instruction("General info", model="claude-haiku-4-5-20251001", system_instruction="Provide general help")
+    .instruction(
+        "General info",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide general help",
+    )
     .end()
     # No merge -- decision picks ONE branch, they converge on the next node.
-
     # Second decision: urgency check (boolean if-node)
     .if_node("Is urgent?", expression="severity == 'high'")
     .on("true")
-        .instruction("Escalate", model="claude-haiku-4-5-20251001", system_instruction="Create urgent ticket")
-        .static("Alert team", text="Urgent issue!")
+    .instruction(
+        "Escalate",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create urgent ticket",
+    )
+    .static("Alert team", text="Urgent issue!")
     .end()
     .on("false")
-        .instruction("Standard response", model="claude-haiku-4-5-20251001", system_instruction="Provide standard help")
+    .instruction(
+        "Standard response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide standard help",
+    )
     .end()
     # No merge -- IF picks ONE branch.
-
     # Third decision: user feedback (manual choice)
     .decision("Was this helpful?", options=["yes", "no"])
     .on("yes")
-        .instruction("Thank user", model="claude-haiku-4-5-20251001", system_instruction="Thank them and close")
+    .instruction(
+        "Thank user",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Thank them and close",
+    )
     .end()
     .on("no")
-        .instruction("Escalate to human", model="claude-haiku-4-5-20251001", system_instruction="Transfer to human agent")
-    .end()
+    .instruction(
+        "Escalate to human",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Transfer to human agent",
+    )
     .end()
 )
 
-run_graph(agent, user_input="My server keeps crashing with out-of-memory errors every few hours")
+qm.run_graph(
+    agent,
+    user_input="My server keeps crashing with out-of-memory errors every few hours",
+)

--- a/examples/04_sub_graphs.py
+++ b/examples/04_sub_graphs.py
@@ -12,42 +12,66 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # --- Reusable sub-graphs ---------------------------------------------------
 
 research_flow = (
-    Graph("Research")
-    .start()
-    .instruction("Search web", model="claude-haiku-4-5-20251001", system_instruction="Find relevant information")
-    .instruction("Summarize findings", model="claude-haiku-4-5-20251001", system_instruction="Create a concise summary")
-    .end()
+    qm.Graph("Research")
+    .instruction(
+        "Search web",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Find relevant information",
+    )
+    .instruction(
+        "Summarize findings",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create a concise summary",
+    )
 )
 
 code_review_flow = (
-    Graph("Code Review")
-    .start()
-    .instruction("Analyze code", model="claude-haiku-4-5-20251001", system_instruction="Review code for bugs and style")
-    .instruction("Generate suggestions", model="claude-haiku-4-5-20251001", system_instruction="Suggest improvements")
-    .end()
+    qm.Graph("Code Review")
+    .instruction(
+        "Analyze code",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Review code for bugs and style",
+    )
+    .instruction(
+        "Generate suggestions",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Suggest improvements",
+    )
 )
 
 # --- Compose into a main agent ---------------------------------------------
 
 agent = (
-    Graph("Dev Assistant")
-    .start()
+    qm.Graph("Dev Assistant")
     .user("What do you need help with?")
     .decision("Task type?", options=["research", "code_review", "chat"])
-    .on("research").use(research_flow).end()
-    .on("code_review").use(code_review_flow).end()
+    .on("research")
+    .use(research_flow)
+    .end()
+    .on("code_review")
+    .use(code_review_flow)
+    .end()
     .on("chat")
-        .instruction("Chat", model="claude-haiku-4-5-20251001", system_instruction="Have a helpful conversation")
+    .instruction(
+        "Chat",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Have a helpful conversation",
+    )
     .end()
     # No merge -- decision picks ONE branch.
-    .instruction("Deliver answer", model="claude-haiku-4-5-20251001", system_instruction="Present the final result clearly")
-    .end()
+    .instruction(
+        "Deliver answer",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Present the final result clearly",
+    )
 )
 
-run_graph(agent, user_input="Research the latest trends in WebAssembly for server-side applications")
+qm.run_graph(
+    agent,
+    user_input="Research the latest trends in WebAssembly for server-side applications",
+)

--- a/examples/05_memory_flow.py
+++ b/examples/05_memory_flow.py
@@ -18,30 +18,32 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Customer Service Agent")
-    .start()
-
+    qm.Graph("Customer Service Agent")
     # --- Step 1: Collect customer name ----------------------------------------
     .user("What is your name?")
     .var("Capture name", variable="customer_name")
     .write_memory("Remember customer", memory_name="customer_name")
-
     # --- Step 2: Personalised greeting using a text template ------------------
-    .text("Greeting", template="Hello {{customer_name}}, welcome to support! How can I help?")
-
+    .text(
+        "Greeting",
+        template="Hello {{customer_name}}, welcome to support! How can I help?",
+    )
     # --- Step 3: Collect and store the issue -----------------------------------
     .user("Describe your issue")
     .var("Capture issue", variable="issue_description")
     .write_memory(
         "Create ticket",
         memory_name="support_ticket",
-        variables=[{"name": "issue_description", "value": "status:open | issue:{{issue_description}}"}],
+        variables=[
+            {
+                "name": "issue_description",
+                "value": "status:open | issue:{{issue_description}}",
+            }
+        ],
     )
-
     # --- Step 4: Read back customer name for personalised resolution ----------
     .read_memory("Recall customer", memory_name="customer_name")
     .instruction(
@@ -52,21 +54,23 @@ agent = (
             "Their issue: {{issue_description}}. Provide a clear, empathetic resolution."
         ),
     )
-
     # --- Step 5: Update ticket and log interaction ----------------------------
     .update_memory("Close ticket", memory_name="support_ticket")
     .write_memory(
         "Log interaction",
         memory_name="interaction_log",
-        variables=[{"name": "interaction", "value": "resolved | customer:{{customer_name}} | issue:{{issue_description}}"}],
+        variables=[
+            {
+                "name": "interaction",
+                "value": "resolved | customer:{{customer_name}} | issue:{{issue_description}}",
+            }
+        ],
     )
-
     # --- Step 6: Farewell -----------------------------------------------------
     .text(
         "Farewell",
         template="Thank you {{customer_name}}! Your ticket has been resolved.",
     )
-    .end()
 )
 
-run_graph(agent, user_input="Alice")
+qm.run_graph(agent, user_input="Alice")

--- a/examples/06_tool_decorator.py
+++ b/examples/06_tool_decorator.py
@@ -72,4 +72,6 @@ print(f"\nWeather result: {result}")
 # Export as JSON Schema for LLM function calling
 print("\nJSON Schema export:")
 for schema in registry.to_json_schema():
-    print(f"  {schema['name']}: {len(schema['parameters'].get('properties', {}))} params")
+    print(
+        f"  {schema['name']}: {len(schema['parameters'].get('properties', {}))} params"
+    )

--- a/examples/07_switch_router.py
+++ b/examples/07_switch_router.py
@@ -11,23 +11,54 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # Multi-language support agent with switch-style routing
 agent = (
-    Graph("Multi-Language Agent")
-    .start()
+    qm.Graph("Multi-Language Agent")
     .user("Enter your message")
-    .instruction("Detect language", model="claude-haiku-4-5-20251001", system_instruction="Detect the language. Output: en/es/fr/de/other")
+    .instruction(
+        "Detect language",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Detect the language. Output: en/es/fr/de/other",
+    )
     .decision("Language?", options=["en", "es", "fr", "de", "other"])
-    .on("en").instruction("English handler", model="claude-haiku-4-5-20251001", system_instruction="Respond in English").end()
-    .on("es").instruction("Spanish handler", model="claude-haiku-4-5-20251001", system_instruction="Responde en espanol").end()
-    .on("fr").instruction("French handler", model="claude-haiku-4-5-20251001", system_instruction="Repondez en francais").end()
-    .on("de").instruction("German handler", model="claude-haiku-4-5-20251001", system_instruction="Antworten Sie auf Deutsch").end()
-    .on("other").instruction("Fallback", model="claude-haiku-4-5-20251001", system_instruction="Respond in English, note language").end()
-    # No merge -- decision picks one language branch, they converge on End.
+    .on("en")
+    .instruction(
+        "English handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Respond in English",
+    )
     .end()
+    .on("es")
+    .instruction(
+        "Spanish handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Responde en espanol",
+    )
+    .end()
+    .on("fr")
+    .instruction(
+        "French handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Repondez en francais",
+    )
+    .end()
+    .on("de")
+    .instruction(
+        "German handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Antworten Sie auf Deutsch",
+    )
+    .end()
+    .on("other")
+    .instruction(
+        "Fallback",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Respond in English, note language",
+    )
+    .end()
+    # No merge -- decision picks one language branch, they converge on the (implicit) end.
 )
 
-run_graph(agent, user_input="Bonjour, comment allez-vous aujourd'hui?")
+qm.run_graph(agent, user_input="Bonjour, comment allez-vous aujourd'hui?")

--- a/examples/08_iterative_refinement.py
+++ b/examples/08_iterative_refinement.py
@@ -18,9 +18,8 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_graph.enums import TraverseIn
-from quartermaster_engine import run_graph
 
 
 WRITER = dict(model="claude-haiku-4-5-20251001", provider="anthropic")
@@ -29,27 +28,30 @@ CRITIC = dict(model="llama-3.3-70b-versatile", provider="groq")
 MAX_ITERATIONS = 3
 
 agent = (
-    Graph("Iterative Refinement")
-    .start()
+    qm.Graph("Iterative Refinement")
     .user("What should I write about?")
     .var("Capture topic", variable="topic", show_output=False)
-
-    .text("Brief", template=(
-        "Assignment: Write a short, compelling paragraph about: {{topic}}\n"
-        "We will refine it through " + str(MAX_ITERATIONS) + " rounds of writing and critique."
-    ))
-
+    .text(
+        "Brief",
+        template=(
+            "Assignment: Write a short, compelling paragraph about: {{topic}}\n"
+            "We will refine it through "
+            + str(MAX_ITERATIONS)
+            + " rounds of writing and critique."
+        ),
+    )
     # -- Initialize iteration counter --
     .var("Init iteration", variable="iteration", expression="1", show_output=False)
-
     # -- Loop target --
-    .text("Iteration header", template=(
-        "\n──── Iteration {{iteration}} of " + str(MAX_ITERATIONS) + " ────"
-    ), traverse_in=TraverseIn.AWAIT_FIRST)
-
+    .text(
+        "Iteration header",
+        template=("\n──── Iteration {{iteration}} of " + str(MAX_ITERATIONS) + " ────"),
+        traverse_in=TraverseIn.AWAIT_FIRST,
+    )
     # -- Writer drafts/revises --
     .instruction(
-        "Writer drafts", **WRITER,
+        "Writer drafts",
+        **WRITER,
         system_instruction=(
             "You are a skilled writer. Write or revise a SHORT paragraph (3-5 sentences) "
             "about the given topic.\n\n"
@@ -59,10 +61,10 @@ agent = (
             "Output ONLY the paragraph, no meta-commentary."
         ),
     )
-
     # -- Critic reviews --
     .instruction(
-        "Critic reviews", **CRITIC,
+        "Critic reviews",
+        **CRITIC,
         system_instruction=(
             "You are a sharp editorial critic. Review the paragraph you just read.\n\n"
             "Give exactly 3 specific, actionable suggestions for improvement. "
@@ -73,45 +75,52 @@ agent = (
             "Format: numbered list, one line each. No fluff."
         ),
     )
-
     # -- Increment and check --
-    .var("Increment", variable="iteration", expression="iteration + 1", show_output=False)
-    .if_node("More iterations?", expression=f"iteration > {MAX_ITERATIONS}", show_output=False)
-
+    .var(
+        "Increment", variable="iteration", expression="iteration + 1", show_output=False
+    )
+    .if_node(
+        "More iterations?",
+        expression=f"iteration > {MAX_ITERATIONS}",
+        show_output=False,
+    )
     # TRUE: done refining
     .on("true")
-        .text("Refinement complete", template=(
+    .text(
+        "Refinement complete",
+        template=(
             "\n──── Refinement Complete ────\n"
-            "The paragraph has been refined through {0} rounds of writing and critique." + str(MAX_ITERATIONS)
-        ))
-        .instruction(
-            "Final polish", **WRITER,
-            system_instruction=(
-                "You are the writer making a FINAL polish. "
-                "Take the latest draft and apply the last critic's feedback. "
-                "Output ONLY the final, polished paragraph. Make every word count."
-            ),
-        )
+            "The paragraph has been refined through {0} rounds of writing and critique."
+            + str(MAX_ITERATIONS)
+        ),
+    )
+    .instruction(
+        "Final polish",
+        **WRITER,
+        system_instruction=(
+            "You are the writer making a FINAL polish. "
+            "Take the latest draft and apply the last critic's feedback. "
+            "Output ONLY the final, polished paragraph. Make every word count."
+        ),
+    )
     .end()
-
     # FALSE: loop back
     .on("false")
-        .text("Next iteration", template="", show_output=False)
-    .end()
-
+    .text("Next iteration", template="", show_output=False)
     .end()
 )
 
 # -- Wire the loop back-edge --
 agent.connect("Next iteration", "Iteration header", label="next_iteration")
 
-# -- Build and run --
+# -- Build and run -- .build(validate=False) kept here because we deliberately
+# form a cycle (loop-back edge) which the default validator rejects.
 graph = agent.build(validate=False)
 
 print(f"Graph: {len(graph.nodes)} nodes, {len(graph.edges)} edges")
 print()
 
-run_graph(
+qm.run_graph(
     graph,
     user_input="The feeling of writing code at 3am when everything finally clicks",
 )

--- a/examples/09_parallel_agents.py
+++ b/examples/09_parallel_agents.py
@@ -32,6 +32,7 @@ for topic in topics:
 
     def make_task(t: str):
         """Create a closure over the topic string."""
+
         def task(s):
             # Simulate research work with a small delay
             time.sleep(0.1)
@@ -39,6 +40,7 @@ for topic in topics:
                 AgentMessage(role="assistant", content=f"Researching: {t}")
             )
             return {"topic": t, "findings": f"Key findings about {t}"}
+
         return task
 
     manager.start_session(session.id, make_task(topic))

--- a/examples/10_enterprise_agent.py
+++ b/examples/10_enterprise_agent.py
@@ -17,8 +17,7 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # ---------------------------------------------------------------------------
 # Sub-graph: HR department
@@ -26,20 +25,26 @@ from quartermaster_engine import run_graph
 # Analyses HR queries and conditionally escalates for manager approval.
 
 hr_flow = (
-    Graph("HR Handler")
-    .start()
-    .instruction("HR analysis", model="claude-haiku-4-5-20251001", system_instruction="Analyse HR-related query and determine policy")
+    qm.Graph("HR Handler")
+    .instruction(
+        "HR analysis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Analyse HR-related query and determine policy",
+    )
     .if_node("Needs approval?", expression="requires_manager_approval")
     .on("true")
-        .static("Alert manager", text="HR request requires manager approval")
-        .user("Awaiting manager response")
+    .static("Alert manager", text="HR request requires manager approval")
+    .user("Awaiting manager response")
     .end()
     .on("false")
-        .instruction("Direct HR response", model="claude-haiku-4-5-20251001", system_instruction="Provide HR information from policy database")
+    .instruction(
+        "Direct HR response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide HR information from policy database",
+    )
     .end()
     # No merge — IF picks one branch, they converge here.
     .write_memory("Log HR query", memory_name="hr_query_log")
-    .end()
 )
 
 # ---------------------------------------------------------------------------
@@ -49,22 +54,34 @@ hr_flow = (
 # before suggesting a fix.
 
 it_flow = (
-    Graph("IT Handler")
-    .start()
-    .instruction("IT diagnosis", model="claude-haiku-4-5-20251001", system_instruction="Diagnose the reported IT issue")
-
+    qm.Graph("IT Handler")
+    .instruction(
+        "IT diagnosis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Diagnose the reported IT issue",
+    )
     # Parallel: run security and performance checks concurrently
     .parallel()
     .branch()
-        .instruction("Security check", model="claude-haiku-4-5-20251001", system_instruction="Check for security implications")
+    .instruction(
+        "Security check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Check for security implications",
+    )
     .end()
     .branch()
-        .instruction("Performance check", model="claude-haiku-4-5-20251001", system_instruction="Assess performance impact")
+    .instruction(
+        "Performance check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Assess performance impact",
+    )
     .end()
     .static_merge("Combine IT checks")
-
-    .instruction("Suggest fix", model="claude-haiku-4-5-20251001", system_instruction="Provide troubleshooting steps based on diagnosis and checks")
-    .end()
+    .instruction(
+        "Suggest fix",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide troubleshooting steps based on diagnosis and checks",
+    )
 )
 
 # ---------------------------------------------------------------------------
@@ -73,20 +90,30 @@ it_flow = (
 # Handles finance queries with an IF for large amounts requiring CFO sign-off.
 
 finance_flow = (
-    Graph("Finance Handler")
-    .start()
-    .instruction("Finance analysis", model="claude-haiku-4-5-20251001", system_instruction="Analyse the finance-related request")
+    qm.Graph("Finance Handler")
+    .instruction(
+        "Finance analysis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Analyse the finance-related request",
+    )
     .if_node("Large amount?", expression="amount > 10000")
     .on("true")
-        .static("CFO alert", text="Finance request over $10k requires CFO approval")
-        .instruction("Prepare CFO brief", model="claude-haiku-4-5-20251001", system_instruction="Summarise request for CFO review")
+    .static("CFO alert", text="Finance request over $10k requires CFO approval")
+    .instruction(
+        "Prepare CFO brief",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Summarise request for CFO review",
+    )
     .end()
     .on("false")
-        .instruction("Process directly", model="claude-haiku-4-5-20251001", system_instruction="Handle finance request within standard limits")
+    .instruction(
+        "Process directly",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Handle finance request within standard limits",
+    )
     .end()
     # No merge — IF picks one branch.
     .write_memory("Log finance query", memory_name="last_finance_query")
-    .end()
 )
 
 # ---------------------------------------------------------------------------
@@ -94,46 +121,81 @@ finance_flow = (
 # ---------------------------------------------------------------------------
 
 agent = (
-    Graph("Enterprise Assistant")
-    .start()
+    qm.Graph("Enterprise Assistant")
     .user("How can I help you today?")
-    .write_memory("Log session start", memory_name="session_start", variables=[{"name": "timestamp", "value": "{{timestamp}}"}])
-    .instruction("Classify request", model="claude-haiku-4-5-20251001", system_instruction="Classify the request into: hr, it, finance, or general")
-
+    .write_memory(
+        "Log session start",
+        memory_name="session_start",
+        variables=[{"name": "timestamp", "value": "{{timestamp}}"}],
+    )
+    .instruction(
+        "Classify request",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Classify the request into: hr, it, finance, or general",
+    )
     # --- Department routing ---------------------------------------------------
     .decision("Department?", options=["hr", "it", "finance", "general"])
     .on("hr")
-        .use(hr_flow)
+    .use(hr_flow)
     .end()
     .on("it")
-        .use(it_flow)
+    .use(it_flow)
     .end()
     .on("finance")
-        .use(finance_flow)
+    .use(finance_flow)
     .end()
     .on("general")
-        .instruction("General help", model="claude-haiku-4-5-20251001", system_instruction="Provide general assistance")
+    .instruction(
+        "General help",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide general assistance",
+    )
     .end()
     # No merge after decision — only one department branch runs.
-
     # --- Quality gate ---------------------------------------------------------
-    .instruction("Quality check", model="claude-haiku-4-5-20251001", system_instruction="Review the response for accuracy and completeness (0-1 score)")
+    .instruction(
+        "Quality check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Review the response for accuracy and completeness (0-1 score)",
+    )
     .if_node("Quality OK?", expression="quality_score > 0.8")
     .on("true")
-        .instruction("Deliver", model="claude-haiku-4-5-20251001", system_instruction="Format and deliver the final response")
+    .instruction(
+        "Deliver",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Format and deliver the final response",
+    )
     .end()
     .on("false")
-        .instruction("Improve", model="claude-haiku-4-5-20251001", system_instruction="Rewrite the response to improve clarity and accuracy")
-        .instruction("Re-deliver", model="claude-haiku-4-5-20251001", system_instruction="Format and deliver the improved response")
+    .instruction(
+        "Improve",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Rewrite the response to improve clarity and accuracy",
+    )
+    .instruction(
+        "Re-deliver",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Format and deliver the improved response",
+    )
     .end()
     # No merge after IF — only one branch runs.
-
     # --- Audit trail ----------------------------------------------------------
-    .write_memory("Audit log", memory_name="audit_log", variables=[{"name": "audit", "value": "completed | dept:{{department}} | quality:{{quality_score}}"}])
+    .write_memory(
+        "Audit log",
+        memory_name="audit_log",
+        variables=[
+            {
+                "name": "audit",
+                "value": "completed | dept:{{department}} | quality:{{quality_score}}",
+            }
+        ],
+    )
     .static("Completion notice", text="Request handled successfully")
     .static("Audit", text="Enterprise request completed")
-    .end()
 )
 
 # Execute with a real LLM
-run_graph(agent, user_input="My laptop won't connect to the VPN and I need access to the finance portal urgently")
+qm.run_graph(
+    agent,
+    user_input="My laptop won't connect to the VPN and I need access to the finance portal urgently",
+)

--- a/examples/11_nested_control_flow.py
+++ b/examples/11_nested_control_flow.py
@@ -14,48 +14,58 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Whiteboard Agent")
-    .start()
+    qm.Graph("Whiteboard Agent")
     .user("Describe your task")
-    .instruction("Analyse input", model="claude-haiku-4-5-20251001", system_instruction="Break the task into components for parallel processing")
-
+    .instruction(
+        "Analyse input",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Break the task into components for parallel processing",
+    )
     # --- Parallel fan-out: 3 branches with nested control flow ----------------
     .parallel("Fan out")
-
     # Branch A: deep analysis pipeline
     .branch()
-        .text("Prepare context", template="Task context: {{user_input}}")
-        .instruction("Deep analysis", model="claude-haiku-4-5-20251001", system_instruction="Perform thorough analysis of the task")
+    .text("Prepare context", template="Task context: {{user_input}}")
+    .instruction(
+        "Deep analysis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Perform thorough analysis of the task",
+    )
     .end()
-
     # Branch B: independent lightweight check (pass-through)
     .branch()
-        .instruction("Quick check", model="claude-haiku-4-5-20251001", system_instruction="Perform a fast independent assessment")
+    .instruction(
+        "Quick check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Perform a fast independent assessment",
+    )
     .end()
-
     # Branch C: conditional quality gate (IF picks one path — no merge needed)
     .branch()
-        .if_node("Confidence high?", expression="confidence > 0.7")
-        .on("true")
-            .text("Accept result", template="Result meets confidence threshold -- approved")
-        .end()
-        .on("false")
-            .text("Flag for review", template="Low confidence -- manual review recommended")
-        .end()
-        # IF branches converge on this static node, which becomes the branch endpoint
-        .static("Quality gate result", text="Quality gate complete")
+    .if_node("Confidence high?", expression="confidence > 0.7")
+    .on("true")
+    .text("Accept result", template="Result meets confidence threshold -- approved")
     .end()
-
+    .on("false")
+    .text("Flag for review", template="Low confidence -- manual review recommended")
+    .end()
+    # IF branches converge on this static node, which becomes the branch endpoint
+    .static("Quality gate result", text="Quality gate complete")
+    .end()
     .static_merge("Combine all branches")
-
     # --- Final synthesis -------------------------------------------------------
-    .summarize("Final synthesis", model="claude-haiku-4-5-20251001", system_instruction="Combine all branch results into a coherent response")
-    .end()
+    .summarize(
+        "Final synthesis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Combine all branch results into a coherent response",
+    )
 )
 
 # Execute with a real LLM
-run_graph(agent, user_input="Design a Python microservice that handles user authentication with JWT tokens and rate limiting")
+qm.run_graph(
+    agent,
+    user_input="Design a Python microservice that handles user authentication with JWT tokens and rate limiting",
+)

--- a/examples/12_full_showcase.py
+++ b/examples/12_full_showcase.py
@@ -25,20 +25,29 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # ---------------------------------------------------------------------------
 # Sub-graph: Web research pipeline
 # ---------------------------------------------------------------------------
 
 web_research = (
-    Graph("Web Research")
-    .start()
-    .instruction("Web search", model="claude-haiku-4-5-20251001", system_instruction="Search the web for recent information on the topic")
-    .instruction("Extract key facts", model="claude-haiku-4-5-20251001", system_instruction="Extract and list the key facts from search results")
-    .instruction("Assess source quality", model="claude-haiku-4-5-20251001", system_instruction="Rate the reliability of each source (1-5)")
-    .end()
+    qm.Graph("Web Research")
+    .instruction(
+        "Web search",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Search the web for recent information on the topic",
+    )
+    .instruction(
+        "Extract key facts",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Extract and list the key facts from search results",
+    )
+    .instruction(
+        "Assess source quality",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Rate the reliability of each source (1-5)",
+    )
 )
 
 # ---------------------------------------------------------------------------
@@ -46,12 +55,22 @@ web_research = (
 # ---------------------------------------------------------------------------
 
 academic_research = (
-    Graph("Academic Research")
-    .start()
-    .instruction("Search papers", model="claude-haiku-4-5-20251001", system_instruction="Search academic databases for peer-reviewed papers")
-    .instruction("Summarise papers", model="claude-haiku-4-5-20251001", system_instruction="Create structured summaries of the top papers")
-    .instruction("Identify consensus", model="claude-haiku-4-5-20251001", system_instruction="Identify areas of scientific consensus and debate")
-    .end()
+    qm.Graph("Academic Research")
+    .instruction(
+        "Search papers",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Search academic databases for peer-reviewed papers",
+    )
+    .instruction(
+        "Summarise papers",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create structured summaries of the top papers",
+    )
+    .instruction(
+        "Identify consensus",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Identify areas of scientific consensus and debate",
+    )
 )
 
 # ---------------------------------------------------------------------------
@@ -59,84 +78,111 @@ academic_research = (
 # ---------------------------------------------------------------------------
 
 agent = (
-    Graph("AI Research Assistant")
-    .start()
-
+    qm.Graph("AI Research Assistant")
     # --- Input and topic capture ----------------------------------------------
     .user("What do you want to research?")
     .var("Capture topic", variable="research_topic")
     .write_memory("Store topic", memory_name="research_topic")
     .text("Acknowledge", template="Researching: {{research_topic}}")
-
     # --- Strategy selection ----------------------------------------------------
-    .instruction("Classify research", model="claude-haiku-4-5-20251001", system_instruction="Classify the research type: academic, general, or technical")
-
+    .instruction(
+        "Classify research",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Classify the research type: academic, general, or technical",
+    )
     .decision("Research strategy?", options=["academic", "general", "technical"])
-
     .on("academic")
-        .use(academic_research)
+    .use(academic_research)
     .end()
-
     .on("general")
-        .use(web_research)
+    .use(web_research)
     .end()
-
     .on("technical")
-        .instruction("Technical deep-dive", model="claude-haiku-4-5-20251001", system_instruction="Perform in-depth technical analysis with code examples")
-        .instruction("Benchmark review", model="claude-haiku-4-5-20251001", system_instruction="Review benchmarks and performance comparisons")
+    .instruction(
+        "Technical deep-dive",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Perform in-depth technical analysis with code examples",
+    )
+    .instruction(
+        "Benchmark review",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Review benchmarks and performance comparisons",
+    )
     .end()
-
     # No merge — decision picks ONE research strategy.
-
     # --- Quality review: parallel checks with nested IF -----------------------
     .read_memory("Recall topic", memory_name="research_topic")
-
     .parallel("Quality review")
-
     # Branch 1: Fact-checking with pass/fail gate
     .branch()
-        .instruction("Fact-check", model="claude-haiku-4-5-20251001", system_instruction="Verify all factual claims against sources")
-        .if_node("Facts verified?", expression="verification_score > 0.9")
-        .on("true")
-            .text("Facts OK", template="All facts verified successfully")
-        .end()
-        .on("false")
-            .instruction("Fix errors", model="claude-haiku-4-5-20251001", system_instruction="Correct any unverified or inaccurate claims")
-        .end()
-        # IF branches converge on a result node
-        .static("Fact-check done", text="Fact-check complete")
+    .instruction(
+        "Fact-check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Verify all factual claims against sources",
+    )
+    .if_node("Facts verified?", expression="verification_score > 0.9")
+    .on("true")
+    .text("Facts OK", template="All facts verified successfully")
     .end()
-
+    .on("false")
+    .instruction(
+        "Fix errors",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Correct any unverified or inaccurate claims",
+    )
+    .end()
+    # IF branches converge on a result node
+    .static("Fact-check done", text="Fact-check complete")
+    .end()
     # Branch 2: Bias assessment (no conditional, straight-through)
     .branch()
-        .instruction("Bias assessment", model="claude-haiku-4-5-20251001", system_instruction="Check for confirmation bias, source bias, and framing issues")
+    .instruction(
+        "Bias assessment",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Check for confirmation bias, source bias, and framing issues",
+    )
     .end()
-
     # Branch 3: Completeness check with gap detection
     .branch()
-        .if_node("Coverage gaps?", expression="has_coverage_gaps")
-        .on("true")
-            .instruction("Fill gaps", model="claude-haiku-4-5-20251001", system_instruction="Research and fill identified coverage gaps")
-        .end()
-        .on("false")
-            .text("Coverage complete", template="Research covers all key aspects of {{research_topic}}")
-        .end()
-        # IF branches converge on a result node
-        .static("Coverage done", text="Coverage check complete")
+    .if_node("Coverage gaps?", expression="has_coverage_gaps")
+    .on("true")
+    .instruction(
+        "Fill gaps",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Research and fill identified coverage gaps",
+    )
     .end()
-
+    .on("false")
+    .text(
+        "Coverage complete",
+        template="Research covers all key aspects of {{research_topic}}",
+    )
+    .end()
+    # IF branches converge on a result node
+    .static("Coverage done", text="Coverage check complete")
+    .end()
     .static_merge("Quality review complete")
-
     # --- Synthesis and delivery -----------------------------------------------
-    .instruction("Synthesise findings", model="claude-haiku-4-5-20251001", provider="anthropic", system_instruction="Synthesise all research findings into a coherent analysis")
-    .summarize("Executive summary", model="claude-haiku-4-5-20251001", system_instruction="Create a concise executive summary with key takeaways")
-
+    .instruction(
+        "Synthesise findings",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction="Synthesise all research findings into a coherent analysis",
+    )
+    .summarize(
+        "Executive summary",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create a concise executive summary with key takeaways",
+    )
     # --- Audit trail ----------------------------------------------------------
     .update_memory("Update status", memory_name="research_status")
-    .static("Report ready", text="Research report on {{research_topic}} is ready for review")
+    .static(
+        "Report ready", text="Research report on {{research_topic}} is ready for review"
+    )
     .static("Completed", text="Research pipeline completed for: {{research_topic}}")
-    .end()
 )
 
 # Execute with a real LLM
-run_graph(agent, user_input="What are the latest advances in quantum error correction?")
+qm.run_graph(
+    agent, user_input="What are the latest advances in quantum error correction?"
+)

--- a/examples/13_orchestrator.py
+++ b/examples/13_orchestrator.py
@@ -20,14 +20,12 @@ Usage:
     uv run examples/13_orchestrator.py
 """
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # -- Build the graph ----------------------------------------------------------
 graph = (
-    Graph("ParallelOrchestrator")
+    qm.Graph("ParallelOrchestrator")
     .allowed_agents("researcher", "writer", "reviewer")
-    .start()
     # 1. Collect the user's request
     .user("Describe the project you'd like researched, written, and reviewed.")
     # 2. Orchestrator -- an Agent node with session-management tools
@@ -62,8 +60,10 @@ graph = (
             "reviewer's feedback."
         ),
     )
-    .end()
 )
 
 # Execute with a real LLM
-run_graph(graph, user_input="Write a technical blog post about WebAssembly's role in server-side computing")
+qm.run_graph(
+    graph,
+    user_input="Write a technical blog post about WebAssembly's role in server-side computing",
+)

--- a/examples/14_user_forms.py
+++ b/examples/14_user_forms.py
@@ -20,8 +20,7 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 
 # ---------------------------------------------------------------------------
@@ -29,33 +28,59 @@ from quartermaster_engine import run_graph
 # ---------------------------------------------------------------------------
 
 agent = (
-    Graph("Event Registration")
-    .start()
-
+    qm.Graph("Event Registration")
     # --- Step 1: Greet the user -------------------------------------------------
     .text("Welcome", template="Welcome! Ready to register for TechConf 2026?")
-
     # --- Step 2: Structured form for registration data ------------------------
-    .user_form("Registration form", parameters=[
-        {"name": "full_name",    "type": "text",   "label": "Full name",     "required": "true"},
-        {"name": "email",        "type": "email",  "label": "Email address", "required": "true"},
-        {"name": "company",      "type": "text",   "label": "Company",       "required": "false"},
-        {"name": "ticket_type",  "type": "select", "label": "Ticket type",   "options": "standard,vip"},
-        {"name": "quantity",     "type": "number", "label": "Number of tickets", "default": "1"},
-    ])
-
+    .user_form(
+        "Registration form",
+        parameters=[
+            {
+                "name": "full_name",
+                "type": "text",
+                "label": "Full name",
+                "required": "true",
+            },
+            {
+                "name": "email",
+                "type": "email",
+                "label": "Email address",
+                "required": "true",
+            },
+            {
+                "name": "company",
+                "type": "text",
+                "label": "Company",
+                "required": "false",
+            },
+            {
+                "name": "ticket_type",
+                "type": "select",
+                "label": "Ticket type",
+                "options": "standard,vip",
+            },
+            {
+                "name": "quantity",
+                "type": "number",
+                "label": "Number of tickets",
+                "default": "1",
+            },
+        ],
+    )
     # --- Step 3: Compute derived value from form data -------------------------
     # ticket_type, quantity, full_name, email, company are already available
     # from the form -- no need to re-capture them with var().
-    .var("Calculate price",
-         variable="total_price",
-         expression="int(quantity) * 500 if ticket_type == 'vip' else int(quantity) * 150")
-
+    .var(
+        "Calculate price",
+        variable="total_price",
+        expression="int(quantity) * 500 if ticket_type == 'vip' else int(quantity) * 150",
+    )
     # --- Step 4: Conditional branch based on ticket type ----------------------
     .if_node("VIP ticket?", expression="ticket_type == 'vip'")
-
     .on("true")
-        .text("VIP perks", template=(
+    .text(
+        "VIP perks",
+        template=(
             "VIP Registration for {{full_name}}\n"
             "-------------------------------\n"
             "Your VIP package includes:\n"
@@ -63,42 +88,50 @@ agent = (
             "  - Speaker meet-and-greet\n"
             "  - Exclusive networking dinner\n"
             "  - Priority Q&A access"
-        ))
+        ),
+    )
     .end()
-
     .on("false")
-        .text("Standard info", template=(
+    .text(
+        "Standard info",
+        template=(
             "Standard Registration for {{full_name}}\n"
             "-----------------------------------\n"
             "Your standard package includes:\n"
             "  - General admission seating\n"
             "  - Access to all talks\n"
             "  - Conference materials"
-        ))
+        ),
+    )
     .end()
-
     # IF picks one branch -- no merge needed. Branches converge here.
-
     # --- Step 5: Confirmation summary using Jinja2 template -------------------
-    .text("Confirmation", template=(
-        "=== Registration Confirmed ===\n"
-        "\n"
-        "Name:      {{full_name}}\n"
-        "Email:     {{email}}\n"
-        "Company:   {{company}}\n"
-        "Ticket:    {{ticket_type}} x{{quantity}}\n"
-        "Total:     ${{total_price}}\n"
-        "\n"
-        "A confirmation email will be sent to {{email}}."
-    ))
-
+    .text(
+        "Confirmation",
+        template=(
+            "=== Registration Confirmed ===\n"
+            "\n"
+            "Name:      {{full_name}}\n"
+            "Email:     {{email}}\n"
+            "Company:   {{company}}\n"
+            "Ticket:    {{ticket_type}} x{{quantity}}\n"
+            "Total:     ${{total_price}}\n"
+            "\n"
+            "A confirmation email will be sent to {{email}}."
+        ),
+    )
     # --- Step 6: Persist to memory --------------------------------------------
-    .write_memory("Save registration", memory_name="registrations", variables=[
-        {"name": "registration", "value": "{{full_name}}|{{email}}|{{ticket_type}}|{{quantity}}|{{total_price}}"},
-    ])
-
+    .write_memory(
+        "Save registration",
+        memory_name="registrations",
+        variables=[
+            {
+                "name": "registration",
+                "value": "{{full_name}}|{{email}}|{{ticket_type}}|{{quantity}}|{{total_price}}",
+            },
+        ],
+    )
     .text("Thank you", template="Thank you {{full_name}}! See you at TechConf 2026.")
-    .end()
 )
 
 
@@ -107,54 +140,74 @@ agent = (
 # ---------------------------------------------------------------------------
 
 feedback = (
-    Graph("Feedback Collector")
-    .start()
-
+    qm.Graph("Feedback Collector")
     .text("Greeting", template="We'd love your feedback!")
-
-    .user_form("Feedback form", parameters=[
-        {"name": "rating",   "type": "number", "label": "Rating (1-5)",     "required": "true"},
-        {"name": "comments", "type": "text",   "label": "Comments",         "required": "false"},
-        {"name": "contact",  "type": "email",  "label": "Follow-up email",  "required": "false"},
-    ])
-
+    .user_form(
+        "Feedback form",
+        parameters=[
+            {
+                "name": "rating",
+                "type": "number",
+                "label": "Rating (1-5)",
+                "required": "true",
+            },
+            {
+                "name": "comments",
+                "type": "text",
+                "label": "Comments",
+                "required": "false",
+            },
+            {
+                "name": "contact",
+                "type": "email",
+                "label": "Follow-up email",
+                "required": "false",
+            },
+        ],
+    )
     # rating is already available from the form -- only compute derived values
     .var("Parse rating", variable="rating_num", expression="int(rating)")
-
     # Branch on rating
     .if_node("Good rating?", expression="rating_num >= 4")
-
     .on("true")
-        .text("Positive thanks", template=(
+    .text(
+        "Positive thanks",
+        template=(
             "Thank you for the great rating ({{rating}}/5)!\n"
             "We're glad you enjoyed the experience."
-        ))
+        ),
+    )
     .end()
-
     .on("false")
-        .text("Improvement note", template=(
+    .text(
+        "Improvement note",
+        template=(
             "We're sorry the experience wasn't perfect ({{rating}}/5).\n"
             "Your feedback: {{comments}}\n"
             "We'll work on improving."
-        ))
-        .instruction("Suggest improvements",
-                     model="claude-haiku-4-5-20251001",
-                     system_instruction=(
-                         "The user rated us {{rating}}/5 and said: '{{comments}}'. "
-                         "Suggest 2-3 specific improvements we could make."
-                     ))
+        ),
+    )
+    .instruction(
+        "Suggest improvements",
+        model="claude-haiku-4-5-20251001",
+        system_instruction=(
+            "The user rated us {{rating}}/5 and said: '{{comments}}'. "
+            "Suggest 2-3 specific improvements we could make."
+        ),
+    )
     .end()
-
     # IF picks one branch -- no merge needed.
-
-    .write_memory("Store feedback", memory_name="feedback_log", variables=[
-        {"name": "entry", "value": "rating:{{rating}}|comments:{{comments}}"},
-    ])
-    .end()
+    .write_memory(
+        "Store feedback",
+        memory_name="feedback_log",
+        variables=[
+            {"name": "entry", "value": "rating:{{rating}}|comments:{{comments}}"},
+        ],
+    )
 )
 
 
 # Execute both graphs
-run_graph(agent, user_input="Register me for the conference")
+qm.run_graph(agent, user_input="Register me for the conference")
 print("\n" + "=" * 60 + "\n")
-run_graph(feedback, user_input="I want to leave feedback")
+qm.run_graph(feedback, user_input="I want to leave feedback")

--- a/examples/15_courtroom_debate.py
+++ b/examples/15_courtroom_debate.py
@@ -21,16 +21,15 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_graph.enums import TraverseIn
-from quartermaster_engine import run_graph
 
 
 # -- Provider config --------------------------------------------------------
 
 PROSECUTOR = dict(model="grok-3-mini-fast", provider="xai")
-DEFENSE    = dict(model="gpt-4o", provider="openai")
-JUDGE      = dict(model="claude-haiku-4-5-20251001", provider="anthropic")
+DEFENSE = dict(model="gpt-4o", provider="openai")
+JUDGE = dict(model="claude-haiku-4-5-20251001", provider="anthropic")
 
 MAX_ROUNDS = 5
 
@@ -38,49 +37,53 @@ MAX_ROUNDS = 5
 # -- Main trial graph -------------------------------------------------------
 
 trial = (
-    Graph("The People v. Dr. Sarah Chen")
-    .start()
+    qm.Graph("The People v. Dr. Sarah Chen")
     .user("Describe the case")
     .var("Capture case", variable="case_description", show_output=False)
     .write_memory("File case", memory_name="case_file", show_output=False)
-
-    .text("Court opens", template=(
-        "═══════════════════════════════════════════\n"
-        "  SUPERIOR COURT — DEPARTMENT 7\n"
-        "  TechCorp Inc. v. Dr. Sarah Chen\n"
-        "  Charges: Trade secret theft, NDA breach\n"
-        "═══════════════════════════════════════════\n\n"
-        "BAILIFF: All rise. Court is now in session.\n"
-        f"JUDGE: We will hear {MAX_ROUNDS} rounds of argument.\n"
-    ))
-
+    .text(
+        "Court opens",
+        template=(
+            "═══════════════════════════════════════════\n"
+            "  SUPERIOR COURT — DEPARTMENT 7\n"
+            "  TechCorp Inc. v. Dr. Sarah Chen\n"
+            "  Charges: Trade secret theft, NDA breach\n"
+            "═══════════════════════════════════════════\n\n"
+            "BAILIFF: All rise. Court is now in session.\n"
+            f"JUDGE: We will hear {MAX_ROUNDS} rounds of argument.\n"
+        ),
+    )
     # -- Initialize loop counter --
     .var("Init round", variable="round_number", expression="1", show_output=False)
-
     # -- Loop target --
-    .text("Round announce", template=(
-        "\n──── Round {{round_number}} of 5 ────"
-    ), traverse_in=TraverseIn.AWAIT_FIRST)
-
+    .text(
+        "Round announce",
+        template=("\n──── Round {{round_number}} of 5 ────"),
+        traverse_in=TraverseIn.AWAIT_FIRST,
+    )
     # -- Round context injected as a text node so LLMs see it --
-    .text("Round context", template=(
-        "COURT CLERK: This is round {{round_number}} of 5.\n"
-        "{% if round_number == 1 %}"
-        "Phase: OPENING STATEMENTS. Present your theory of the case."
-        "{% elif round_number == 2 %}"
-        "Phase: EVIDENCE. Present forensic evidence, call expert witnesses, cite specific data."
-        "{% elif round_number == 3 %}"
-        "Phase: CROSS-EXAMINATION. Challenge the opposing side's evidence and witnesses directly."
-        "{% elif round_number == 4 %}"
-        "Phase: REBUTTAL. Address weaknesses in your case, introduce new counter-evidence."
-        "{% else %}"
-        "Phase: CLOSING ARGUMENTS. This is your final chance. Make it count."
-        "{% endif %}"
-    ), show_output=False)
-
+    .text(
+        "Round context",
+        template=(
+            "COURT CLERK: This is round {{round_number}} of 5.\n"
+            "{% if round_number == 1 %}"
+            "Phase: OPENING STATEMENTS. Present your theory of the case."
+            "{% elif round_number == 2 %}"
+            "Phase: EVIDENCE. Present forensic evidence, call expert witnesses, cite specific data."
+            "{% elif round_number == 3 %}"
+            "Phase: CROSS-EXAMINATION. Challenge the opposing side's evidence and witnesses directly."
+            "{% elif round_number == 4 %}"
+            "Phase: REBUTTAL. Address weaknesses in your case, introduce new counter-evidence."
+            "{% else %}"
+            "Phase: CLOSING ARGUMENTS. This is your final chance. Make it count."
+            "{% endif %}"
+        ),
+        show_output=False,
+    )
     # -- Prosecution --
     .instruction(
-        "Prosecution argues", **PROSECUTOR,
+        "Prosecution argues",
+        **PROSECUTOR,
         system_instruction=(
             "You are the lead prosecutor in TechCorp v. Dr. Sarah Chen.\n"
             "The court clerk has announced the current phase. Follow it STRICTLY:\n\n"
@@ -97,10 +100,10 @@ trial = (
             "2-3 paragraphs. Address the judge as 'Your Honor'."
         ),
     )
-
     # -- Defense --
     .instruction(
-        "Defense rebuts", **DEFENSE,
+        "Defense rebuts",
+        **DEFENSE,
         system_instruction=(
             "You are the defense attorney for Dr. Sarah Chen.\n"
             "The court clerk has announced the current phase. Follow it STRICTLY:\n\n"
@@ -121,41 +124,47 @@ trial = (
             "2-3 paragraphs. Address the judge as 'Your Honor'."
         ),
     )
-
     # -- Increment and check --
-    .var("Increment", variable="round_number", expression="round_number + 1", show_output=False)
-    .if_node("More rounds?", expression=f"round_number > {MAX_ROUNDS}", show_output=False)
-
+    .var(
+        "Increment",
+        variable="round_number",
+        expression="round_number + 1",
+        show_output=False,
+    )
+    .if_node(
+        "More rounds?", expression=f"round_number > {MAX_ROUNDS}", show_output=False
+    )
     # TRUE: verdict
     .on("true")
-        .text("Debate over", template=(
+    .text(
+        "Debate over",
+        template=(
             "\n═══════════════════════════════════════════\n"
             "  ALL ARGUMENTS HEARD — DELIVERING VERDICT\n"
             "═══════════════════════════════════════════"
-        ))
-        .instruction(
-            "Judge delivers verdict", **JUDGE,
-            system_instruction=(
-                "You are the presiding judge delivering the FINAL VERDICT.\n"
-                "You heard 5 rounds: openings, evidence, cross-examination, rebuttal, closings.\n\n"
-                "Structure your verdict:\n"
-                "1. FINDINGS OF FACT — what was established\n"
-                "2. PROSECUTION'S CASE — strongest points and weaknesses\n"
-                "3. DEFENSE'S CASE — strongest points and weaknesses\n"
-                "4. EVIDENCE EVALUATION — the 78% code similarity, access logs, expert testimony\n"
-                "5. NON-COMPETE RULING — enforceable or not, with legal reasoning\n"
-                "6. VERDICT — GUILTY, NOT GUILTY, or MISTRIAL with clear rationale\n\n"
-                "Be thorough and judicial. This is a formal ruling."
-            ),
-        )
-        .text("Adjournment", template="\n--- Court is adjourned ---")
+        ),
+    )
+    .instruction(
+        "Judge delivers verdict",
+        **JUDGE,
+        system_instruction=(
+            "You are the presiding judge delivering the FINAL VERDICT.\n"
+            "You heard 5 rounds: openings, evidence, cross-examination, rebuttal, closings.\n\n"
+            "Structure your verdict:\n"
+            "1. FINDINGS OF FACT — what was established\n"
+            "2. PROSECUTION'S CASE — strongest points and weaknesses\n"
+            "3. DEFENSE'S CASE — strongest points and weaknesses\n"
+            "4. EVIDENCE EVALUATION — the 78% code similarity, access logs, expert testimony\n"
+            "5. NON-COMPETE RULING — enforceable or not, with legal reasoning\n"
+            "6. VERDICT — GUILTY, NOT GUILTY, or MISTRIAL with clear rationale\n\n"
+            "Be thorough and judicial. This is a formal ruling."
+        ),
+    )
+    .text("Adjournment", template="\n--- Court is adjourned ---")
     .end()
-
     # FALSE: loop back
     .on("false")
-        .text("Next round", template="", show_output=False)
-    .end()
-
+    .text("Next round", template="", show_output=False)
     .end()
 )
 
@@ -163,14 +172,15 @@ trial = (
 
 trial.connect("Next round", "Round announce", label="next_round")
 
-# -- Build and run ----------------------------------------------------------
+# -- Build and run -- .build(validate=False) kept here because we deliberately
+# form a cycle (loop-back edge) which the default validator rejects.
 
 agent = trial.build(validate=False)
 
 print(f"Graph: {len(agent.nodes)} nodes, {len(agent.edges)} edges")
 print()
 
-run_graph(
+qm.run_graph(
     agent,
     user_input=(
         "Dr. Sarah Chen, a senior AI engineer, left TechCorp after 5 years "

--- a/examples/16_tool_agent.py
+++ b/examples/16_tool_agent.py
@@ -18,9 +18,8 @@ from __future__ import annotations
 
 import json
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_tools import ToolRegistry
-from quartermaster_engine import run_graph
 
 # ---------------------------------------------------------------------------
 # 1. Define custom tools with @tool()
@@ -127,8 +126,7 @@ print(f"\nAnthropic format: {len(anthropic_tools)} tools exported")
 tool_descriptions = json.dumps(schemas, indent=2)
 
 agent = (
-    Graph("Tool Agent")
-    .start()
+    qm.Graph("Tool Agent")
     .user("Ask something that needs a tool")
     .instruction(
         "Reason about tools",
@@ -154,11 +152,12 @@ agent = (
             "the direct answer. Be concise -- one or two sentences."
         ),
     )
-    .end()
 )
 
 # ---------------------------------------------------------------------------
 # 5. Run the graph
 # ---------------------------------------------------------------------------
 
-run_graph(agent, user_input="What is the capital of Japan and what's the weather there?")
+qm.run_graph(
+    agent, user_input="What is the capital of Japan and what's the weather there?"
+)

--- a/examples/18_compliance_guard.py
+++ b/examples/18_compliance_guard.py
@@ -27,10 +27,12 @@ import tempfile
 from quartermaster_tools.builtin.privacy.detect import DetectPIITool, ScanFilePIITool
 from quartermaster_tools.builtin.privacy.redact import RedactPIITool
 from quartermaster_tools.builtin.compliance.risk_classifier import RiskClassifierTool
-from quartermaster_tools.builtin.compliance.audit_log import AuditLogTool, ReadAuditLogTool
+from quartermaster_tools.builtin.compliance.audit_log import (
+    AuditLogTool,
+    ReadAuditLogTool,
+)
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 
 # ============================================================================
@@ -126,7 +128,10 @@ AuditLogTool.run(
     action="pii_redaction",
     actor="compliance_pipeline",
     system_id="complaint-analyser-v1",
-    details={"strategy": "redact", "entities_redacted": redacted_result.data.get("entities_found", 0)},
+    details={
+        "strategy": "redact",
+        "entities_redacted": redacted_result.data.get("entities_found", 0),
+    },
     log_path=audit_path,
 )
 
@@ -167,19 +172,18 @@ print()
 # -- Build the graph ---------------------------------------------------------
 
 agent = (
-    Graph("Compliance-Aware Agent")
-    .start()
-
+    qm.Graph("Compliance-Aware Agent")
     # The user input is the REDACTED text (PII already removed)
     .user("Enter the complaint text")
     .var("Capture complaint", variable="complaint_text")
     .write_memory("Store complaint", memory_name="complaint")
-
-    .text("Status", template=(
-        "--- Compliance Pipeline ---\n"
-        "PII has been removed. Processing cleaned text..."
-    ))
-
+    .text(
+        "Status",
+        template=(
+            "--- Compliance Pipeline ---\n"
+            "PII has been removed. Processing cleaned text..."
+        ),
+    )
     # Analyse the complaint (safe -- no PII in the text)
     .instruction(
         "Analyse complaint",
@@ -198,47 +202,50 @@ agent = (
         ),
     )
     .var("Capture analysis", variable="analysis", show_output=False)
-
     # Route by priority
     .if_node("High priority?", expression="priority_level <= 2")
     .on("true")
-        .text("Escalation", template=(
+    .text(
+        "Escalation",
+        template=(
             "\n*** ESCALATION ***\n"
             "High-priority complaint detected. Flagging for immediate review."
-        ))
-        .instruction(
-            "Escalation brief",
-            model="claude-haiku-4-5-20251001",
-            provider="anthropic",
-            system_instruction=(
-                "Write a brief escalation summary for a manager. Include "
-                "the core issue, why it is urgent, and recommended immediate "
-                "actions. Keep it under 100 words."
-            ),
-        )
+        ),
+    )
+    .instruction(
+        "Escalation brief",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction=(
+            "Write a brief escalation summary for a manager. Include "
+            "the core issue, why it is urgent, and recommended immediate "
+            "actions. Keep it under 100 words."
+        ),
+    )
     .end()
     .on("false")
-        .instruction(
-            "Standard response",
-            model="claude-haiku-4-5-20251001",
-            provider="anthropic",
-            system_instruction=(
-                "Draft a professional customer response acknowledging the "
-                "complaint and outlining the resolution timeline. Do NOT "
-                "include any personal data."
-            ),
-        )
+    .instruction(
+        "Standard response",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction=(
+            "Draft a professional customer response acknowledging the "
+            "complaint and outlining the resolution timeline. Do NOT "
+            "include any personal data."
+        ),
+    )
     .end()
-
     # Final summary
     .write_memory("Store resolution", memory_name="resolution")
-    .text("Complete", template=(
-        "\n--- Pipeline Complete ---\n"
-        "Complaint processed. Resolution stored in memory."
-    ))
-    .end()
+    .text(
+        "Complete",
+        template=(
+            "\n--- Pipeline Complete ---\n"
+            "Complaint processed. Resolution stored in memory."
+        ),
+    )
 )
 
 # -- Execute with the cleaned text as input ----------------------------------
 
-run_graph(agent, user_input=clean_text)
+qm.run_graph(agent, user_input=clean_text)

--- a/examples/19_mcp_client.py
+++ b/examples/19_mcp_client.py
@@ -146,6 +146,7 @@ async def demo_mcp_client() -> list[McpTool]:
 # and docstrings -- but for MCP tools the schema already exists, so we
 # build the wrapper programmatically.
 
+
 def mcp_to_quartermaster_tools(
     mcp_tools: list[McpTool],
     server_url: str = MCP_SERVER_URL,
@@ -264,7 +265,13 @@ def mcp_to_quartermaster_tools(
             wrapper.__name__ = t.name
             wrapper.__doc__ = t.description
             wrapper.__annotations__ = {
-                p.name: str if p.type == "string" else int if p.type == "integer" else float if p.type == "number" else object
+                p.name: str
+                if p.type == "string"
+                else int
+                if p.type == "integer"
+                else float
+                if p.type == "number"
+                else object
                 for p in t.parameters
             }
             wrapper.__annotations__["return"] = dict
@@ -295,6 +302,7 @@ def mcp_to_quartermaster_tools(
 # passed to an Agent or Instruction node via the ``tools=`` parameter.
 # Below we build the graph structure to show how it all fits together.
 
+
 def demo_graph_with_mcp_tools() -> None:
     """Build a graph that incorporates MCP-provided tools."""
     print("=" * 60)
@@ -303,17 +311,16 @@ def demo_graph_with_mcp_tools() -> None:
     print()
 
     try:
-        from quartermaster_graph import Graph
+        import quartermaster_sdk as qm
     except ImportError:
-        print("quartermaster-graph is not installed; skipping graph demo.")
+        print("quartermaster-sdk is not installed; skipping graph demo.")
         return
 
     # Imagine the MCP server exposes "weather_lookup" and "web_search".
     # After wrapping them (Part 2) they live in a ToolRegistry.
     # An Agent node references them by name via ``tools=[...]``.
     graph = (
-        Graph("MCP Research Agent")
-        .start()
+        qm.Graph("MCP Research Agent")
         .user("What would you like to research?")
         .agent(
             "Researcher",
@@ -338,10 +345,11 @@ def demo_graph_with_mcp_tools() -> None:
                 "concise answer for the user."
             ),
         )
-        .end()
     )
 
-    # Print the graph structure
+    # Print the graph structure — we call .build() here just to inspect the
+    # validated spec; ``qm.run_graph(graph, ...)`` would accept the builder
+    # directly in the v0.2.0 API.
     built = graph.build()
     print("Graph structure:")
     for node in built.nodes:
@@ -355,21 +363,22 @@ def demo_graph_with_mcp_tools() -> None:
         print(f"  {src} -> {tgt}{label}")
     print()
 
-    # To actually run this graph you would use the _runner helper:
+    # To actually run this graph:
     #
-    #   from quartermaster_engine import run_graph
-    #   run_graph(graph, user_input="What is the weather in Tokyo?")
+    #   import quartermaster_sdk as qm
+    #   qm.run_graph(graph, user_input="What is the weather in Tokyo?")
     #
     # The runner wires the ToolRegistry into the FlowRunner so the
     # Agent node can call tools during its reasoning loop.
     print(
         "To execute, set an API key and call:\n"
-        "  run_graph(graph, user_input='What is the weather in Tokyo?')\n"
+        "  qm.run_graph(graph, user_input='What is the weather in Tokyo?')\n"
     )
 
 
 # ── Part 4: Sync API one-liner ─────────────────────────────────────────────
 # For scripts that do not use asyncio the sync wrappers are convenient.
+
 
 def demo_sync_api() -> None:
     """Demonstrate the synchronous (non-async) MCP client API."""
@@ -402,6 +411,7 @@ def demo_sync_api() -> None:
 
 
 # ── Main ────────────────────────────────────────────────────────────────────
+
 
 async def main() -> None:
     # Part 1: connect to a live MCP server (graceful if unavailable)

--- a/examples/20_ollama_local.py
+++ b/examples/20_ollama_local.py
@@ -14,9 +14,8 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_tools import ToolRegistry, tool
-from quartermaster_engine import run_graph
 
 
 MODEL = "gemma4:26b"
@@ -57,16 +56,28 @@ def search_knowledge(query: str) -> dict:
         query: Search query string.
     """
     kb = [
-        {"title": "Quartermaster", "fact": "AI agent orchestration framework by MindMade"},
-        {"title": "Gemma 4", "fact": "Google's open model with vision and tool calling"},
+        {
+            "title": "Quartermaster",
+            "fact": "AI agent orchestration framework by MindMade",
+        },
+        {
+            "title": "Gemma 4",
+            "fact": "Google's open model with vision and tool calling",
+        },
         {"title": "Slovenia", "fact": "Country in Central Europe, capital Ljubljana"},
     ]
-    results = [r for r in kb if query.lower() in r["title"].lower() or query.lower() in r["fact"].lower()]
+    results = [
+        r
+        for r in kb
+        if query.lower() in r["title"].lower() or query.lower() in r["fact"].lower()
+    ]
     return {"query": query, "results": results}
 
 
 # Build tool descriptions for the system prompt
-tool_list = "\n".join(f"- {s['name']}: {s.get('description', '')}" for s in registry.to_json_schema())
+tool_list = "\n".join(
+    f"- {s['name']}: {s.get('description', '')}" for s in registry.to_json_schema()
+)
 
 
 # ============================================================================
@@ -93,12 +104,12 @@ else:
     print("  (Sample image not found — using text description)")
 
 vision_agent = (
-    Graph("Gemma Vision")
-    .start()
+    qm.Graph("Gemma Vision")
     .user("Analyze this image")
     .vision(
         "Describe image",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction=(
             "You are an image analyst. Describe exactly what you see: "
             "the subject, colors, setting, mood, and any notable details. "
@@ -106,10 +117,9 @@ vision_agent = (
             "3-4 sentences."
         ),
     )
-    .end()
 )
 
-run_graph(vision_agent, user_input=image_prompt)
+qm.run_graph(vision_agent, user_input=image_prompt)
 
 
 # ============================================================================
@@ -119,12 +129,12 @@ run_graph(vision_agent, user_input=image_prompt)
 print("\n--- Demo 2: Tool Calling ---\n")
 
 tool_agent = (
-    Graph("Gemma Tools")
-    .start()
+    qm.Graph("Gemma Tools")
     .user("Ask anything")
     .instruction(
         "Think and call tools",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction=(
             "You are a helpful assistant with tools. When you need data, "
             "describe which tool you would call and why.\n\n"
@@ -132,13 +142,11 @@ tool_agent = (
             "Reason step-by-step about which tools to use, then answer."
         ),
     )
-    .end()
 )
 
-run_graph(
+qm.run_graph(
     tool_agent,
     user_input="What's the weather in Ljubljana and what do you know about Slovenia?",
-
 )
 
 
@@ -149,29 +157,28 @@ run_graph(
 print("\n--- Demo 3: Multi-step Pipeline ---\n")
 
 pipeline = (
-    Graph("Gemma Pipeline")
-    .start()
+    qm.Graph("Gemma Pipeline")
     .user("Topic")
     .instruction(
         "Research",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction="Write 3 key facts about the given topic. Be concise and specific.",
     )
     .instruction(
         "Summarize",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction=(
             "Take the research above and write a single compelling paragraph "
             "for a non-expert. Under 100 words."
         ),
     )
-    .end()
 )
 
-run_graph(
+qm.run_graph(
     pipeline,
     user_input="The history of artificial intelligence",
-
 )
 
 

--- a/examples/run_interactive.py
+++ b/examples/run_interactive.py
@@ -18,19 +18,23 @@ from __future__ import annotations
 
 import argparse
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 
 def main():
     parser = argparse.ArgumentParser(description="Interactive Quartermaster agent")
-    parser.add_argument("--model", default="claude-haiku-4-5-20251001", help="Model to use")
-    parser.add_argument("--provider", default="anthropic", help="Provider (anthropic, openai, groq, xai, ollama)")
+    parser.add_argument(
+        "--model", default="claude-haiku-4-5-20251001", help="Model to use"
+    )
+    parser.add_argument(
+        "--provider",
+        default="anthropic",
+        help="Provider (anthropic, openai, groq, xai, ollama)",
+    )
     args = parser.parse_args()
 
     agent = (
-        Graph("Interactive Assistant")
-        .start()
+        qm.Graph("Interactive Assistant")
         .user("You")
         .instruction(
             "Respond",
@@ -41,7 +45,6 @@ def main():
                 "Respond in the same language the user writes in."
             ),
         )
-        .end()
     )
 
     print(f"Interactive Assistant ({args.model} via {args.provider})")
@@ -49,7 +52,7 @@ def main():
 
     while True:
         try:
-            result = run_graph(agent)
+            result = qm.run_graph(agent)
             if result is None:
                 break
         except (KeyboardInterrupt, EOFError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.2.0"
+version = "0.2.1"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.1.6"
+version = "0.2.0"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/quartermaster-code-runner/pyproject.toml
+++ b/quartermaster-code-runner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-code-runner"
-version = "0.2.0"
+version = "0.2.1"
 description = "Secure sandboxed code execution service supporting Python, Node.js, Go, Rust, Deno, and Bun via Docker containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-code-runner/pyproject.toml
+++ b/quartermaster-code-runner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-code-runner"
-version = "0.1.6"
+version = "0.2.0"
 description = "Secure sandboxed code execution service supporting Python, Node.js, Go, Rust, Deno, and Bun via Docker containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/quartermaster-engine/pyproject.toml
+++ b/quartermaster-engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-engine"
-version = "0.1.6"
+version = "0.2.0"
 description = "Execution engine for AI agent graphs — traversal, branching, merging, memory, message passing, and error handling"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,13 +25,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "quartermaster-graph>=0.1.6",
-    "quartermaster-providers>=0.1.6",
+    "quartermaster-graph>=0.2.0",
+    "quartermaster-providers>=0.2.0",
     # ``quartermaster-nodes`` ships ``safe_eval`` (a simpleeval sandbox)
     # which the example runner uses for ``Var``/``If``/``Switch`` node
     # expression evaluation.  Pre-0.1.2 this was an implicit workspace
     # dep — it would ImportError when installed standalone.
-    "quartermaster-nodes>=0.1.6",
+    "quartermaster-nodes>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/quartermaster-engine/pyproject.toml
+++ b/quartermaster-engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-engine"
-version = "0.2.0"
+version = "0.2.1"
 description = "Execution engine for AI agent graphs — traversal, branching, merging, memory, message passing, and error handling"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,13 +25,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "quartermaster-graph>=0.2.0",
-    "quartermaster-providers>=0.2.0",
+    "quartermaster-graph>=0.2.1",
+    "quartermaster-providers>=0.2.1",
     # ``quartermaster-nodes`` ships ``safe_eval`` (a simpleeval sandbox)
     # which the example runner uses for ``Var``/``If``/``Switch`` node
     # expression evaluation.  Pre-0.1.2 this was an implicit workspace
     # dep — it would ImportError when installed standalone.
-    "quartermaster-nodes>=0.2.0",
+    "quartermaster-nodes>=0.2.1",
 ]
 
 [project.optional-dependencies]

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -412,6 +412,28 @@ def _tool_definitions(tool_registry: Any) -> list[dict[str, Any]] | None:
     return None
 
 
+#: Provider-specific tool-namespace prefixes that should be stripped before
+#: looking the tool up in the registry.  Gemma-family models go through
+#: Ollama's OpenAI-compat proxy and emit ``default_api:list_orders``; the
+#: OpenAI native wire format uses ``functions:list_orders``; the MCP bridge
+#: emits ``mcp:foo``.  All three resolve to the same registered tool name.
+_TOOL_NAME_PREFIXES: tuple[str, ...] = (
+    "default_api:",
+    "default_api.",
+    "functions:",
+    "functions.",
+    "mcp:",
+)
+
+
+def _normalise_tool_name(tool_name: str) -> str:
+    """Strip provider-specific namespace prefixes from a tool call's name."""
+    for prefix in _TOOL_NAME_PREFIXES:
+        if tool_name.startswith(prefix):
+            return tool_name[len(prefix) :]
+    return tool_name
+
+
 def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> str:
     """Run one tool from the registry and serialise its result for the LLM.
 
@@ -423,26 +445,31 @@ def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> 
     """
     if tool_registry is None:
         return f"[ERROR: no tool registry available to execute '{tool_name}']"
+    # Strip ``default_api:`` / ``functions:`` / ``mcp:`` prefixes that
+    # different providers attach to the function name.  Without this the
+    # registry lookup would miss a tool that's registered under the bare
+    # name — a recurring integrator complaint before v0.2.0.
+    normalised = _normalise_tool_name(tool_name)
     try:
-        tool = tool_registry.get(tool_name)
+        tool = tool_registry.get(normalised)
     except Exception as exc:
-        logger.warning("Tool lookup failed for %r: %s", tool_name, exc)
-        return f"[ERROR: tool '{tool_name}' not found]"
+        logger.warning("Tool lookup failed for %r: %s", normalised, exc)
+        return f"[ERROR: tool '{normalised}' not found]"
     safe_run = getattr(tool, "safe_run", None) or getattr(tool, "run", None)
     if safe_run is None:
-        return f"[ERROR: tool '{tool_name}' has no run() method]"
+        return f"[ERROR: tool '{normalised}' has no run() method]"
     try:
         result = safe_run(**parameters)
     except Exception as exc:
-        logger.warning("Tool %r raised during execution: %s", tool_name, exc)
-        return f"[ERROR: tool '{tool_name}' execution failed]"
+        logger.warning("Tool %r raised during execution: %s", normalised, exc)
+        return f"[ERROR: tool '{normalised}' execution failed]"
     # ToolResult duck-typing: prefer .data, fall back to str().
     if hasattr(result, "success") and not result.success:
         # Tool itself returned a structured failure — these errors come from
         # the tool's own validation/business logic and are safe to surface,
         # but log them too for ops visibility.
         err = getattr(result, "error", "tool failed")
-        logger.info("Tool %r returned error result: %s", tool_name, err)
+        logger.info("Tool %r returned error result: %s", normalised, err)
         return f"[ERROR: {err}]"
     if hasattr(result, "data"):
         return str(result.data)

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -60,7 +60,14 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class FlowResult:
-    """The final result of a flow execution."""
+    """The final result of a flow execution.
+
+    The UUID-keyed ``node_results`` is the authoritative per-node record
+    and is mostly useful for debugging tooling (visualisers, trace
+    dumps).  The name-keyed ``captures`` dict (v0.2.0+) is what
+    application code should reach for — populated from the
+    ``capture_as="..."`` kwarg users pass on node builder methods.
+    """
 
     flow_id: UUID
     success: bool
@@ -68,7 +75,34 @@ class FlowResult:
     output_data: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
     node_results: dict[UUID, NodeResult] = field(default_factory=dict)
+    #: Name → NodeResult mapping for nodes that set ``capture_as="..."``.
+    #: Lets callers write ``result.captures["research"].output_text`` instead
+    #: of fishing through ``node_results`` with UUID keys and node-type
+    #: pattern matching.
+    captures: dict[str, NodeResult] = field(default_factory=dict)
     duration_seconds: float = 0.0
+
+    def __getitem__(self, name: str) -> NodeResult:
+        """Syntactic sugar: ``result["research"]`` → the captured node result.
+
+        Raises ``KeyError`` with a helpful message listing available
+        capture names when *name* is unknown.  The SDK's ``Result`` type
+        uses the same message format (see ``quartermaster_sdk._result.
+        format_missing_capture_error``) so switching between the two is
+        seamless.
+        """
+        try:
+            return self.captures[name]
+        except KeyError:
+            raise KeyError(_format_missing_capture(name, self.captures)) from None
+
+
+def _format_missing_capture(name: str, captures: dict[str, NodeResult]) -> str:
+    """Shared format for "no capture named X" errors — matches the SDK's
+    ``format_missing_capture_error``.  Kept as a module-private helper here
+    so the engine doesn't depend on the SDK package."""
+    available = ", ".join(sorted(captures)) or "(no captures registered)"
+    return f"No capture named {name!r}. Available captures: {available}"
 
 
 class FlowRunner:
@@ -551,6 +585,7 @@ class FlowRunner:
         """Collect the final result after all nodes have completed."""
         executions = self.store.get_all_node_executions(flow_id)
         node_results: dict[UUID, NodeResult] = {}
+        captures: dict[str, NodeResult] = {}
         final_output = ""
         all_success = True
         errors: list[str] = []
@@ -564,12 +599,21 @@ class FlowRunner:
                     errors.append(execution.error)
 
             if execution.result:
-                node_results[nid] = NodeResult(
+                nr = NodeResult(
                     success=execution.status == NodeStatus.FINISHED,
                     data=execution.output_data,
                     output_text=execution.result,
                     error=execution.error,
                 )
+                node_results[nid] = nr
+                # Populate name-keyed captures if the builder set
+                # ``capture_as="..."`` on this node.  We look up via the
+                # shared constant from ``quartermaster_graph`` so rename
+                # drift is caught at import time.
+                if node is not None:
+                    capture_name = node.metadata.get("capture_as")
+                    if isinstance(capture_name, str) and capture_name:
+                        captures[capture_name] = nr
 
             # The final output comes from End nodes
             if node and node.type == NodeType.END and execution.result:
@@ -589,6 +633,7 @@ class FlowRunner:
             success=all_success,
             final_output=final_output,
             node_results=node_results,
+            captures=captures,
             error="; ".join(errors) if errors else None,
         )
 

--- a/quartermaster-graph/pyproject.toml
+++ b/quartermaster-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-graph"
-version = "0.2.0"
+version = "0.2.1"
 description = "Framework-agnostic agent graph schema for AI agent workflows as directed acyclic graphs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-graph/pyproject.toml
+++ b/quartermaster-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-graph"
-version = "0.1.6"
+version = "0.2.0"
 description = "Framework-agnostic agent graph schema for AI agent workflows as directed acyclic graphs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Enums

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 __all__ = [
     # Enums

--- a/quartermaster-graph/src/quartermaster_graph/builder.py
+++ b/quartermaster-graph/src/quartermaster_graph/builder.py
@@ -27,8 +27,16 @@ _FLOW_CONFIG_KEYS = {
     "error_handling",
 }
 
-# Metadata-level config keys (stored in node.metadata, not as node attributes)
-_META_CONFIG_KEYS = {"show_output"}
+# Metadata-level config keys (stored in node.metadata, not as node attributes).
+# ``capture_as`` (v0.2.0) lets callers name a node's output so
+# ``Result.captures["name"]`` can retrieve it post-run without fishing through
+# UUID-keyed ``node_results``.
+_META_CONFIG_KEYS = {"show_output", "capture_as"}
+
+# Node-metadata key under which ``capture_as`` is stored.  Kept as a named
+# constant so the engine side can import it rather than hard-coding the
+# string (see ``quartermaster_engine.runner.flow_runner``).
+CAPTURE_AS_METADATA_KEY = "capture_as"
 
 # Combined set for extraction from kwargs
 _ALL_CONFIG_KEYS = _FLOW_CONFIG_KEYS | _META_CONFIG_KEYS
@@ -41,7 +49,9 @@ def _apply_flow_config(node: GraphNode, kwargs: dict[str, Any]) -> None:
             setattr(node, key, kwargs.pop(key))
     for key in _META_CONFIG_KEYS:
         if key in kwargs:
-            node.metadata[key] = kwargs.pop(key)
+            value = kwargs.pop(key)
+            if value is not None:
+                node.metadata[key] = value
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -1062,7 +1072,18 @@ class GraphBuilder:
         )
     """
 
-    def __init__(self, name: str, description: str = "") -> None:
+    def __init__(self, name: str, description: str = "", *, auto_start: bool = True) -> None:
+        """Build a new graph.
+
+        Args:
+            name: Human-readable graph name.
+            description: Optional description stored on the spec.
+            auto_start: When ``True`` (the default, v0.2.0+) a ``Start``
+                node is added automatically so chains can open with
+                ``Graph("x").user()...`` instead of ``.start().user()...``.
+                Set to ``False`` only if you want to construct the start
+                yourself (rare — legacy compatibility path).
+        """
         self._name = name
         self._description = description
         self._nodes: list[GraphNode] = []
@@ -1075,6 +1096,24 @@ class GraphBuilder:
         self._position_x = 0
         self._position_y = 0
         self._allowed_agents: list[str] = []
+        if auto_start:
+            self._create_start_node()
+
+    def _create_start_node(self) -> None:
+        """Append the graph's ``Start`` node and mark it as the entry point.
+
+        Internal helper used by ``__init__`` (via ``auto_start=True``) and
+        by the now-idempotent :meth:`start` method so explicit callers
+        don't accidentally create two Start nodes.
+        """
+        node = GraphNode(
+            type=NodeType.START,
+            name="Start",
+            thought_type=ThoughtType.SKIP,
+            message_type=MessageType.VARIABLE,
+        )
+        self._start_node_id = node.id
+        self._add_node(node)
 
     # ------------------------------------------------------------------
     # Agent control
@@ -1199,15 +1238,20 @@ class GraphBuilder:
     # ------------------------------------------------------------------
 
     def start(self) -> GraphBuilder:
-        """Add a Start node."""
-        node = GraphNode(
-            type=NodeType.START,
-            name="Start",
-            thought_type=ThoughtType.SKIP,
-            message_type=MessageType.VARIABLE,
-        )
-        self._start_node_id = node.id
-        return self._add_node(node)
+        """Add a Start node (idempotent since v0.2.0).
+
+        ``Graph(name)`` auto-creates the Start node, so chained calls to
+        ``.start()`` are no-ops — the method is kept only for readability
+        of legacy snippets.  Explicitly creating a second Start via
+        ``auto_start=False`` + a manual ``.start()`` call is still
+        supported.
+        """
+        if self._start_node_id is not None:
+            # Auto-start already happened (or the caller previously
+            # called .start()) — don't create a duplicate.
+            return self
+        self._create_start_node()
+        return self
 
     def end(self) -> GraphBuilder:
         """Add an End node.

--- a/quartermaster-graph/src/quartermaster_graph/validation.py
+++ b/quartermaster-graph/src/quartermaster_graph/validation.py
@@ -57,15 +57,12 @@ def validate_graph(version: GraphSpec) -> list[ValidationError]:  # type: ignore
                 )
             )
 
-    # --- End node ---
-    end_nodes = [n for n in version.nodes if n.type == NodeType.END]
-    if len(end_nodes) == 0:
-        errors.append(
-            ValidationError(
-                code="no_end",
-                message="Graph must have at least one End node",
-            )
-        )
+    # --- End node (optional since v0.2.0) ---
+    # Pre-0.2.0 a graph without an explicit End node was rejected here.
+    # The runner has always been fine with "no End" — it falls back to the
+    # last finished node's output in ``FlowResult``.  Making ``.end()``
+    # optional means single-node flows (``Graph("x").instruction(...).build()``)
+    # don't need a trailing ``.end()`` boilerplate line.
 
     # --- Start node ID valid ---
     if version.start_node_id not in node_map:
@@ -214,5 +211,44 @@ def validate_graph(version: GraphSpec) -> list[ValidationError]:  # type: ignore
                         node_id=node.id,
                     )
                 )
+
+    # --- capture_as collisions with reserved node metadata keys ---
+    # v0.2.0 lets callers name a node's output via ``capture_as="x"``.
+    # A YAML-loaded graph could set ``capture_as: llm_model`` — that's
+    # not a correctness bug (captures are a separate namespace from
+    # node metadata), but the resulting ``result.captures["llm_model"]``
+    # is confusing to debug because it shadows a well-known concept.
+    # Warn so the operator sees it in logs.
+    _reserved_capture_names = frozenset(
+        {
+            "llm_model",
+            "llm_provider",
+            "llm_temperature",
+            "llm_system_instruction",
+            "llm_max_output_tokens",
+            "llm_max_input_tokens",
+            "llm_stream",
+            "llm_vision",
+            "llm_thinking_level",
+            "show_output",
+            "capture_as",
+        }
+    )
+    for node in version.nodes:
+        capture_name = node.metadata.get("capture_as")
+        if isinstance(capture_name, str) and capture_name in _reserved_capture_names:
+            errors.append(
+                ValidationError(
+                    code="capture_as_shadows_reserved_key",
+                    message=(
+                        f"Node '{node.name}' has capture_as={capture_name!r} which "
+                        f"collides with a reserved node-metadata key. Captures "
+                        f"live in a separate namespace so this still works, but "
+                        f"rename to something unambiguous for readability."
+                    ),
+                    node_id=node.id,
+                    severity="warning",
+                )
+            )
 
     return errors

--- a/quartermaster-graph/tests/test_builder.py
+++ b/quartermaster-graph/tests/test_builder.py
@@ -28,18 +28,29 @@ class TestBasicBuilder:
         assert len(version.nodes) == 5
         assert len(version.edges) == 4
 
-    def test_no_start_raises(self):
-        with pytest.raises(ValueError, match="start node"):
-            GraphBuilder("Test").instruction("X").end().build()
+    def test_auto_start_creates_start_node(self):
+        """v0.2.0+ — ``Graph(name)`` auto-creates a Start node."""
+        version = GraphBuilder("Test").instruction("X").end().build()
+        starts = [n for n in version.nodes if n.type.value.startswith("Start")]
+        assert len(starts) == 1, "exactly one Start node should exist"
 
-    def test_validation_on_build(self):
-        # No end node should produce validation warnings/errors (but build still returns)
-        version = GraphBuilder("Test").start().instruction("X").build()
+    def test_auto_start_opt_out(self):
+        """``auto_start=False`` reverts to manual .start() call (legacy path)."""
+        with pytest.raises(ValueError, match="start node"):
+            # No auto-start AND no manual .start() → no start node → .build() rejects.
+            GraphBuilder("Test", auto_start=False).instruction("X").end().build()
+
+    def test_no_end_is_now_allowed(self):
+        """v0.2.0+ — graphs without an explicit End node are valid."""
+        version = GraphBuilder("Test").instruction("X").build()
         from quartermaster_graph.validation import validate_graph
 
         errors = validate_graph(version)
         real_errors = [e for e in errors if e.severity == "error"]
-        assert len(real_errors) > 0
+        assert real_errors == [], (
+            "No-End-node is intentional post-v0.2.0; runner falls back to the "
+            f"last finished node's output.  Got errors: {real_errors}"
+        )
 
     def test_skip_validation(self):
         version = GraphBuilder("Test").start().instruction("X").build(validate=False)

--- a/quartermaster-graph/tests/test_builder_advanced.py
+++ b/quartermaster-graph/tests/test_builder_advanced.py
@@ -504,7 +504,10 @@ class TestGraphWithoutBuild:
         assert start.type == NodeType.START
 
     def test_start_node_id_raises_without_start(self):
-        graph = GraphBuilder("Empty")
+        # v0.2.0+: the Graph constructor auto-creates a Start node by
+        # default.  To hit the "no start node" path we have to opt out
+        # with ``auto_start=False``.
+        graph = GraphBuilder("Empty", auto_start=False)
         with pytest.raises(ValueError, match="No start node"):
             _ = graph.start_node_id
 

--- a/quartermaster-graph/tests/test_validation.py
+++ b/quartermaster-graph/tests/test_validation.py
@@ -86,7 +86,16 @@ class TestStartNodeValidation:
 
 
 class TestEndNodeValidation:
-    def test_no_end_node(self, agent):
+    def test_no_end_node_is_now_allowed(self, agent):
+        """v0.2.0+ — graphs without an explicit End node validate clean.
+
+        Pre-0.2.0 the validator emitted a ``no_end`` error.  That check
+        was removed because the runner has always been fine with no End
+        (it falls back to the last finished node's output in
+        ``FlowResult``).  Single-node flows like
+        ``Graph("x").instruction("y").build()`` no longer need the
+        trailing ``.end()`` boilerplate.
+        """
         start = GraphNode(type=NodeType.START, name="Start")
         inst = GraphNode(type=NodeType.INSTRUCTION, name="Inst")
         edge = GraphEdge(source_id=start.id, target_id=inst.id)
@@ -98,7 +107,7 @@ class TestEndNodeValidation:
         )
         errors = validate_graph(version)
         codes = [e.code for e in errors]
-        assert "no_end" in codes
+        assert "no_end" not in codes
 
 
 class TestEdgeValidation:

--- a/quartermaster-graph/tests/test_validation_integration.py
+++ b/quartermaster-graph/tests/test_validation_integration.py
@@ -24,11 +24,17 @@ def agent() -> Agent:
 
 
 class TestMissingStartNode:
-    """Validation must reject graphs without a Start node."""
+    """Validation must reject graphs without a Start node.
+
+    Post-v0.2.0 this is only reachable when the caller opts out of the
+    auto-start convenience via ``auto_start=False`` and then forgets to
+    call ``.start()`` themselves — still a valid error path, just a
+    harder one to hit by accident.
+    """
 
     def test_builder_requires_start(self) -> None:
-        """GraphBuilder.build() raises if .start() was never called."""
-        builder = GraphBuilder("No Start")
+        """GraphBuilder(auto_start=False).build() raises if .start() was never called."""
+        builder = GraphBuilder("No Start", auto_start=False)
         builder._nodes.append(GraphNode(type=NodeType.END, name="End"))
         with pytest.raises(ValueError, match="start node"):
             builder.build()
@@ -80,10 +86,12 @@ class TestMissingStartNode:
 
 
 class TestMissingEndNode:
-    """Validation must reject graphs without an End node."""
+    """Graphs without an End node are allowed since v0.2.0."""
 
-    def test_no_end_node(self, agent: Agent) -> None:
-        """Graph with Start and Instruction but no End produces no_end error."""
+    def test_no_end_node_validates_clean(self, agent: Agent) -> None:
+        """Pre-0.2.0 the validator emitted ``no_end``.  Now it's legal —
+        the runner falls back to the last finished node's output so
+        single-node flows don't need trailing ``.end()`` boilerplate."""
         start = GraphNode(type=NodeType.START, name="Start")
         inst = GraphNode(type=NodeType.INSTRUCTION, name="Process")
         edge = GraphEdge(source_id=start.id, target_id=inst.id)
@@ -95,7 +103,7 @@ class TestMissingEndNode:
         )
         errors = validate_graph(version)
         codes = {e.code for e in errors if e.severity == "error"}
-        assert "no_end" in codes
+        assert "no_end" not in codes
 
 
 class TestOrphanNodes:
@@ -327,7 +335,12 @@ class TestMultipleValidationErrors:
     """Validation returns all errors at once, not just the first."""
 
     def test_multiple_errors_reported(self, agent: Agent) -> None:
-        """A graph with multiple issues reports all of them."""
+        """A graph with multiple issues reports all of them.
+
+        Note: ``no_end`` was removed from the validator in v0.2.0 (End
+        nodes are optional now), so only ``no_start`` and
+        ``invalid_edge_target`` survive in this fixture.
+        """
         # No start node, no end node, invalid edge
         inst = GraphNode(type=NodeType.INSTRUCTION, name="Lonely")
         bad_edge = GraphEdge(source_id=inst.id, target_id=uuid4())
@@ -340,7 +353,6 @@ class TestMultipleValidationErrors:
         errors = validate_graph(version)
         codes = {e.code for e in errors}
         assert "no_start" in codes
-        assert "no_end" in codes
         assert "invalid_edge_target" in codes
 
 
@@ -348,12 +360,12 @@ class TestBuilderValidation:
     """The builder's validate=True flag rejects invalid graphs."""
 
     def test_builder_rejects_invalid_graph(self) -> None:
-        """Builder returns version but validation finds errors (no end node)."""
-        builder = GraphBuilder("Invalid")
-        builder.start()
+        """Builder still surfaces genuinely invalid graphs (dangling edge target)."""
+        builder = GraphBuilder("Invalid")  # auto-start creates a Start node
         builder.instruction("Process")
-        # No .end() call -- build still returns but validation finds errors
-        version = builder.build(validate=True)
+        # Dangling edge to a uuid that doesn't resolve — still an error.
+        builder._edges.append(GraphEdge(source_id=uuid4(), target_id=uuid4()))
+        version = builder.build(validate=False)  # bypass builder-side raise
         errors = validate_graph(version)
         real_errors = [e for e in errors if e.severity == "error"]
         assert len(real_errors) > 0

--- a/quartermaster-mcp-client/pyproject.toml
+++ b/quartermaster-mcp-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-mcp-client"
-version = "0.1.6"
+version = "0.2.0"
 description = "Lightweight MCP (Model Context Protocol) client with async/sync support, SSE and Streamable HTTP transports"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-mcp-client/pyproject.toml
+++ b/quartermaster-mcp-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-mcp-client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Lightweight MCP (Model Context Protocol) client with async/sync support, SSE and Streamable HTTP transports"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/quartermaster-nodes/pyproject.toml
+++ b/quartermaster-nodes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-nodes"
-version = "0.1.6"
+version = "0.2.0"
 description = "Library of composable node types for building AI agent graphs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1",
-    "quartermaster-graph>=0.1.6",
-    "quartermaster-providers>=0.1.6",
+    "quartermaster-graph>=0.2.0",
+    "quartermaster-providers>=0.2.0",
     "simpleeval>=1.0.5",
 ]
 

--- a/quartermaster-nodes/pyproject.toml
+++ b/quartermaster-nodes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-nodes"
-version = "0.2.0"
+version = "0.2.1"
 description = "Library of composable node types for building AI agent graphs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1",
-    "quartermaster-graph>=0.2.0",
-    "quartermaster-providers>=0.2.0",
+    "quartermaster-graph>=0.2.1",
+    "quartermaster-providers>=0.2.1",
     "simpleeval>=1.0.5",
 ]
 

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 __all__ = [
     # Enums

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Enums

--- a/quartermaster-providers/pyproject.toml
+++ b/quartermaster-providers/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-providers"
-version = "0.2.0"
+version = "0.2.1"
 description = "Unified multi-LLM provider abstraction supporting OpenAI, Anthropic, Google, Groq, xAI and more"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/quartermaster-providers/pyproject.toml
+++ b/quartermaster-providers/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-providers"
-version = "0.1.6"
+version = "0.2.0"
 description = "Unified multi-LLM provider abstraction supporting OpenAI, Anthropic, Google, Groq, xAI and more"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -48,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 __author__ = "MindMade"
 
 __all__ = [

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -48,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "MindMade"
 
 __all__ = [

--- a/quartermaster-sdk/README.md
+++ b/quartermaster-sdk/README.md
@@ -24,32 +24,67 @@ ollama pull gemma4:26b      # or any model you've pulled
 ```
 
 ```python
-from quartermaster_sdk import Graph, FlowRunner, register_local
+import quartermaster_sdk as qm
 
-provider_registry = register_local(
-    "ollama",
+qm.configure(
+    provider="ollama",
     base_url="http://localhost:11434",   # or set $OLLAMA_HOST
     default_model="gemma4:26b",
 )
 
-graph = Graph("chat").start().user().agent().end().build()
-runner = FlowRunner(graph=graph, provider_registry=provider_registry)
-result = runner.run("Pozdravljen, koliko je ura?")
-print(result.final_output)
+# Graph() auto-creates Start; .end() / .build() are both optional when running via qm.run().
+result = qm.run(qm.Graph("chat").user().agent(), "Pozdravljen, koliko je ura?")
+print(result.text)
+```
+
+## Single-shot helpers (no graph visible)
+
+```python
+# prompt → str
+reply = qm.instruction(system="Respond in Slovenian.", user="Pozdravljen!")
+
+# prompt → Pydantic model (typed JSON extraction)
+from pydantic import BaseModel
+
+class Classification(BaseModel):
+    category: str
+    priority: str
+
+data = qm.instruction_form(Classification, system="Classify.", user=email_body)
+```
+
+## Reading specific node outputs with `capture_as=`
+
+```python
+graph = (
+    qm.Graph("enrich")
+    .agent("Research", tools=[...], capture_as="notes")
+    .instruction_form(CustomerData, system="Extract.", capture_as="data")
+)
+result = qm.run(graph, "VT-Treyd Slovenija")
+result["notes"].output_text    # agent's free-text research
+result["data"].output_text     # extracted JSON
+```
+
+## Streaming
+
+```python
+for chunk in qm.run.stream(qm.Graph("chat").user().agent(), "Tell me a story"):
+    if chunk.type == "token":
+        print(chunk.content, end="", flush=True)
+    elif chunk.type == "done":
+        final = chunk.result    # qm.Result
 ```
 
 ## Quick Start (cloud provider)
 
 ```python
-from quartermaster_sdk import Graph
-
 agent = (
-    Graph("My Agent")
-    .start()
+    qm.Graph("My Agent")
     .user("What can I help you with?")
     .instruction("Respond", model="gpt-4o", system_instruction="You are a helpful assistant.")
-    .end()
 )
+result = qm.run(agent, "How does photosynthesis work?")
 ```
 
 ## Sync chat shim (no graph needed)

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-sdk"
-version = "0.1.6"
+version = "0.2.0"
 description = "Quartermaster — modular AI agent orchestration framework. Install this to get all packages."
 readme = "README.md"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "quartermaster-graph>=0.1.6",
-    "quartermaster-providers>=0.1.6",
-    "quartermaster-tools>=0.1.6",
-    "quartermaster-nodes>=0.1.6",
-    "quartermaster-engine>=0.1.6",
+    "quartermaster-graph>=0.2.0",
+    "quartermaster-providers>=0.2.0",
+    "quartermaster-tools>=0.2.0",
+    "quartermaster-nodes>=0.2.0",
+    "quartermaster-engine>=0.2.0",
 ]
 
 [project.optional-dependencies]
@@ -54,8 +54,8 @@ observability = ["quartermaster-tools[observability]"]
 tools-all = ["quartermaster-tools[all]"]
 
 # Standalone packages (not included by default)
-mcp = ["quartermaster-mcp-client>=0.1.6"]
-code-runner = ["quartermaster-code-runner>=0.1.6"]
+mcp = ["quartermaster-mcp-client>=0.2.0"]
+code-runner = ["quartermaster-code-runner>=0.2.0"]
 
 # Everything
 all = [

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Quartermaster — modular AI agent orchestration framework. Install this to get all packages."
 readme = "README.md"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "quartermaster-graph>=0.2.0",
-    "quartermaster-providers>=0.2.0",
-    "quartermaster-tools>=0.2.0",
-    "quartermaster-nodes>=0.2.0",
-    "quartermaster-engine>=0.2.0",
+    "quartermaster-graph>=0.2.1",
+    "quartermaster-providers>=0.2.1",
+    "quartermaster-tools>=0.2.1",
+    "quartermaster-nodes>=0.2.1",
+    "quartermaster-engine>=0.2.1",
 ]
 
 [project.optional-dependencies]
@@ -54,8 +54,8 @@ observability = ["quartermaster-tools[observability]"]
 tools-all = ["quartermaster-tools[all]"]
 
 # Standalone packages (not included by default)
-mcp = ["quartermaster-mcp-client>=0.2.0"]
-code-runner = ["quartermaster-code-runner>=0.2.0"]
+mcp = ["quartermaster-mcp-client>=0.2.1"]
+code-runner = ["quartermaster-code-runner>=0.2.1"]
 
 # Everything
 all = [

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -18,7 +18,7 @@ Optional extras:
 - pip install quartermaster-sdk[all]           — Everything
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # ── v0.2.0 primary API ────────────────────────────────────────────────
 #

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -18,7 +18,7 @@ Optional extras:
 - pip install quartermaster-sdk[all]           — Everything
 """
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 # Re-export the most common entry points for convenience.  Pre-0.1.4 the SDK
 # re-exported only the graph-builder surface, forcing downstream callers to

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -20,12 +20,20 @@ Optional extras:
 
 __version__ = "0.2.0"
 
-# Re-export the most common entry points for convenience.  Pre-0.1.4 the SDK
-# re-exported only the graph-builder surface, forcing downstream callers to
-# `from quartermaster_engine import FlowRunner` and `from quartermaster_providers
-# import register_local` separately even though the SDK is the recommended
-# install.  These re-exports cover the v0.1.4 release-notes snippet so a single
-# `from quartermaster_sdk import …` line is enough to wire up the simplest graph.
+# ── v0.2.0 primary API ────────────────────────────────────────────────
+#
+# The recommended path is a four-import line for 90% of callsites:
+#
+#     from quartermaster_sdk import Graph, run, configure, instruction
+#
+# * ``Graph("x").user().agent().build()`` — auto-Start, optional End
+# * ``run(graph, user_input)`` / ``run.stream(...)`` — no ``FlowRunner``
+# * ``configure(provider="ollama", default_model=...)`` — boot once
+# * ``instruction(system=..., user=...)`` — single-shot prompt → text
+# * ``instruction_form(schema, system=..., user=...)`` — prompt → typed JSON
+#
+# Legacy v0.1.x exports (``FlowRunner``, ``build_default_registry``, …)
+# remain available for integrators who need the low-level surface.
 from quartermaster_engine import (  # noqa: F401
     AgentExecutor,
     FlowResult,
@@ -52,17 +60,54 @@ from quartermaster_providers import (  # noqa: F401
     register_local,
 )
 
+from ._chunks import (  # noqa: F401
+    AwaitInputChunk,
+    Chunk,
+    DoneChunk,
+    ErrorChunk,
+    NodeFinishChunk,
+    NodeStartChunk,
+    TokenChunk,
+    ToolCallChunk,
+    ToolResultChunk,
+)
+from ._config import (  # noqa: F401
+    configure,
+    get_default_model,
+    get_default_registry,
+    reset_config,
+)
+from ._helpers import instruction, instruction_form  # noqa: F401
+from ._result import Result  # noqa: F401
+from ._runner import run  # noqa: F401
+
 
 __all__ = [
     # Version
     "__version__",
+    # ── v0.2.0 primary surface ──
+    "configure",
+    "run",
+    "instruction",
+    "instruction_form",
+    "Result",
+    # Typed streaming chunks
+    "Chunk",
+    "TokenChunk",
+    "NodeStartChunk",
+    "NodeFinishChunk",
+    "ToolCallChunk",
+    "ToolResultChunk",
+    "AwaitInputChunk",
+    "DoneChunk",
+    "ErrorChunk",
     # Graph builder + spec
     "Graph",
     "GraphBuilder",
     "GraphSpec",
     "AgentGraph",  # deprecated
     "NodeType",
-    # Engine — runner + node-registry surface
+    # Engine — runner + node-registry surface (low-level)
     "FlowRunner",
     "FlowResult",
     "NodeRegistry",
@@ -78,4 +123,7 @@ __all__ = [
     "ChatResult",
     "ProviderRegistry",
     "register_local",
+    "get_default_registry",
+    "get_default_model",
+    "reset_config",
 ]

--- a/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
@@ -1,0 +1,137 @@
+"""Typed stream-chunk classes for :func:`quartermaster_sdk.run.stream`.
+
+v0.2.0 wraps :class:`quartermaster_engine.FlowEvent` into a small typed
+discriminated union so callers can pattern-match on ``chunk.type`` without
+needing to know about the underlying engine event hierarchy.  The mapping:
+
+``FlowEvent``                           → ``Chunk``
+``TokenGenerated``                      → :class:`TokenChunk`
+``NodeStarted``                         → :class:`NodeStartChunk`
+``NodeFinished``                        → :class:`NodeFinishChunk`
+``FlowFinished``                        → :class:`DoneChunk`
+``FlowError``                           → :class:`ErrorChunk`
+``UserInputRequired``                   → :class:`AwaitInputChunk`
+tool-call inside an ``AgentExecutor``   → :class:`ToolCallChunk` + :class:`ToolResultChunk`
+                                          (future; currently surface via
+                                          ``NodeFinishChunk.node_name``.)
+
+The classes are intentionally flat dataclasses — callers can compare
+``chunk.type`` against literal strings (``"token"``, ``"done"``, etc.) or do
+``isinstance(chunk, TokenChunk)``; both styles work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, Union
+
+if TYPE_CHECKING:
+    from ._result import Result
+
+
+@dataclass
+class TokenChunk:
+    """Streaming text token from an LLM node."""
+
+    content: str
+    node_name: str | None = None
+    type: Literal["token"] = "token"
+
+
+@dataclass
+class NodeStartChunk:
+    """A node has begun executing."""
+
+    node_name: str
+    node_type: str
+    type: Literal["node_start"] = "node_start"
+
+
+@dataclass
+class NodeFinishChunk:
+    """A node has finished executing.
+
+    ``output`` is the string output of the node (may be empty).  For
+    LLM nodes this is the full assembled text; for tool or decision
+    nodes it's whatever the executor wrote to ``NodeResult.output_text``.
+    """
+
+    node_name: str
+    output: str = ""
+    type: Literal["node_finish"] = "node_finish"
+
+
+@dataclass
+class ToolCallChunk:
+    """The agent executor requested a tool call."""
+
+    tool: str
+    args: dict[str, Any] = field(default_factory=dict)
+    type: Literal["tool_call"] = "tool_call"
+
+
+@dataclass
+class ToolResultChunk:
+    """A tool call completed with a result (or an error payload)."""
+
+    tool: str
+    result: Any = None
+    error: str | None = None
+    type: Literal["tool_result"] = "tool_result"
+
+
+@dataclass
+class AwaitInputChunk:
+    """A ``User`` node is waiting for a ``runner.resume`` call."""
+
+    prompt: str
+    options: list[str] = field(default_factory=list)
+    type: Literal["await_input"] = "await_input"
+
+
+@dataclass
+class DoneChunk:
+    """The flow finished — carries the final :class:`Result`."""
+
+    result: Result
+    type: Literal["done"] = "done"
+
+
+@dataclass
+class ErrorChunk:
+    """The flow failed with an unrecoverable error."""
+
+    error: str
+    node_name: str | None = None
+    type: Literal["error"] = "error"
+
+
+Chunk = Union[
+    TokenChunk,
+    NodeStartChunk,
+    NodeFinishChunk,
+    ToolCallChunk,
+    ToolResultChunk,
+    AwaitInputChunk,
+    DoneChunk,
+    ErrorChunk,
+]
+"""Discriminated union of every chunk a stream can yield.
+
+Callers usually pattern-match on ``chunk.type`` — the literal strings are
+``"token"``, ``"node_start"``, ``"node_finish"``, ``"tool_call"``,
+``"tool_result"``, ``"await_input"``, ``"done"``, ``"error"``.
+"""
+
+
+__all__ = [
+    "Chunk",
+    "TokenChunk",
+    "NodeStartChunk",
+    "NodeFinishChunk",
+    "ToolCallChunk",
+    "ToolResultChunk",
+    "AwaitInputChunk",
+    "DoneChunk",
+    "ErrorChunk",
+]

--- a/quartermaster-sdk/src/quartermaster_sdk/_config.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_config.py
@@ -1,0 +1,158 @@
+"""Module-level configuration for the v0.2.0 ergonomic API.
+
+Callers set up their provider once at app boot:
+
+    import quartermaster_sdk as qm
+    qm.configure(
+        provider="ollama",
+        base_url="http://localhost:11434",    # or $OLLAMA_HOST
+        default_model="gemma4:26b",           # or $QM_DEFAULT_MODEL
+    )
+
+Every subsequent ``qm.run(...)``, ``qm.instruction(...)``,
+``qm.instruction_form(...)`` call picks this up automatically.  Per-call
+overrides (``model="other"``, ``provider="anthropic"``) still work and
+take precedence.
+
+The design mirrors how ``openai.OpenAI()`` and ``anthropic.Anthropic()``
+clients are typically used in real codebases — one construct at boot,
+reused everywhere else.
+
+**Deployment note:** the configured registry lives in module-level
+globals.  Under pre-fork ASGI servers (``gunicorn -w 4``, Uvicorn with
+``--workers``) each worker has its own copy — calling :func:`configure`
+in the parent process before ``fork`` is visible to the children, but
+calling it after fork only affects that worker.  Best practice: call
+:func:`configure` inside your ASGI lifespan startup hook rather than at
+module import time.  Single-process servers (``uvicorn app:api``) and
+Celery workers are unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from quartermaster_providers import ProviderRegistry, register_local
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton state.  Threading note: writes from ``configure()``
+# are not serialised — call it once at startup, not from worker threads.
+_default_registry: ProviderRegistry | None = None
+_default_model: str | None = None
+
+
+def configure(
+    *,
+    provider: str = "ollama",
+    base_url: str | None = None,
+    api_key: str | None = None,
+    default_model: str | None = None,
+    registry: ProviderRegistry | None = None,
+) -> ProviderRegistry:
+    """Bind a default provider registry for subsequent ``qm.*`` calls.
+
+    Args:
+        provider: ``"ollama"``, ``"vllm"``, ``"lm-studio"``, ``"tgi"``,
+            ``"localai"``, ``"llama-cpp"``, or ``"custom"``.  For
+            cloud-hosted providers (openai / anthropic / groq / xai)
+            register them via :class:`ProviderRegistry` directly and
+            pass the result as *registry*.
+        base_url: Endpoint URL.  Falls back to ``$OLLAMA_HOST`` when
+            provider is ``"ollama"`` and no value is passed.
+        api_key: Auth token for providers that need one.
+        default_model: Model to use when a call doesn't pass ``model=``.
+            Falls back to ``$QM_DEFAULT_MODEL``.
+        registry: Hand in a fully-built registry instead of having
+            ``configure`` build one.  Mutually exclusive with
+            ``base_url`` / ``api_key``.
+
+    Returns:
+        The bound :class:`ProviderRegistry` — useful for tests that
+        want to introspect it.
+    """
+    global _default_registry, _default_model
+
+    resolved_default_model = default_model or os.environ.get("QM_DEFAULT_MODEL")
+
+    if registry is not None:
+        if base_url is not None or api_key is not None:
+            raise ValueError(
+                "configure(): pass either registry= OR base_url/api_key, not both."
+            )
+        _default_registry = registry
+    else:
+        # Let OllamaProvider pick up $OLLAMA_HOST when base_url is unset —
+        # that's already the provider's documented behaviour.
+        _default_registry = register_local(
+            provider,
+            base_url=base_url,
+            api_key=api_key,
+            default_model=resolved_default_model,
+        )
+
+    _default_model = resolved_default_model
+    logger.info(
+        "quartermaster_sdk configured: provider=%s default_model=%s",
+        provider,
+        resolved_default_model,
+    )
+    return _default_registry
+
+
+def get_default_registry() -> ProviderRegistry:
+    """Return the module-level default registry or raise a helpful error."""
+    if _default_registry is None:
+        raise RuntimeError(
+            "No default provider registry configured. Call "
+            "quartermaster_sdk.configure(provider='ollama', default_model=...) "
+            "once at app boot, or pass provider_registry= explicitly to run()."
+        )
+    return _default_registry
+
+
+def get_default_model() -> str | None:
+    """Return the module-level default model name, if set.
+
+    Resolution order:
+
+    1. The explicit ``default_model=`` passed to :func:`configure`, or
+       ``$QM_DEFAULT_MODEL`` env var it picked up.
+    2. The default model registered on the provider registry itself
+       (e.g. via ``register_local("ollama", default_model=...)`` or
+       ``registry.set_default_model("ollama", "gemma4:26b")``).
+    3. ``None`` — callers then have to pass ``model=`` per call.
+    """
+    if _default_model is not None:
+        return _default_model
+    if _default_registry is not None:
+        # ``ProviderRegistry.get_default_model()`` returns the fallback
+        # provider's default model.  We narrow the catch so real bugs
+        # (e.g. a registry that overrides the method with the wrong
+        # signature) surface instead of being silently swallowed as
+        # "no default".
+        try:
+            return _default_registry.get_default_model()
+        except (AttributeError, TypeError) as exc:
+            logger.warning(
+                "Configured registry does not expose a usable get_default_model(): %s",
+                exc,
+            )
+            return None
+    return None
+
+
+def reset_config() -> None:
+    """Clear the configured registry — used by tests to start fresh."""
+    global _default_registry, _default_model
+    _default_registry = None
+    _default_model = None
+
+
+__all__ = [
+    "configure",
+    "get_default_registry",
+    "get_default_model",
+    "reset_config",
+]

--- a/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
@@ -1,0 +1,226 @@
+"""Top-level single-shot helpers: :func:`instruction`, :func:`instruction_form`.
+
+These wrap a single-node graph so callers never touch ``Graph``,
+``FlowRunner``, or ``register_local`` for the 90% of use-cases that are
+just ``prompt → text`` or ``prompt → typed JSON``.
+
+The docs / Sorex feedback called this "the thing we'd actually write";
+v0.2.0 ships it as the primary recommended API for non-agentic calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, TypeVar
+
+from quartermaster_graph import Graph
+
+from ._config import get_default_model
+from ._runner import run
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+    from quartermaster_providers import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+T = TypeVar("T", bound="BaseModel")
+
+
+# Match an opening ```lang\n (or ``` alone) at the start of a response and
+# a closing ``` at the end, leaving any triple-backtick-looking characters
+# INSIDE the JSON alone.  ``str.strip("`")`` would eat backticks out of
+# string values (e.g. SQL or regex examples quoted in the JSON body);
+# this regex pair targets only the fence itself.
+_MD_FENCE_OPEN_RE = re.compile(r"\A\s*```[A-Za-z0-9_-]*\s*\n?")
+_MD_FENCE_CLOSE_RE = re.compile(r"\n?\s*```\s*\Z")
+
+
+def _strip_markdown_fence(raw: str) -> str:
+    """Remove a leading ``` fence (with optional language tag) and a trailing ``` fence.
+
+    Preserves every backtick that appears inside the fenced content —
+    ``re.sub(r'^```[lang]\\n?', '')`` + ``re.sub(r'\\n?```$', '')`` rather
+    than the pre-0.2.0 naive ``str.strip("`")`` which corrupted JSON
+    strings containing literal backticks.
+    """
+    text = _MD_FENCE_OPEN_RE.sub("", raw)
+    text = _MD_FENCE_CLOSE_RE.sub("", text)
+    return text.strip()
+
+
+def instruction(
+    *,
+    user: str,
+    system: str = "",
+    model: str | None = None,
+    provider: str = "",
+    temperature: float = 0.7,
+    max_output_tokens: int | None = None,
+    thinking_level: str = "off",
+    provider_registry: ProviderRegistry | None = None,
+) -> str:
+    """Single-shot prompt → text.
+
+    Builds a one-node ``Instruction`` graph under the hood, runs it,
+    and returns the final assistant text.  The ``user`` kwarg is the
+    primary user message — no ``.user()`` node boilerplate.
+
+    Args:
+        user: The user message / prompt.  **Required.**
+        system: System instruction steering the model.
+        model: Model identifier.  Falls back to the ``default_model`` set
+            via :func:`configure` or ``$QM_DEFAULT_MODEL``.
+        provider: Optional explicit provider name.  Leave blank for
+            auto-resolution from the registry.
+        temperature: Sampling temperature.
+        max_output_tokens: Hard cap on output tokens.
+        thinking_level: ``off``/``low``/``medium``/``high`` — forwarded
+            to reasoning-capable models.
+        provider_registry: Override the module-level default registry.
+
+    Returns:
+        The assistant's reply as a plain ``str``.  Raises
+        ``RuntimeError`` when the underlying flow fails.
+    """
+    resolved_model = model or get_default_model()
+    if not resolved_model:
+        raise ValueError(
+            "instruction(): no model resolved. Pass model=... or call "
+            "quartermaster_sdk.configure(default_model=...) at app boot."
+        )
+
+    graph = (
+        Graph("instruction")
+        .instruction(
+            "Instruction",
+            model=resolved_model,
+            provider=provider,
+            temperature=temperature,
+            system_instruction=system,
+            max_output_tokens=max_output_tokens,
+            thinking_level=thinking_level,
+        )
+        .build()
+    )
+
+    result = run(graph, user, provider_registry=provider_registry)
+    if not result.success:
+        raise RuntimeError(f"instruction() failed: {result.error}")
+    return result.text
+
+
+def instruction_form(
+    schema: type[T],
+    *,
+    user: str,
+    system: str = "",
+    model: str | None = None,
+    provider: str = "",
+    temperature: float = 0.1,
+    max_output_tokens: int | None = None,
+    provider_registry: ProviderRegistry | None = None,
+) -> T:
+    """Single-shot prompt → Pydantic model.
+
+    Runs the prompt through a one-node instruction graph, then parses
+    the LLM's JSON output into *schema* via ``model_validate_json``.
+    Default temperature is 0.1 — structured extraction benefits from
+    the more-deterministic end of the range.
+
+    The helper injects the schema into the system prompt so the LLM
+    knows what JSON shape to return; callers don't need to describe
+    the format themselves.
+
+    Args:
+        schema: A Pydantic v2 ``BaseModel`` subclass describing the
+            output shape.  **Required.**
+        user: The user message / prompt.  **Required.**
+        system: Instruction steering the extraction (e.g. "Classify
+            this email...").  The schema description is appended
+            automatically.
+        model: Model identifier (falls back to the configured default).
+        temperature: Sampling temperature — default 0.1 for
+            determinism.
+
+    Returns:
+        An instance of *schema* populated from the LLM's output.
+
+    Raises:
+        ValueError: ``schema`` isn't a Pydantic ``BaseModel`` subclass.
+        RuntimeError: the underlying flow failed, or the model's output
+            couldn't be parsed into *schema* (raises a
+            ``ValidationError``-wrapping ``RuntimeError`` with the raw
+            text attached for debugging).
+
+    .. warning::
+        The schema's JSON representation is injected **verbatim** into
+        the system prompt so the LLM knows the target shape.  That
+        includes every field's ``description=`` and ``default=``
+        metadata.  If your Pydantic model derives descriptions from
+        external / attacker-influenced sources (rare but not unheard of
+        in code-generation pipelines), an attacker could use them as an
+        indirect-prompt-injection channel.  Keep ``Field(description=)``
+        values static / developer-controlled.
+    """
+    try:
+        from pydantic import BaseModel, ValidationError
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover — pydantic is a hard dep of many ecosystems
+        raise ImportError(
+            "instruction_form() requires pydantic. Install with `pip install pydantic`."
+        ) from exc
+
+    if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
+        raise ValueError(
+            f"instruction_form(schema=...) must be a pydantic.BaseModel "
+            f"subclass; got {type(schema).__name__}"
+        )
+
+    # Inject a JSON-schema hint into the system prompt so the model
+    # knows what fields are expected.  Keep this short — bloating the
+    # system prompt with a giant schema eats context.
+    try:
+        schema_json = json.dumps(schema.model_json_schema(), separators=(",", ":"))
+    except Exception:
+        schema_json = str(schema.__name__)
+
+    full_system = (
+        f"{system}\n\n"
+        "Respond with a single JSON object matching this schema. "
+        "Do not wrap the JSON in markdown code fences. Do not emit any "
+        "text outside the JSON object.\n\n"
+        f"Schema: {schema_json}"
+    ).strip()
+
+    raw = instruction(
+        user=user,
+        system=full_system,
+        model=model,
+        provider=provider,
+        temperature=temperature,
+        max_output_tokens=max_output_tokens,
+        thinking_level="off",
+        provider_registry=provider_registry,
+    )
+
+    # Strip fences in case the model insists on markdown despite instructions.
+    # Uses a regex-anchored pattern — the pre-0.2.0 ``str.strip("`")`` ate
+    # backticks out of string values (code snippets, regex examples) and
+    # corrupted the JSON before parsing could see it.
+    cleaned = _strip_markdown_fence(raw)
+
+    try:
+        return schema.model_validate_json(cleaned)
+    except ValidationError as exc:
+        raise RuntimeError(
+            f"instruction_form(): model output did not match schema "
+            f"{schema.__name__}. Raw output:\n{raw}\n\nValidation errors:\n{exc}"
+        ) from exc
+
+
+__all__ = ["instruction", "instruction_form"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_result.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_result.py
@@ -1,0 +1,91 @@
+"""The v0.2.0 integrator-facing :class:`Result` type.
+
+Wraps :class:`quartermaster_engine.FlowResult` with a nicer public
+surface.  ``FlowResult.node_results`` is UUID-keyed (good for debugging
+tooling); the :class:`Result` here puts name-keyed ``captures`` front-
+and-centre so callers can write ``result["research"].output_text``
+instead of iterating ``for uuid, r in flow_result.node_results.items():
+if r.node_type == NodeType.INSTRUCTION_FORM: ...``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from quartermaster_engine import FlowResult
+    from quartermaster_engine.nodes import NodeResult
+
+
+def format_missing_capture_error(name: str, captures: dict[str, "NodeResult"]) -> str:
+    """Shared error-message formatter for missing capture keys.
+
+    Used by both :class:`Result.__getitem__` here and
+    :class:`FlowResult.__getitem__` in the engine — kept in this module
+    because the engine imports *from* the SDK only via public API, and
+    duplicating the string was flagged by the v0.2.0 reviewer as a
+    maintenance footgun (changing wording in one spot would leave the
+    other silently out of date).
+    """
+    available = ", ".join(sorted(captures)) or "(no captures registered)"
+    return f"No capture named {name!r}. Available captures: {available}"
+
+
+@dataclass
+class Result:
+    """Run result — what :func:`run` returns.
+
+    Attributes:
+        text: Final text output of the flow.  Equivalent to
+            ``FlowResult.final_output``.  For graphs without an End
+            node, this is the output of the last finished node.
+        captures: Dict of ``capture_as="name"`` → :class:`NodeResult`
+            for every node the graph-builder tagged.  Access via
+            ``result.captures["notes"].output_text`` or the shorthand
+            ``result["notes"]``.
+        success: ``True`` when every node finished without a ``STOP``
+            strategy error bubbling up.
+        error: Concatenated error messages from any failed node, or
+            ``None`` on success.
+        duration_seconds: Wall-clock time the flow took to execute.
+        raw: The underlying :class:`FlowResult` — escape hatch when you
+            need UUID-keyed ``node_results`` or the full ``output_data``
+            maps.
+    """
+
+    text: str
+    captures: dict[str, NodeResult] = field(default_factory=dict)
+    success: bool = True
+    error: str | None = None
+    duration_seconds: float = 0.0
+    raw: FlowResult | None = None
+
+    def __getitem__(self, name: str) -> NodeResult:
+        """``result["notes"]`` → the captured NodeResult.
+
+        Raises ``KeyError`` with a list of known capture names on miss
+        so the caller can see immediately which key they meant.
+        """
+        try:
+            return self.captures[name]
+        except KeyError:
+            raise KeyError(format_missing_capture_error(name, self.captures)) from None
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.captures
+
+    @classmethod
+    def from_flow_result(cls, fr: FlowResult) -> Result:
+        """Build a :class:`Result` from the underlying :class:`FlowResult`."""
+        return cls(
+            text=fr.final_output,
+            captures=dict(fr.captures),
+            success=fr.success,
+            error=fr.error,
+            duration_seconds=fr.duration_seconds,
+            raw=fr,
+        )
+
+
+__all__ = ["Result", "format_missing_capture_error"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -1,0 +1,246 @@
+"""The v0.2.0 ergonomic graph runner.
+
+Replaces the "import FlowRunner, build a node registry, construct the
+runner, call .run()" dance with a one-liner:
+
+    from quartermaster_sdk import Graph, run
+
+    graph = Graph("chat").user().agent().build()
+    result = run(graph, "Hello!")                 # sync
+    for chunk in run.stream(graph, "Hello!"):    # streaming
+        if chunk.type == "token":
+            print(chunk.content, end="")
+
+Provider is picked up from :func:`configure` or the
+``provider_registry=`` kwarg; no need for the integrator to touch
+``quartermaster_engine.FlowRunner`` or
+``quartermaster_engine.build_default_registry`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from typing import TYPE_CHECKING, Any, Iterator
+from uuid import uuid4
+
+from quartermaster_engine import (
+    FlowError,
+    FlowEvent,
+    FlowFinished,
+    FlowRunner,
+    NodeFinished,
+    NodeStarted,
+    TokenGenerated,
+    UserInputRequired,
+)
+
+from ._chunks import (
+    AwaitInputChunk,
+    Chunk,
+    DoneChunk,
+    ErrorChunk,
+    NodeFinishChunk,
+    NodeStartChunk,
+    TokenChunk,
+)
+from ._config import get_default_registry
+from ._result import Result
+
+if TYPE_CHECKING:
+    from quartermaster_graph import GraphBuilder, GraphSpec
+    from quartermaster_providers import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_graph(graph: GraphBuilder | GraphSpec) -> GraphSpec:
+    """Accept either a builder (auto-finalise) or a pre-built spec."""
+    if hasattr(graph, "build"):
+        return graph.build()
+    return graph
+
+
+class _RunCallable:
+    """Callable + ``.stream`` method exposed as ``qm.run``.
+
+    Packaged as a class so ``run`` and ``run.stream`` share the same
+    argument-resolution path without repeating boilerplate.
+    """
+
+    def __call__(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Result:
+        """Execute *graph* against *user_input* and return a :class:`Result`.
+
+        Args:
+            graph: Either a :class:`GraphBuilder` (auto-finalised) or
+                a pre-built :class:`GraphSpec`.
+            user_input: Primary user message injected into the graph.
+            provider_registry: Override the configured default registry.
+            tool_registry: Optional :class:`quartermaster_tools.ToolRegistry`
+                made available to ``agent()``-type nodes that specify
+                ``tools=[...]``.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+        )
+        fr = runner.run(user_input)
+        return Result.from_flow_result(fr)
+
+    def stream(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Iterator[Chunk]:
+        """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Terminates with a :class:`DoneChunk` (on success) or
+        :class:`ErrorChunk` (on unrecoverable failure).  The graph
+        executes on a background thread so the caller can iterate the
+        yielded chunks synchronously — no ``async``/``await`` required.
+
+        **Cancellation:** breaking out of the loop early (``break``,
+        ``return`` from an enclosing function, raising inside the
+        consumer) calls :meth:`FlowRunner.stop` on the in-flight
+        ``flow_id``, which the engine checks in ``_execute_node``
+        before dispatching any further work.  Nodes already mid-flight
+        finish their current LLM/tool call — no hard kill — but no new
+        nodes are dispatched, so long agent loops unwind within a
+        bounded time instead of leaking API costs in the background.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+
+        q: queue.Queue[FlowEvent | None] = queue.Queue()
+        holder_lock = threading.Lock()
+        holder: dict[str, Any] = {}
+        # Pre-generate the flow_id so cancellation can call
+        # ``runner.stop(flow_id)`` even if the caller breaks out of the
+        # iterator before the first event fires.  ``FlowRunner.run``
+        # accepts an optional ``flow_id=`` and will use ours instead of
+        # minting its own — this is the documented public API, not
+        # reaching into a private attribute.
+        flow_id = uuid4()
+
+        def on_event(event: FlowEvent) -> None:
+            q.put(event)
+
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+            on_event=on_event,
+        )
+
+        def _run_thread() -> None:
+            try:
+                fr = runner.run(user_input, flow_id=flow_id)
+                with holder_lock:
+                    holder["result"] = fr
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.exception("run.stream: runner.run raised")
+                with holder_lock:
+                    holder["exception"] = exc
+            finally:
+                # Sentinel: signal the iterator loop that there are no
+                # more events.  Placed in ``finally`` so a runner crash
+                # doesn't hang the caller.
+                q.put(None)
+
+        thread = threading.Thread(target=_run_thread, name="qm-run-stream", daemon=True)
+        thread.start()
+
+        try:
+            while True:
+                # Short timeout so the caller can still get control back
+                # (e.g. to abort, log progress) if the runner stalls.
+                try:
+                    event = q.get(timeout=300.0)
+                except queue.Empty:
+                    logger.warning("run.stream: no event for 5 minutes; still waiting")
+                    continue
+                if event is None:
+                    break
+                chunk = _event_to_chunk(event)
+                if chunk is not None:
+                    yield chunk
+        finally:
+            # Caller abandoned the iterator — tell the runner to stop
+            # the flow by its pre-generated id.  ``_execute_node``
+            # short-circuits on the next dispatch, so nodes mid-LLM-call
+            # finish (no hard kill) but no new work is scheduled.
+            if thread.is_alive():
+                try:
+                    runner.stop(flow_id)
+                except Exception:  # pragma: no cover — defensive
+                    logger.exception("run.stream: runner.stop(%s) raised", flow_id)
+            thread.join(timeout=5.0)
+
+        with holder_lock:
+            exception = holder.get("exception")
+            fr = holder.get("result")
+
+        if exception is not None:
+            yield ErrorChunk(error=str(exception))
+            return
+
+        if fr is None:
+            yield ErrorChunk(error="run.stream: runner produced no result")
+            return
+
+        yield DoneChunk(result=Result.from_flow_result(fr))
+
+
+def _event_to_chunk(event: FlowEvent) -> Chunk | None:
+    """Translate an engine :class:`FlowEvent` into a public :class:`Chunk`.
+
+    Returns ``None`` for events we intentionally swallow (they fold into
+    ``DoneChunk`` at the end of the stream).
+    """
+    if isinstance(event, TokenGenerated):
+        return TokenChunk(content=event.token)
+    if isinstance(event, NodeStarted):
+        return NodeStartChunk(
+            node_name=event.node_name,
+            node_type=event.node_type.value,
+        )
+    if isinstance(event, NodeFinished):
+        return NodeFinishChunk(
+            node_name=getattr(event, "node_name", ""),
+            output=event.result or "",
+        )
+    if isinstance(event, UserInputRequired):
+        return AwaitInputChunk(
+            prompt=event.prompt,
+            options=list(event.options or []),
+        )
+    if isinstance(event, FlowError):
+        return ErrorChunk(error=event.error)
+    if isinstance(event, FlowFinished):
+        # DoneChunk is emitted explicitly after the thread joins so the
+        # caller gets the full Result (not just the final_output string
+        # this event carries).
+        return None
+    return None
+
+
+#: Publicly exported runner.  ``qm.run(graph, input)`` runs sync;
+#: ``qm.run.stream(graph, input)`` yields typed Chunk objects.
+run = _RunCallable()
+
+
+__all__ = ["run", "Result", "Chunk"]

--- a/quartermaster-sdk/tests/test_v020_surface.py
+++ b/quartermaster-sdk/tests/test_v020_surface.py
@@ -1,0 +1,465 @@
+"""Tests for the v0.2.0 ergonomic surface.
+
+Covers the four primary new-in-0.2.0 public entry points:
+
+* :func:`quartermaster_sdk.configure` — module-level default registry
+* :func:`quartermaster_sdk.run` — one-liner graph runner returning a
+  :class:`Result`
+* :func:`quartermaster_sdk.run.stream` — typed :class:`Chunk` stream
+* :func:`quartermaster_sdk.instruction` / :func:`instruction_form` —
+  single-shot prompt helpers with no ``Graph`` boilerplate
+
+Plus the underlying primitives: auto-start, optional End, ``capture_as=``
+threading through :attr:`Result.captures`.
+
+We mock the provider with :class:`MockProvider` so the suite runs with
+no real LLM.  ``instruction_form`` uses a Pydantic model; the mock is
+primed to return canned JSON.
+"""
+
+from __future__ import annotations
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Build a ProviderRegistry with a MockProvider registered as ``ollama``.
+
+    Both text (streamed) and native-response channels are primed so
+    tests that pick either path see a consistent reply.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+# ── configure() ───────────────────────────────────────────────────────
+
+
+class TestConfigure:
+    def test_configure_with_registry(self):
+        reg, _ = _mock_registry()
+        returned = qm.configure(registry=reg)
+        assert returned is reg
+        assert qm.get_default_registry() is reg
+
+    def test_configure_rejects_mixed_args(self):
+        reg, _ = _mock_registry()
+        with pytest.raises(ValueError, match="registry= OR base_url"):
+            qm.configure(registry=reg, base_url="http://localhost:11434")
+
+    def test_get_default_registry_raises_before_configure(self):
+        with pytest.raises(RuntimeError, match="No default provider registry"):
+            qm.get_default_registry()
+
+    def test_env_default_model_picked_up(self, monkeypatch):
+        monkeypatch.setenv("QM_DEFAULT_MODEL", "gemma4:26b")
+        reg, _ = _mock_registry()
+        qm.configure(registry=reg)
+        # registry= path uses the env var for get_default_model()
+        assert qm.get_default_model() == "gemma4:26b"
+
+
+# ── Graph builder v0.2.0 ──────────────────────────────────────────────
+
+
+class TestBuilderPassthrough:
+    """Regression: ``qm.run()`` accepts a ``GraphBuilder`` directly —
+    ``.build()`` is purely optional.  This pins the ergonomic shortcut
+    advertised in the v0.2.0 READMEs and every migrated example so a
+    future refactor of ``_resolve_graph`` can't silently force callers
+    back into the ``.build()`` boilerplate."""
+
+    def test_run_accepts_builder_without_explicit_build(self):
+        reg, _ = _mock_registry("no build call")
+        qm.configure(registry=reg)
+        builder = qm.Graph("x").instruction("One")
+        # Pass the BUILDER (not .build()).  run() finalises internally.
+        result = qm.run(builder, "hi")
+        assert result.success
+        assert result.text == "no build call"
+
+    def test_run_accepts_pre_built_spec_too(self):
+        """The inverse — passing the result of ``.build()`` still works."""
+        reg, _ = _mock_registry("pre built")
+        qm.configure(registry=reg)
+        spec = qm.Graph("x").instruction("One").build()
+        result = qm.run(spec, "hi")
+        assert result.success
+        assert result.text == "pre built"
+
+    def test_run_stream_accepts_builder_without_explicit_build(self):
+        reg, _ = _mock_registry("streamed")
+        qm.configure(registry=reg)
+        builder = qm.Graph("x").instruction("One")
+        chunks = list(qm.run.stream(builder, "hi"))
+        assert chunks[-1].type == "done"
+        assert chunks[-1].result.text == "streamed"
+
+
+class TestAutoStart:
+    def test_graph_constructor_creates_start_node(self):
+        graph = qm.Graph("x").instruction("Plain").build()
+        starts = [n for n in graph.nodes if n.type.value.startswith("Start")]
+        assert len(starts) == 1, "exactly one Start node should exist"
+
+    def test_explicit_start_call_is_idempotent(self):
+        """Calling .start() after auto-start must NOT create a second Start."""
+        graph = qm.Graph("x").start().instruction("Plain").build()
+        starts = [n for n in graph.nodes if n.type.value.startswith("Start")]
+        assert len(starts) == 1
+
+    def test_auto_start_opt_out(self):
+        """``auto_start=False`` restores the pre-0.2.0 manual path."""
+        with pytest.raises(ValueError, match="start node"):
+            qm.Graph("x", auto_start=False).instruction("Plain").build()
+
+
+class TestOptionalEnd:
+    def test_graph_without_end_validates_clean(self):
+        # Just builds — no .end() call.  Previously this raised "no_end".
+        graph = qm.Graph("x").instruction("Plain").build()
+        assert graph is not None
+
+
+# ── run() + capture_as + Result ──────────────────────────────────────
+
+
+class TestRunAndCaptures:
+    def test_run_returns_result_with_text(self):
+        reg, _ = _mock_registry("Pozdravljen!")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One", capture_as="one").build()
+        result = qm.run(graph, "hi")
+        assert result.success
+        assert result.text == "Pozdravljen!"
+        assert isinstance(result, qm.Result)
+
+    def test_capture_as_populates_captures_dict(self):
+        reg, _ = _mock_registry("hello")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("Named", capture_as="reply").build()
+        result = qm.run(graph, "?")
+        assert "reply" in result.captures
+        assert result.captures["reply"].output_text == "hello"
+
+    def test_result_getitem_shorthand(self):
+        reg, _ = _mock_registry("hello")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("Named", capture_as="reply").build()
+        result = qm.run(graph, "?")
+        # result["reply"] is the shorthand for result.captures["reply"]
+        assert result["reply"].output_text == "hello"
+
+    def test_missing_capture_key_raises_with_known_keys(self):
+        reg, _ = _mock_registry("hello")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("Named", capture_as="reply").build()
+        result = qm.run(graph, "?")
+        with pytest.raises(KeyError, match="Available captures: reply"):
+            _ = result["nope"]
+
+    def test_run_stream_yields_typed_chunks_ending_with_done(self):
+        reg, _ = _mock_registry("streaming words")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+
+        chunks = list(qm.run.stream(graph, "hi"))
+        types = [c.type for c in chunks]
+        # Must end with a DoneChunk that carries a populated Result.
+        assert types[-1] == "done"
+        last = chunks[-1]
+        assert isinstance(last, qm.DoneChunk)
+        assert last.result.success
+        # Intermediate events should include at least one node_start / node_finish.
+        assert "node_start" in types
+        assert "node_finish" in types
+
+    def test_run_uses_configured_registry_when_none_passed(self):
+        reg, mock = _mock_registry("configured")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+        result = qm.run(graph, "?")
+        assert result.success
+        assert mock.call_count >= 1
+
+    def test_run_override_registry_wins(self):
+        reg_a, _ = _mock_registry("A")
+        reg_b, _ = _mock_registry("B")
+        qm.configure(registry=reg_a)
+        graph = qm.Graph("x").instruction("One").build()
+        result = qm.run(graph, "?", provider_registry=reg_b)
+        assert result.text == "B"
+
+
+# ── instruction() / instruction_form() ───────────────────────────────
+
+
+class TestInstruction:
+    def test_instruction_returns_str(self):
+        reg, _ = _mock_registry("gotcha")
+        qm.configure(registry=reg)
+        reply = qm.instruction(system="sys", user="usr")
+        assert reply == "gotcha"
+
+    def test_instruction_requires_model(self):
+        reg, _ = _mock_registry()
+        # Configure without default_model — instruction() must complain
+        reg_no_default = ProviderRegistry(auto_configure=False)
+        reg_no_default.register_instance("ollama", MockProvider())
+        reg_no_default.set_default_provider("ollama")
+        qm.configure(registry=reg_no_default)
+        with pytest.raises(ValueError, match="no model resolved"):
+            qm.instruction(user="x")
+
+
+class TestInstructionForm:
+    class _Classification(BaseModel):
+        category: str
+        priority: str
+
+    def test_instruction_form_returns_pydantic_model(self):
+        canned = '{"category":"order","priority":"urgent"}'
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        out = qm.instruction_form(
+            self._Classification, system="Classify.", user="urgent order 42"
+        )
+        assert isinstance(out, self._Classification)
+        assert out.category == "order"
+        assert out.priority == "urgent"
+
+    def test_instruction_form_strips_markdown_fence(self):
+        """Models sometimes insist on fencing JSON in ```json. Must be tolerated."""
+        canned = '```json\n{"category":"ok","priority":"normal"}\n```'
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        out = qm.instruction_form(self._Classification, system="c", user="u")
+        assert out.category == "ok"
+
+    def test_instruction_form_raises_on_schema_mismatch(self):
+        canned = '{"not_the_right":"shape"}'
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        with pytest.raises(RuntimeError, match="did not match schema"):
+            qm.instruction_form(self._Classification, system="c", user="u")
+
+    def test_instruction_form_rejects_non_pydantic_schema(self):
+        reg, _ = _mock_registry("{}")
+        qm.configure(registry=reg)
+        with pytest.raises(ValueError, match="pydantic.BaseModel subclass"):
+            qm.instruction_form(dict, system="c", user="u")  # type: ignore[arg-type]
+
+
+# ── Tool-name prefix stripping ───────────────────────────────────────
+
+
+class TestToolNamePrefixStripping:
+    """Regression: Gemma-family models emit ``default_api:foo``; OpenAI
+    native wire uses ``functions:foo``; MCP bridge uses ``mcp:foo``.  All
+    three must resolve to the same registered tool."""
+
+    def test_strip_helper(self):
+        from quartermaster_engine.example_runner import _normalise_tool_name
+
+        assert _normalise_tool_name("default_api:list_orders") == "list_orders"
+        assert _normalise_tool_name("default_api.list_orders") == "list_orders"
+        assert _normalise_tool_name("functions:list_orders") == "list_orders"
+        assert _normalise_tool_name("functions.list_orders") == "list_orders"
+        assert _normalise_tool_name("mcp:list_orders") == "list_orders"
+        # Bare names pass through unchanged.
+        assert _normalise_tool_name("list_orders") == "list_orders"
+
+
+class TestMarkdownFenceStripping:
+    """Regression for the v0.2.0 reviewer HIGH: the old implementation
+    used ``str.strip("`")`` which ate backticks from anywhere in the
+    string — corrupting JSON whose string values contained literal
+    backticks.  The new regex-anchored stripper only touches the fence."""
+
+    def test_preserves_backticks_inside_json_strings(self):
+        from quartermaster_sdk._helpers import _strip_markdown_fence
+
+        raw = "```json\n" + '{"sql":"SELECT `id` FROM users"}' + "\n```"
+        assert _strip_markdown_fence(raw) == '{"sql":"SELECT `id` FROM users"}', (
+            "fence stripper must preserve backticks that appear inside string values"
+        )
+
+    def test_bare_triple_backtick_fence(self):
+        from quartermaster_sdk._helpers import _strip_markdown_fence
+
+        raw = '```\n{"ok":true}\n```'
+        assert _strip_markdown_fence(raw) == '{"ok":true}'
+
+    def test_unfenced_passes_through(self):
+        from quartermaster_sdk._helpers import _strip_markdown_fence
+
+        raw = '{"plain":"value"}'
+        assert _strip_markdown_fence(raw) == raw
+
+    def test_instruction_form_survives_backticks_in_json(self):
+        """The integration case: ``instruction_form`` returns a valid
+        Pydantic model even when the canned response contains backticks
+        inside a string field."""
+
+        class Sample(BaseModel):
+            query: str
+
+        canned = "```json\n" + '{"query":"SELECT `id` FROM users"}' + "\n```"
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        out = qm.instruction_form(Sample, system="c", user="u")
+        # The backticks survive — they were part of the JSON value, not the fence.
+        assert out.query == "SELECT `id` FROM users"
+
+
+class TestStreamEarlyExitCancels:
+    """Regression for the v0.2.0 reviewer HIGHs: abandoning the
+    generator early must call ``FlowRunner.stop(flow_id)`` (via the
+    pre-generated UUID) and join the runner thread within the
+    documented timeout — not leak the thread *or* let the flow keep
+    burning API calls in the background."""
+
+    def test_break_out_of_stream_finishes_promptly(self):
+        import threading as _threading
+        import time as _time
+
+        reg, _ = _mock_registry("streaming response tokens")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+
+        before = _threading.active_count()
+        for _chunk in qm.run.stream(graph, "hi"):
+            break  # abandon the iterator immediately
+        # Allow the join(timeout=5.0) in the generator's finally to run.
+        _time.sleep(0.2)
+        after = _threading.active_count()
+        # Some background threads are OK (pytest, etc.), but our named
+        # "qm-run-stream" must have exited.
+        leaked = [
+            t
+            for t in _threading.enumerate()
+            if t.name == "qm-run-stream" and t.is_alive()
+        ]
+        assert leaked == [], (
+            f"run.stream thread leaked after early break; still alive: {leaked}. "
+            f"active count went from {before} to {after}."
+        )
+
+    def test_stream_uses_pre_generated_flow_id(self, monkeypatch):
+        """The cancel path must have a flow_id to stop.  Pre-0.2.0 (in
+        the buggy intermediate commit) it captured from the first event,
+        racing with early break.  Now the flow_id is minted up front
+        and passed as ``runner.run(..., flow_id=...)`` — so even a break
+        before the first event has a valid id to stop."""
+        reg, _ = _mock_registry("ok")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+
+        captured: dict[str, Any] = {}
+
+        from quartermaster_engine import FlowRunner
+
+        original_run = FlowRunner.run
+
+        def capture_run(self, input_message, flow_id=None):
+            captured["flow_id_passed"] = flow_id
+            return original_run(self, input_message, flow_id=flow_id)
+
+        monkeypatch.setattr(FlowRunner, "run", capture_run)
+
+        # Consume the full stream (no break) to confirm the happy path.
+        chunks = list(qm.run.stream(graph, "hi"))
+        assert chunks[-1].type == "done"
+        assert captured["flow_id_passed"] is not None, (
+            "run.stream must pre-generate a flow_id and forward it to "
+            "FlowRunner.run(flow_id=...), otherwise cancellation can't "
+            "target the right flow."
+        )
+
+
+class TestStreamAwaitInputChunk:
+    """Coverage gap caught by code-reviewer: ``AwaitInputChunk`` (the
+    ``UserInputRequired`` → chunk mapping) wasn't exercised."""
+
+    def test_user_node_with_no_input_yields_await_chunk(self):
+        """In non-interactive mode the User node passes through the
+        input without pausing, but we can still verify the chunk
+        mapping exists and covers the UserInputRequired path."""
+        from quartermaster_engine import UserInputRequired
+
+        from quartermaster_sdk._runner import _event_to_chunk
+
+        event = UserInputRequired(
+            flow_id=None,  # type: ignore[arg-type]
+            node_id=None,  # type: ignore[arg-type]
+            prompt="Your input?",
+            options=["A", "B"],
+        )
+        chunk = _event_to_chunk(event)
+        assert isinstance(chunk, qm.AwaitInputChunk)
+        assert chunk.prompt == "Your input?"
+        assert chunk.options == ["A", "B"]
+        assert chunk.type == "await_input"
+
+
+class TestCaptureAsValidationWarning:
+    """Code-reviewer MEDIUM: ``capture_as="llm_model"`` (or any other
+    reserved metadata key) emits a warning — captures still work, but
+    the collision is visible in logs / validator output."""
+
+    def test_capture_as_shadowing_reserved_key_emits_warning(self):
+        """Building a graph with capture_as="llm_model" triggers a
+        warning (not an error) from validate_graph."""
+        from quartermaster_graph.validation import validate_graph
+
+        graph = qm.Graph("x").instruction("One", capture_as="llm_model").build()
+        issues = validate_graph(graph)
+        warnings = [i for i in issues if i.code == "capture_as_shadows_reserved_key"]
+        assert len(warnings) == 1
+        assert warnings[0].severity == "warning"
+
+    def test_normal_capture_as_emits_no_warning(self):
+        from quartermaster_graph.validation import validate_graph
+
+        graph = qm.Graph("x").instruction("One", capture_as="notes").build()
+        issues = validate_graph(graph)
+        warnings = [i for i in issues if i.code == "capture_as_shadows_reserved_key"]
+        assert warnings == []

--- a/quartermaster-tools/pyproject.toml
+++ b/quartermaster-tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-tools"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tool abstraction framework and chain-of-responsibility handler pattern for AI agent orchestration"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 web = ["httpx>=0.25.0"]
-llm = ["quartermaster-providers>=0.2.0"]
+llm = ["quartermaster-providers>=0.2.1"]
 database = ["sqlalchemy>=2.0"]
 vector = ["chromadb>=0.4", "sentence-transformers>=2.2"]
 privacy = ["presidio-analyzer>=2.2"]

--- a/quartermaster-tools/pyproject.toml
+++ b/quartermaster-tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-tools"
-version = "0.1.6"
+version = "0.2.0"
 description = "Tool abstraction framework and chain-of-responsibility handler pattern for AI agent orchestration"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 web = ["httpx>=0.25.0"]
-llm = ["quartermaster-providers>=0.1.6"]
+llm = ["quartermaster-providers>=0.2.0"]
 database = ["sqlalchemy>=2.0"]
 vector = ["chromadb>=0.4", "sentence-transformers>=2.2"]
 privacy = ["presidio-analyzer>=2.2"]

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,7 +3143,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-providers" }
 dependencies = [
     { name = "httpx" },
@@ -3197,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3296,7 +3296,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "we
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3370,7 +3370,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.1.5"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Standard post-release step: pull the auto-generated \`Release v0.2.1\` commit (d5ef77a) from master back onto develop so develop is version-aligned for the next cycle.

No code changes — just the version-bump commit that the publish workflow created when v0.2.1 shipped. Fast-forward from develop's perspective since master = develop + release commit.

After this lands, develop is the right base branch for v0.2.2 work (streaming tool-call events, async runner).