### PR TITLE
v0.2.2: live tool-call streaming + async runner

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -9,6 +9,8 @@ from quartermaster_engine.events import (
     NodeFinished,
     NodeStarted,
     TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
     UserInputRequired,
 )
 from quartermaster_engine.example_runner import (
@@ -67,6 +69,8 @@ __all__ = [
     "FlowFinished",
     "UserInputRequired",
     "FlowError",
+    "ToolCallStarted",
+    "ToolCallFinished",
     # Stores
     "ExecutionStore",
     "InMemoryStore",

--- a/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
+++ b/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
@@ -36,6 +36,14 @@ class ExecutionContext:
     on_message: Callable[[str], None] | None = None
     on_status_change: Callable[[NodeStatus], None] | None = None
     on_token: Callable[[str], None] | None = None
+    # Tool-call streaming — fires once per agent tool invocation so
+    # downstream chat UIs can render live "calling tool X..." cards
+    # instead of waiting for the full NodeResult. Payload shape matches
+    # ``events.ToolCallStarted`` / ``ToolCallFinished``.
+    on_tool_start: Callable[[str, dict, int], None] | None = None
+    on_tool_finish: (
+        Callable[[str, dict, str, Any, str | None, int], None] | None
+    ) = None
 
     def get_meta(self, key: str, default: Any = None) -> Any:
         """Get a value from the node's metadata, falling back to graph metadata."""
@@ -51,6 +59,26 @@ class ExecutionContext:
         """Emit a streaming token if a callback is registered."""
         if self.on_token:
             self.on_token(token)
+
+    def emit_tool_start(
+        self, tool: str, arguments: dict[str, Any], iteration: int
+    ) -> None:
+        """Fire ``on_tool_start`` for the agent-executor tool loop, if wired."""
+        if self.on_tool_start:
+            self.on_tool_start(tool, arguments, iteration)
+
+    def emit_tool_finish(
+        self,
+        tool: str,
+        arguments: dict[str, Any],
+        result: str,
+        raw: Any,
+        error: str | None,
+        iteration: int,
+    ) -> None:
+        """Fire ``on_tool_finish`` for the agent-executor tool loop, if wired."""
+        if self.on_tool_finish:
+            self.on_tool_finish(tool, arguments, result, raw, error, iteration)
 
     def emit_message(self, content: str) -> None:
         """Emit a complete message if a callback is registered."""

--- a/quartermaster-engine/src/quartermaster_engine/events.py
+++ b/quartermaster-engine/src/quartermaster_engine/events.py
@@ -66,3 +66,41 @@ class FlowError(FlowEvent):
     node_id: UUID = field(default_factory=lambda: UUID(int=0))
     error: str = ""
     recoverable: bool = False
+
+
+@dataclass
+class ToolCallStarted(FlowEvent):
+    """Emitted when an agent node is about to invoke a tool.
+
+    Downstream SSE handlers translate this into a
+    ``ToolCallChunk`` so chat UIs can render "calling tool X..."
+    cards as they happen, rather than batching them at the end of
+    the turn.  The ``iteration`` field corresponds to the agent's
+    tool-loop round the call belongs to.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    tool: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    iteration: int = 0
+
+
+@dataclass
+class ToolCallFinished(FlowEvent):
+    """Emitted after a tool call resolves (success or error).
+
+    ``result`` is the string surface the LLM sees next turn; the
+    original structured payload — if any — lives under ``raw``.
+    ``error`` is populated for tool-registry lookups that fail or
+    for tools that raised during execution; in both cases ``result``
+    also carries an ``[ERROR: ...]`` sentinel string so the model
+    can react to the failure and retry or apologise.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    tool: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    result: str = ""
+    raw: Any = None
+    error: str | None = None
+    iteration: int = 0

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pathlib
 import sys
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -434,17 +435,41 @@ def _normalise_tool_name(tool_name: str) -> str:
     return tool_name
 
 
-def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> str:
-    """Run one tool from the registry and serialise its result for the LLM.
+@dataclass
+class _ToolInvocation:
+    """Result of invoking one tool from the registry.
 
-    The returned string is fed back into the next LLM prompt, so exception
-    detail is intentionally generic — the full traceback goes to the
-    module logger instead, where ops can inspect it without exposing
-    internal paths/identifiers to the model (or, by extension, to any
-    user who can read the model's reasoning).
+    ``prompt_text`` is what gets baked into the next LLM prompt
+    (string, safe for the model to read); ``raw`` is the original
+    structured payload — a dict for most ``@tool()``-decorated
+    callables, ``None`` when the tool errored or returned nothing
+    structured. ``error`` is set when the lookup failed or the tool
+    raised; downstream ``ToolCallFinished`` event handlers surface
+    it to chat UIs so the user sees a red tool card.
+    """
+
+    prompt_text: str
+    raw: Any
+    error: str | None
+
+
+def _execute_tool_call(
+    tool_registry: Any, tool_name: str, parameters: dict
+) -> _ToolInvocation:
+    """Run one tool from the registry and return both the LLM-facing
+    string and the structured payload for live streaming.
+
+    The ``prompt_text`` surface is fed back into the next LLM prompt, so
+    exception detail is intentionally generic — the full traceback goes
+    to the module logger instead, where ops can inspect it without
+    exposing internal paths/identifiers to the model (or, by extension,
+    to any user who can read the model's reasoning). The structured
+    ``raw`` + ``error`` fields are only observed by the agent loop and
+    the ``ToolCallFinished`` event downstream, never fed back to the LLM.
     """
     if tool_registry is None:
-        return f"[ERROR: no tool registry available to execute '{tool_name}']"
+        msg = f"[ERROR: no tool registry available to execute '{tool_name}']"
+        return _ToolInvocation(prompt_text=msg, raw=None, error="no tool registry")
     # Strip ``default_api:`` / ``functions:`` / ``mcp:`` prefixes that
     # different providers attach to the function name.  Without this the
     # registry lookup would miss a tool that's registered under the bare
@@ -454,15 +479,18 @@ def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> 
         tool = tool_registry.get(normalised)
     except Exception as exc:
         logger.warning("Tool lookup failed for %r: %s", normalised, exc)
-        return f"[ERROR: tool '{normalised}' not found]"
+        msg = f"[ERROR: tool '{normalised}' not found]"
+        return _ToolInvocation(prompt_text=msg, raw=None, error=f"not found: {exc}")
     safe_run = getattr(tool, "safe_run", None) or getattr(tool, "run", None)
     if safe_run is None:
-        return f"[ERROR: tool '{normalised}' has no run() method]"
+        msg = f"[ERROR: tool '{normalised}' has no run() method]"
+        return _ToolInvocation(prompt_text=msg, raw=None, error="no run() method")
     try:
         result = safe_run(**parameters)
     except Exception as exc:
         logger.warning("Tool %r raised during execution: %s", normalised, exc)
-        return f"[ERROR: tool '{normalised}' execution failed]"
+        msg = f"[ERROR: tool '{normalised}' execution failed]"
+        return _ToolInvocation(prompt_text=msg, raw=None, error=str(exc))
     # ToolResult duck-typing: prefer .data, fall back to str().
     if hasattr(result, "success") and not result.success:
         # Tool itself returned a structured failure — these errors come from
@@ -470,10 +498,14 @@ def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> 
         # but log them too for ops visibility.
         err = getattr(result, "error", "tool failed")
         logger.info("Tool %r returned error result: %s", normalised, err)
-        return f"[ERROR: {err}]"
+        return _ToolInvocation(
+            prompt_text=f"[ERROR: {err}]",
+            raw=getattr(result, "data", None),
+            error=str(err),
+        )
     if hasattr(result, "data"):
-        return str(result.data)
-    return str(result)
+        return _ToolInvocation(prompt_text=str(result.data), raw=result.data, error=None)
+    return _ToolInvocation(prompt_text=str(result), raw=result, error=None)
 
 
 class AgentExecutor(NodeExecutor):
@@ -553,6 +585,13 @@ class AgentExecutor(NodeExecutor):
         prompt = base_prompt
         final_text = ""
         accumulated_tool_log: list[str] = []
+        # Structured record of every tool invocation this node made.
+        # Surfaces on ``NodeResult.data["tool_calls"]`` so downstream
+        # ``Result.captures["name"].data["tool_calls"]`` works for both
+        # the blocking (``qm.run``) and streaming (``qm.run.stream``)
+        # paths.  Each entry: {tool, arguments, result, raw, error,
+        # iteration}.
+        tool_call_log: list[dict[str, Any]] = []
         iteration = 0
         requires_another_call = True
         hit_iteration_cap = False
@@ -634,7 +673,40 @@ class AgentExecutor(NodeExecutor):
                     params = getattr(call, "parameters", None)
                     if params is None:
                         params = getattr(call, "arguments", {}) or {}
-                result = _execute_tool_call(per_node_tools, tool_name, params)
+
+                # Normalise the tool name BEFORE emitting the "started"
+                # event so downstream UIs see the same name the registry
+                # looks up (strips ``default_api:`` / ``functions:`` /
+                # ``mcp:`` prefixes).  Without this the chat card would
+                # say ``default_api:list_orders`` while the tool call log
+                # says ``list_orders`` — confusing.
+                public_name = _normalise_tool_name(tool_name)
+                context.emit_tool_start(public_name, dict(params), iteration)
+
+                invocation = _execute_tool_call(per_node_tools, tool_name, params)
+
+                context.emit_tool_finish(
+                    public_name,
+                    dict(params),
+                    invocation.prompt_text,
+                    invocation.raw,
+                    invocation.error,
+                    iteration,
+                )
+
+                # Structured record for NodeResult.data["tool_calls"] so
+                # ``qm.run(...)`` callers (non-streaming) can read exactly
+                # the same shape the streaming ToolCallFinished event
+                # carries.  Both surfaces stay in sync by construction.
+                tool_call_log.append({
+                    "tool": public_name,
+                    "arguments": dict(params),
+                    "result": invocation.prompt_text,
+                    "raw": invocation.raw,
+                    "error": invocation.error,
+                    "iteration": iteration,
+                })
+
                 # Wrap each tool result in an explicit untrusted-data block.
                 # Tool output frequently includes external content (web
                 # pages, file contents, DB rows), which can carry indirect
@@ -643,8 +715,8 @@ class AgentExecutor(NodeExecutor):
                 # instructions, blunts that attack class.
                 accumulated_tool_log.append(
                     "<tool_result"
-                    f' tool="{tool_name}" iteration="{iteration}"'
-                    f" args={params!r}>\n{result}\n</tool_result>"
+                    f' tool="{public_name}" iteration="{iteration}"'
+                    f" args={params!r}>\n{invocation.prompt_text}\n</tool_result>"
                 )
 
             tool_history = "\n".join(accumulated_tool_log)
@@ -677,7 +749,15 @@ class AgentExecutor(NodeExecutor):
         _append_to_conversation(conversation, node_name, final_text, round_num)
         return NodeResult(
             success=True,
-            data={"memory_updates": {"__conversation__": conversation}},
+            data={
+                "memory_updates": {"__conversation__": conversation},
+                # Surface the structured tool-call log on NodeResult.data
+                # so the SDK's Result.captures["x"].data["tool_calls"]
+                # read matches what streaming ToolCallChunk / ToolResultChunk
+                # events carry.  Empty list when the agent didn't call tools.
+                "tool_calls": tool_call_log,
+                "iterations": iteration,
+            },
             output_text=final_text,
         )
 

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -36,6 +36,8 @@ from quartermaster_engine.events import (
     NodeFinished,
     NodeStarted,
     TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
     UserInputRequired,
 )
 from quartermaster_engine.messaging.context_manager import ContextManager
@@ -467,6 +469,27 @@ class FlowRunner:
             metadata=dict(node.metadata),
             on_token=lambda t: self._emit(
                 TokenGenerated(flow_id=flow_id, node_id=node.id, token=t)
+            ),
+            on_tool_start=lambda tool, args, it: self._emit(
+                ToolCallStarted(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    tool=tool,
+                    arguments=args,
+                    iteration=it,
+                )
+            ),
+            on_tool_finish=lambda tool, args, result, raw, err, it: self._emit(
+                ToolCallFinished(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    tool=tool,
+                    arguments=args,
+                    result=result,
+                    raw=raw,
+                    error=err,
+                    iteration=it,
+                )
             ),
         )
 

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -77,6 +77,7 @@ from ._config import (  # noqa: F401
     get_default_registry,
     reset_config,
 )
+from ._async_runner import arun  # noqa: F401
 from ._helpers import instruction, instruction_form  # noqa: F401
 from ._result import Result  # noqa: F401
 from ._runner import run  # noqa: F401
@@ -88,6 +89,7 @@ __all__ = [
     # ── v0.2.0 primary surface ──
     "configure",
     "run",
+    "arun",
     "instruction",
     "instruction_form",
     "Result",

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -1,0 +1,239 @@
+"""Async variant of the v0.2.0 graph runner.
+
+Mirror of :mod:`quartermaster_sdk._runner` for ``async def`` call sites.
+Django views, FastAPI endpoints, and other asyncio codebases can drop
+``asgiref.sync.sync_to_async(qm.run)(...)`` in favour of the first-class
+coroutine form:
+
+    result = await qm.arun(graph, "Hello!")
+    async for chunk in qm.arun.stream(graph, "Hello!"):
+        if chunk.type == "token":
+            print(chunk.content, end="")
+
+No engine logic is duplicated — under the hood this is a thin adapter
+over :class:`FlowRunner` that dispatches the synchronous execution onto
+a worker thread (via :func:`asyncio.to_thread`) while the event loop
+keeps servicing other tasks.
+
+**Cancellation:** when the consumer's :class:`asyncio.Task` is cancelled,
+``arun`` and ``arun.stream`` both reach into the still-running
+:class:`FlowRunner` and call :meth:`FlowRunner.stop` with the pre-
+generated ``flow_id``.  The engine checks ``flow_id in self._stopped``
+in ``_execute_node`` before dispatching further work, so nodes already
+mid-LLM-call finish their current request (no hard kill) but no new
+nodes are scheduled — long agent loops unwind within a bounded time
+instead of leaking API costs after the HTTP client disconnects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, AsyncIterator
+from uuid import uuid4
+
+from quartermaster_engine import FlowEvent, FlowRunner
+
+from ._chunks import Chunk, DoneChunk, ErrorChunk
+from ._config import get_default_registry
+from ._result import Result
+from ._runner import _event_to_chunk, _resolve_graph
+
+if TYPE_CHECKING:
+    from quartermaster_graph import GraphBuilder, GraphSpec
+    from quartermaster_providers import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class _ARunCallable:
+    """Callable + ``.stream`` method exposed as ``qm.arun``.
+
+    Async analogue of :class:`_RunCallable` — same signature, same
+    semantics, but every public method is a coroutine (or async
+    iterator).  Shares :func:`_resolve_graph` and :func:`_event_to_chunk`
+    with the sync path so event mapping stays in one place.
+    """
+
+    async def __call__(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Result:
+        """Execute *graph* against *user_input* and return a :class:`Result`.
+
+        Args:
+            graph: Either a :class:`GraphBuilder` (auto-finalised) or
+                a pre-built :class:`GraphSpec`.
+            user_input: Primary user message injected into the graph.
+            provider_registry: Override the configured default registry.
+            tool_registry: Optional :class:`quartermaster_tools.ToolRegistry`
+                made available to ``agent()``-type nodes that specify
+                ``tools=[...]``.
+
+        **Cancellation:** if the awaiting task is cancelled, the running
+        flow is stopped via :meth:`FlowRunner.stop` before the
+        ``CancelledError`` propagates — nodes already dispatched finish
+        their current LLM/tool call but no new work is scheduled.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+        )
+        # Pre-generate so the async cancel handler has something to stop,
+        # even if the to_thread() call hasn't entered ``runner.run`` yet.
+        flow_id = uuid4()
+
+        try:
+            fr = await asyncio.to_thread(runner.run, user_input, flow_id=flow_id)
+        except asyncio.CancelledError:
+            # ``asyncio.to_thread`` can't actually interrupt the worker
+            # thread — the thread keeps executing until it voluntarily
+            # returns — but calling ``runner.stop(flow_id)`` flips the
+            # engine's ``_stopped`` gate so it won't dispatch any more
+            # nodes.  The current node completes, the flow wraps up,
+            # and the CancelledError re-raises to the caller.  Net
+            # effect: bounded unwind instead of runaway API calls.
+            try:
+                runner.stop(flow_id)
+            except Exception:  # pragma: no cover — defensive
+                logger.exception("arun: runner.stop(%s) raised", flow_id)
+            raise
+
+        return Result.from_flow_result(fr)
+
+    async def stream(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> AsyncIterator[Chunk]:
+        """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Terminates with a :class:`DoneChunk` (on success) or
+        :class:`ErrorChunk` (on unrecoverable failure).  The graph
+        executes on a background thread; events flow back through an
+        :class:`asyncio.Queue` so the event loop keeps servicing other
+        tasks between chunks — no blocking ``next()`` inside the coro.
+
+        **Cancellation:** if the async iterator is abandoned early
+        (``break`` out of ``async for``, enclosing task cancelled, etc.)
+        :meth:`FlowRunner.stop` is called on the pre-generated
+        ``flow_id``.  The engine short-circuits on its next
+        ``_execute_node`` dispatch — nodes mid-LLM-call finish their
+        current request but no new work is scheduled, so long agent
+        loops unwind within a bounded time instead of leaking API costs
+        after the consumer goes away.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+
+        # Capture the consumer's loop so the thread can marshal events
+        # back to it via ``call_soon_threadsafe``.  ``run_coroutine_threadsafe``
+        # would also work, but we want fire-and-forget ``put`` without
+        # blocking the engine thread on asyncio internals.
+        loop = asyncio.get_running_loop()
+        q: asyncio.Queue[FlowEvent | None] = asyncio.Queue()
+        holder: dict[str, Any] = {}
+        flow_id = uuid4()
+
+        def on_event(event: FlowEvent) -> None:
+            # Called from the engine's worker threads.  Hop back to the
+            # consumer's loop so Queue.put() touches only loop-owned
+            # state — ``asyncio.Queue`` is not thread-safe.
+            loop.call_soon_threadsafe(q.put_nowait, event)
+
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+            on_event=on_event,
+        )
+
+        def _run_sync() -> None:
+            """Runs on the ``to_thread`` worker — synchronous engine loop."""
+            try:
+                fr = runner.run(user_input, flow_id=flow_id)
+                holder["result"] = fr
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.exception("arun.stream: runner.run raised")
+                holder["exception"] = exc
+            finally:
+                # Sentinel — unblocks the async iterator even on crash.
+                loop.call_soon_threadsafe(q.put_nowait, None)
+
+        run_task = asyncio.create_task(
+            asyncio.to_thread(_run_sync), name="qm-arun-stream"
+        )
+
+        try:
+            while True:
+                event = await q.get()
+                if event is None:
+                    break
+                chunk = _event_to_chunk(event)
+                if chunk is not None:
+                    yield chunk
+        finally:
+            # Either the stream completed naturally, the caller
+            # ``break``-ed early, or our task was cancelled.  In the
+            # latter two cases the engine is still running — tell it to
+            # stop so nodes stop getting dispatched.  ``run_task`` may
+            # take up to one node's worth of runtime to actually finish,
+            # which is the same bound the sync variant documents.
+            if not run_task.done():
+                try:
+                    runner.stop(flow_id)
+                except Exception:  # pragma: no cover — defensive
+                    logger.exception(
+                        "arun.stream: runner.stop(%s) raised", flow_id
+                    )
+                # Wait (bounded) for the worker thread to observe the
+                # ``_stopped`` flag and return.  If it overshoots we let
+                # the task leak rather than blocking the event loop
+                # indefinitely — matches the 5s join() on the sync side.
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(run_task), timeout=5.0
+                    )
+                except asyncio.TimeoutError:  # pragma: no cover — defensive
+                    logger.warning(
+                        "arun.stream: runner thread did not exit within 5s"
+                    )
+                except asyncio.CancelledError:
+                    # Expected when the outer task was cancelled — let
+                    # the shielded run_task keep going in the background
+                    # (it will notice ``_stopped`` and bail on its next
+                    # node).  Re-raise so the cancellation semantics
+                    # propagate to the caller.
+                    raise
+
+        exception = holder.get("exception")
+        fr = holder.get("result")
+
+        if exception is not None:
+            yield ErrorChunk(error=str(exception))
+            return
+
+        if fr is None:
+            yield ErrorChunk(error="arun.stream: runner produced no result")
+            return
+
+        yield DoneChunk(result=Result.from_flow_result(fr))
+
+
+#: Publicly exported async runner.  ``await qm.arun(graph, input)`` runs
+#: the flow on a worker thread and awaits its result; ``async for
+#: chunk in qm.arun.stream(graph, input)`` yields typed Chunk objects.
+arun = _ARunCallable()
+
+
+__all__ = ["arun"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -33,6 +33,8 @@ from quartermaster_engine import (
     NodeFinished,
     NodeStarted,
     TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
     UserInputRequired,
 )
 
@@ -44,6 +46,8 @@ from ._chunks import (
     NodeFinishChunk,
     NodeStartChunk,
     TokenChunk,
+    ToolCallChunk,
+    ToolResultChunk,
 )
 from ._config import get_default_registry
 from ._result import Result
@@ -222,6 +226,23 @@ def _event_to_chunk(event: FlowEvent) -> Chunk | None:
         return NodeFinishChunk(
             node_name=getattr(event, "node_name", ""),
             output=event.result or "",
+        )
+    if isinstance(event, ToolCallStarted):
+        # Live "tool is being called now" card — fires before the tool
+        # actually runs.  Arguments are passed straight through so UIs
+        # can render them the moment the call is dispatched, instead of
+        # waiting for the final NodeFinish / Done event.
+        return ToolCallChunk(tool=event.tool, args=dict(event.arguments))
+    if isinstance(event, ToolCallFinished):
+        # Paired with ToolCallStarted.  ``result`` is the string the LLM
+        # sees next turn (``"[ERROR: ...]"`` sentinel on failure);
+        # ``raw`` is the structured payload when the tool returned one,
+        # ``None`` otherwise.  ``error`` is non-None only on failure —
+        # UIs can use it as the "red card" trigger.
+        return ToolResultChunk(
+            tool=event.tool,
+            result=event.raw if event.raw is not None else event.result,
+            error=event.error,
         )
     if isinstance(event, UserInputRequired):
         return AwaitInputChunk(

--- a/quartermaster-sdk/tests/test_v022_async_runner.py
+++ b/quartermaster-sdk/tests/test_v022_async_runner.py
@@ -1,0 +1,111 @@
+"""Smoke tests for the v0.2.2 async runner.
+
+Covers the new :func:`quartermaster_sdk.arun` coroutine and its
+``.stream`` async-iterator counterpart.  The implementation sits on
+top of the existing sync ``FlowRunner`` via :func:`asyncio.to_thread`,
+so the happy-path assertions here mirror the sync suite in
+``test_v020_surface.py`` but exercise the ``await`` / ``async for``
+call sites instead.
+
+Provider is stubbed with :class:`MockProvider` — no real LLM is hit.
+"""
+
+from __future__ import annotations
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Copy of the helper from test_v020_surface.py.
+
+    A ProviderRegistry wired to a MockProvider registered as ``ollama``,
+    with both streamed-token and native-response channels primed so the
+    engine picks a consistent reply regardless of which path it takes.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+# ── arun() ────────────────────────────────────────────────────────────
+
+
+async def test_arun_returns_result():
+    """``await qm.arun(graph, input)`` resolves to a populated ``Result``.
+
+    This is the direct async analogue of ``qm.run(...)`` — the sync body
+    runs on an ``asyncio.to_thread`` worker but the public contract is
+    identical: a :class:`Result` whose ``.text`` contains the mock's
+    canned reply and whose ``.success`` is ``True``.
+    """
+    reg, _ = _mock_registry("async canned")
+    qm.configure(registry=reg)
+
+    graph = qm.Graph("x").instruction("One").build()
+    result = await qm.arun(graph, "hi")
+
+    assert isinstance(result, qm.Result)
+    assert result.success
+    assert result.text == "async canned"
+
+
+async def test_arun_stream_yields_chunks():
+    """``async for chunk in qm.arun.stream(graph, input)`` yields the
+    same typed :class:`Chunk` sequence as the sync ``run.stream``, and
+    terminates with a :class:`DoneChunk` carrying the final result.
+
+    Verifies at least one node-lifecycle pair (``node_start`` →
+    ``node_finish``) surfaces between the open and close of the stream,
+    so we know events are marshalling across the thread→loop boundary
+    and not just the terminal done chunk.
+    """
+    reg, _ = _mock_registry("streaming async words")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    chunks = [chunk async for chunk in qm.arun.stream(graph, "hi")]
+    types = [c.type for c in chunks]
+
+    # Must end with a DoneChunk that carries a populated Result.
+    assert types[-1] == "done"
+    last = chunks[-1]
+    assert isinstance(last, qm.DoneChunk)
+    assert last.result.success
+    assert last.result.text == "streaming async words"
+    # Lifecycle events crossed the thread→loop boundary successfully.
+    assert "node_start" in types
+    assert "node_finish" in types

--- a/quartermaster-sdk/tests/test_v022_tool_streaming.py
+++ b/quartermaster-sdk/tests/test_v022_tool_streaming.py
@@ -1,0 +1,375 @@
+"""Tests for v0.2.2 live tool-call streaming.
+
+Covers the four new surface guarantees introduced in v0.2.2:
+
+1. The engine's new ``ToolCallStarted`` / ``ToolCallFinished`` events
+   arrive during ``qm.run.stream(...)`` as typed
+   :class:`ToolCallChunk` / :class:`ToolResultChunk` chunks, in the
+   correct ordering relative to ``NodeStartChunk`` / ``NodeFinishChunk``
+   / ``DoneChunk``.
+2. A tool that raises surfaces via ``ToolResultChunk.error`` (non-None)
+   while ``.result`` carries the ``[ERROR: ...]`` sentinel string the
+   model sees on the next turn.
+3. The non-streaming ``qm.run(...)`` path populates the agent node's
+   ``NodeResult.data["tool_calls"]`` with the same shape as the streaming
+   events — so callers reading ``result["agent"].data["tool_calls"]``
+   after a sync run get the exact same record the stream surfaced.
+4. Provider-side tool-name prefixes (``default_api:``, ``functions:``,
+   ``mcp:``) are stripped in BOTH the streamed ``ToolCallChunk.tool`` AND
+   the sync ``data["tool_calls"][0]["tool"]`` — so UIs never show the
+   internal namespacing.
+
+A :class:`MockProvider` primed with two ``NativeResponse`` entries
+simulates an AgentExecutor loop: first turn requests a tool, second
+turn returns plain text and terminates the loop.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, ToolCall, TokenResponse
+
+
+# ── Test fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+def _tool_aware_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Build a :class:`ProviderRegistry` whose :class:`MockProvider`
+    replays a two-turn agent loop:
+
+    * turn 1 — model returns one ``ToolCall(tool_name, parameters)``
+    * turn 2 — model returns final text with ``tool_calls=[]`` so the
+      agent executor terminates.
+
+    ``final_text`` lands on ``NodeResult.output_text`` and on
+    ``Result.text`` so the test can assert the flow completed.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg, mock
+
+
+class _OkTool:
+    """A tool that returns a structured success payload the agent
+    executor's ``_execute_tool_call`` will surface as both the LLM-facing
+    prompt string AND the ``raw`` dict on ``ToolCallFinished``."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True, "echo": "hello"}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        # Agent executor reads ``result.data`` for structured payload.
+        r.data = dict(self._data)
+        return r
+
+
+class _RaisingTool:
+    """A tool whose ``safe_run`` raises — exercises the
+    ``[ERROR: ...]`` + ``error`` branch of ``_execute_tool_call``."""
+
+    def safe_run(self, **kwargs: Any):
+        raise RuntimeError("boom")
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's expected interface:
+    ``.get(name) → tool`` and ``.to_openai_tools() → list[dict]``.
+
+    Registered names here are the *stripped* public names (``"x"``),
+    mirroring how integrators register tools in production — the prefix
+    normalisation happens inside the agent executor before lookup.
+    """
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise KeyError(name) from exc
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+def _graph_with_agent() -> Any:
+    """Build a ``start → user → agent(tools=["x"]) → end`` graph with a
+    captured agent output so non-streaming tests can read it back via
+    ``result["agent"]``."""
+    return (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+
+# ── 1. Streaming event ordering ──────────────────────────────────────
+
+
+class TestToolCallStreaming:
+    """The engine's new ``ToolCallStarted`` / ``ToolCallFinished`` events
+    must reach the SDK stream as typed :class:`ToolCallChunk` /
+    :class:`ToolResultChunk` in the expected ordering."""
+
+    def test_tool_call_events_fire_during_stream(self):
+        reg, _ = _tool_aware_registry(
+            tool_name="x",
+            tool_args={"q": "hello"},
+            final_text="Done.",
+        )
+        qm.configure(registry=reg)
+
+        tool_reg = _ToolRegistry({"x": _OkTool({"ok": True, "echo": "hi"})})
+        graph = _graph_with_agent()
+
+        chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
+        types = [c.type for c in chunks]
+
+        # We expect, in order:
+        #   node_start (agent) → tool_call (x) → tool_result (x) →
+        #   node_finish (agent) → done
+        # Other node_start/finish pairs (e.g. user input passthrough)
+        # may appear but the agent-scoped subsequence must be intact.
+        assert "node_start" in types, f"no node_start in {types}"
+        assert "tool_call" in types, f"no tool_call in {types}"
+        assert "tool_result" in types, f"no tool_result in {types}"
+        assert "node_finish" in types, f"no node_finish in {types}"
+        assert types[-1] == "done", f"expected done last, got {types}"
+
+        # Ordering: the tool_call chunk must come AFTER at least one
+        # node_start (the agent node was started) and BEFORE the done.
+        tool_call_idx = types.index("tool_call")
+        tool_result_idx = types.index("tool_result")
+        first_node_start_idx = types.index("node_start")
+        done_idx = types.index("done")
+        assert first_node_start_idx < tool_call_idx < tool_result_idx < done_idx, (
+            f"out-of-order chunks: {types}"
+        )
+        # tool_result immediately pairs with tool_call — nothing else
+        # may slip between them for a synchronous tool.
+        assert tool_result_idx == tool_call_idx + 1, (
+            f"tool_result must immediately follow tool_call, got: {types}"
+        )
+
+        # Payload shape on the two new chunk types.
+        tool_call_chunk = next(c for c in chunks if c.type == "tool_call")
+        assert isinstance(tool_call_chunk, qm.ToolCallChunk)
+        assert tool_call_chunk.tool == "x"
+        assert tool_call_chunk.args == {"q": "hello"}
+
+        tool_result_chunk = next(c for c in chunks if c.type == "tool_result")
+        assert isinstance(tool_result_chunk, qm.ToolResultChunk)
+        assert tool_result_chunk.tool == "x"
+        assert tool_result_chunk.error is None
+        # ``result`` carries the structured ``raw`` payload when the
+        # tool returned a success envelope — mirrors ``_event_to_chunk``.
+        assert tool_result_chunk.result == {"ok": True, "echo": "hi"}
+
+
+# ── 2. Error surfacing ───────────────────────────────────────────────
+
+
+class TestToolErrorChunk:
+    """When the tool raises, ``ToolResultChunk.error`` carries the error
+    message and ``.result`` carries the ``[ERROR: ...]`` sentinel the
+    LLM sees on the next turn."""
+
+    def test_tool_call_error_surfaces_via_result_chunk_error(self):
+        reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+        qm.configure(registry=reg)
+
+        tool_reg = _ToolRegistry({"x": _RaisingTool()})
+        graph = _graph_with_agent()
+
+        chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
+        tool_result = next((c for c in chunks if c.type == "tool_result"), None)
+        assert tool_result is not None, "no tool_result chunk emitted"
+        assert isinstance(tool_result, qm.ToolResultChunk)
+
+        # The raising tool path sets ``error`` to the exception message,
+        # and ``result`` to the ``[ERROR: ...]`` sentinel fed back to the
+        # LLM (since ``raw`` is None on failure, the chunk's ``result``
+        # falls back to the prompt-facing sentinel).
+        assert tool_result.error is not None, "error must be non-None on failure"
+        assert "boom" in tool_result.error
+        assert isinstance(tool_result.result, str)
+        assert tool_result.result.startswith("[ERROR:"), (
+            f"expected [ERROR: ...] sentinel, got {tool_result.result!r}"
+        )
+
+
+# ── 3. Non-streaming run populates data["tool_calls"] ────────────────
+
+
+class TestNonStreamingToolCallCapture:
+    """``qm.run(graph, ...)`` (sync) populates
+    ``result["agent"].data["tool_calls"]`` with the same shape the
+    streaming events carry — so callers don't need to choose between
+    streaming vs introspection."""
+
+    def test_nonstreaming_run_populates_tool_calls_on_capture(self):
+        reg, _ = _tool_aware_registry(
+            tool_name="x",
+            tool_args={"q": "world"},
+            final_text="wrapped",
+        )
+        qm.configure(registry=reg)
+
+        tool_reg = _ToolRegistry({"x": _OkTool({"value": 42})})
+        graph = _graph_with_agent()
+
+        result = qm.run(graph, "hi", tool_registry=tool_reg)
+        assert result.success, result.error
+        assert result.text == "wrapped"
+
+        agent_capture = result["agent"]
+        tool_calls = agent_capture.data.get("tool_calls")
+        assert isinstance(tool_calls, list), (
+            f"expected data['tool_calls'] to be a list, got {type(tool_calls)}"
+        )
+        assert len(tool_calls) == 1, f"expected exactly 1 tool call, got {tool_calls}"
+
+        entry = tool_calls[0]
+        # Keys exactly match the ToolCallFinished event fields so both
+        # surfaces (streaming chunks + NodeResult data) stay in sync.
+        expected_keys = {"tool", "arguments", "result", "raw", "error", "iteration"}
+        assert set(entry) == expected_keys, (
+            f"keys mismatch — missing {expected_keys - set(entry)}, "
+            f"extra {set(entry) - expected_keys}"
+        )
+        assert entry["tool"] == "x"
+        assert entry["arguments"] == {"q": "world"}
+        assert entry["error"] is None
+        assert entry["raw"] == {"value": 42}
+        assert entry["iteration"] == 1
+
+
+# ── 4. Prefix normalisation on BOTH surfaces ─────────────────────────
+
+
+class TestToolPrefixNormalisation:
+    """The provider sometimes emits ``default_api:list_orders`` (Gemma
+    family) or ``functions:foo`` (OpenAI native) or ``mcp:foo`` (MCP
+    bridge).  The engine strips the prefix before dispatching the tool
+    AND before emitting ``ToolCallStarted`` / ``ToolCallFinished``, so
+    BOTH the streamed ``ToolCallChunk.tool`` and the sync
+    ``data['tool_calls'][0]['tool']`` show the bare public name."""
+
+    def test_tool_prefix_normalised_in_events(self):
+        reg, _ = _tool_aware_registry(
+            tool_name="default_api:list_orders",
+            tool_args={"status": "open"},
+            final_text="ack",
+        )
+        qm.configure(registry=reg)
+
+        # Tool is registered under the BARE name "list_orders" — the
+        # prefix is a provider-side quirk, not something integrators
+        # choose when they register tools.
+        tool_reg = _ToolRegistry(
+            {"list_orders": _OkTool({"orders": [1, 2, 3]})},
+            schema_name="list_orders",
+        )
+        graph = (
+            qm.Graph("chat")
+            .user()
+            .agent("Tooled", tools=["list_orders"], capture_as="agent")
+            .build()
+        )
+
+        # --- Streaming surface: ToolCallChunk.tool is stripped ---
+        chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
+        tool_call_chunk = next(
+            (c for c in chunks if c.type == "tool_call"), None
+        )
+        assert tool_call_chunk is not None, "no tool_call chunk emitted"
+        assert isinstance(tool_call_chunk, qm.ToolCallChunk)
+        assert tool_call_chunk.tool == "list_orders", (
+            f"prefix should be stripped in streaming event, got {tool_call_chunk.tool!r}"
+        )
+
+        # --- Non-streaming surface: data['tool_calls'][0]['tool'] ---
+        # Re-run for the sync path (the streamed run already drained the
+        # mock's queued native responses).
+        reg2, _ = _tool_aware_registry(
+            tool_name="default_api:list_orders",
+            tool_args={"status": "open"},
+            final_text="ack",
+        )
+        qm.configure(registry=reg2)
+        tool_reg2 = _ToolRegistry(
+            {"list_orders": _OkTool({"orders": [1, 2, 3]})},
+            schema_name="list_orders",
+        )
+        result = qm.run(graph, "hi", tool_registry=tool_reg2)
+        assert result.success, result.error
+        tool_calls = result["agent"].data["tool_calls"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["tool"] == "list_orders", (
+            "prefix should be stripped in NodeResult.data['tool_calls'], "
+            f"got {tool_calls[0]['tool']!r}"
+        )


### PR DESCRIPTION
Closes two \`⚠️\` items from the downstream Sorex ERP playbook (see \`quartermaster-020-agent-playbook.md\` in the Sorex repo, §8.1 and §8.4).

## 1. Live tool-call streaming

\`ToolCallChunk\` / \`ToolResultChunk\` classes existed in \`quartermaster_sdk\` since v0.2.0 but the engine never emitted matching \`FlowEvent\`s. Chat UIs that wanted live "calling tool X..." cards had to read \`result.captures[...].data\` after \`DoneChunk\`, defeating the streaming UX.

This PR wires the full path:

- New events \`ToolCallStarted(tool, arguments, iteration)\` and \`ToolCallFinished(tool, arguments, result, raw, error, iteration)\`
- Fired by \`AgentExecutor\` around every tool dispatch
- \`ExecutionContext.on_tool_start\` / \`on_tool_finish\` callbacks (mirror of \`on_token\`)
- \`FlowRunner\` wires them to \`_emit\` — no new plumbing for consumers
- SDK \`_event_to_chunk\` translates them to \`ToolCallChunk\` / \`ToolResultChunk\` in \`qm.run.stream(...)\`
- Tool-name prefix normalisation (\`default_api:list_orders\` → \`list_orders\`) happens BEFORE emission so streaming chunks and post-run \`data[\"tool_calls\"]\` agree

**Plus:** non-streaming \`qm.run(...)\` now populates structured \`tool_calls\` on \`NodeResult.data\`. Callers that don't stream still get a queryable tool history — no more parsing the prompt's \`<tool_result>\` log.

## 2. Async runner

\`qm.arun(graph, user_input)\` and \`qm.arun.stream(graph, user_input)\` shipped as first-class async variants. Django / FastAPI async views no longer need \`asgiref.sync.sync_to_async(qm.run)(...)\` wrappers.

- \`arun\` → \`asyncio.to_thread(runner.run, ..., flow_id=...)\` — pre-generated flow_id so cancellation can \`runner.stop(flow_id)\` from the \`asyncio.CancelledError\` handler
- \`arun.stream\` → runs FlowRunner on a worker thread, marshals \`FlowEvent\`s back via \`loop.call_soon_threadsafe(queue.put_nowait, ...)\` into an \`asyncio.Queue\` — the event loop stays responsive
- Clean teardown on cancel/break (shielded 5s drain matching the sync path's \`thread.join(timeout=5.0)\`)

## Tests

- \`test_v022_tool_streaming.py\` — 4 new tests pin the streaming order, error surfacing, non-streaming capture shape, prefix normalisation
- \`test_v022_async_runner.py\` — 2 new tests: \`arun\` returns \`Result\`, \`arun.stream\` yields typed chunks

**Full sweep green:** 432 engine + 89 SDK + 232 graph + 241 providers = 994 tests.

## After merge

Click Actions → Publish to PyPI → Run workflow, \`bump=patch\` → ships **v0.2.2** with these features.