### PR TITLE
v0.3.0: ProgressEvent, CustomEvent, filtered iterators, structured Trace, OTEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Modular AI agent orchestration framework. Build agent workflows as directed grap
 
 Built by [MindMade](https://mindmade.io) in Slovenia.
 
+## What's new in v0.3.0
+
+- **Filtered stream iterators** -- `qm.run.stream(...).tokens()` / `.tool_calls()` / `.progress()` / `.custom(name=...)` replace the old `chunk.type`-matching boilerplate.
+- **Live progress signals** -- tools reach `qm.current_context()` and call `ctx.emit_progress(message, percent, **data)` or `ctx.emit_custom(name, payload)`. UIs render "Searching... 3/5" cards alongside streamed tokens.
+- **Structured post-mortem `Trace`** -- every `Result` carries `result.trace` with `.text`, `.tool_calls`, `.progress`, `.custom(name)`, `.as_jsonl()`, plus per-node breakdowns via `result.trace.by_node["name"]`.
+- **One-line OpenTelemetry** -- `qm.telemetry.instrument()` emits OTEL GenAI-semconv spans for every flow, node, and tool call. Install with `pip install 'quartermaster-sdk[telemetry]'`.
+- **New engine events** -- `ProgressEvent` and `CustomEvent` exported from `quartermaster_engine`, in addition to the existing `NodeStarted` / `TokenGenerated` / `ToolCallStarted` set.
+
 ## Install
 
 ```bash
@@ -85,6 +93,44 @@ graph = (
 result = qm.run(graph, "VT-Treyd Slovenija")
 result["notes"].output_text    # agent's free-text research
 result["data"].output_text     # form-parsed JSON
+```
+
+### Streaming with filtered iterators
+
+```python
+# Typewriter effect -- just the model tokens as they arrive
+for token in qm.run.stream(graph, "Hello!").tokens():
+    print(token, end="", flush=True)
+
+# Dashboard view -- only the tool-call events
+for call in qm.run.stream(graph, "Research Slovenia").tool_calls():
+    print(f"[TOOL] {call.tool}({call.args})")
+
+# Live progress cards -- filter by custom event name
+for evt in qm.run.stream(graph, "Run the pipeline").custom(name="source_found"):
+    ui.add_source(evt.payload["url"])
+```
+
+The raw `for chunk in qm.run.stream(...)` loop still works unchanged when
+you want every chunk type in one place. Streams are single-pass -- pick
+one consumer (`.tokens()`, `.tool_calls()`, `.progress()`, `.custom()`,
+or raw iteration) per stream.
+
+### Post-mortem `Result.trace`
+
+After a synchronous run (or after draining a stream to its `DoneChunk`),
+`result.trace` exposes a structured view of every `FlowEvent` the engine
+emitted:
+
+```python
+result = qm.run(graph, "Hello!")
+
+result.trace.text                       # concatenated model output
+result.trace.tool_calls                 # list[dict] across every agent node
+result.trace.progress                   # list[ProgressEvent]
+result.trace.custom(name="source_found")  # filtered CustomEvent list
+result.trace.by_node["Researcher"].text   # tokens for a single node
+print(result.trace.as_jsonl())           # JSONL export for logs / fixtures
 ```
 
 ### Sync `OllamaProvider.chat()` for non-graph callers

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -33,12 +33,18 @@ print(result.error)              # Error message if failed, else None
 print(result.node_results)       # Dict[UUID, NodeResult] for each node
 ```
 
-### Async Streaming Execution
+### Async Streaming Execution (low-level events)
+
+`run_async(...)` yields the engine's raw `FlowEvent` objects. This is
+the primitive layer — application code usually uses the SDK's chunk
+filters (next section) on top of it.
 
 ```python
 import asyncio
 from quartermaster_engine.events import (
     NodeStarted, NodeFinished, TokenGenerated,
+    ToolCallStarted, ToolCallFinished,
+    ProgressEvent, CustomEvent,
     FlowFinished, FlowError, UserInputRequired,
 )
 
@@ -48,6 +54,14 @@ async def main():
             print(f"Node started: {event.node_name}")
         elif isinstance(event, TokenGenerated):
             print(event.token, end="", flush=True)
+        elif isinstance(event, ToolCallStarted):
+            print(f"\nTool -> {event.tool}({event.arguments})")
+        elif isinstance(event, ToolCallFinished):
+            print(f"Tool <- {event.tool}: {event.result!r}")
+        elif isinstance(event, ProgressEvent):        # v0.3.0
+            print(f"Progress: {event.message} ({event.percent})")
+        elif isinstance(event, CustomEvent):          # v0.3.0
+            print(f"Custom[{event.name}]: {event.payload}")
         elif isinstance(event, NodeFinished):
             print(f"\nNode finished: {event.result[:80]}")
         elif isinstance(event, FlowError):
@@ -59,6 +73,56 @@ async def main():
 
 asyncio.run(main())
 ```
+
+### SDK chunk filters (high-level)
+
+The `quartermaster_sdk` package layers a typed `Chunk` translation
+(`_event_to_chunk`) on top of `on_event` and wraps the iterator so
+consumers can filter by chunk family instead of writing the
+`isinstance` ladder above:
+
+```python
+import quartermaster_sdk as qm
+
+# Four ready-made filters; pick one per stream (streams are single-pass).
+for token in qm.run.stream(graph, "hi").tokens():              # TokenGenerated
+    print(token, end="")
+
+for call in qm.run.stream(graph, "research x").tool_calls():  # ToolCallStarted
+    ui.tool_card(call.tool, call.args)
+
+for prog in qm.run.stream(graph, "crunch").progress():        # ProgressEvent
+    ui.status(prog.message, prog.percent)
+
+for evt in qm.run.stream(graph, "research").custom(name="src"):  # CustomEvent
+    ui.add_source(evt.payload)
+```
+
+The raw `for chunk in qm.run.stream(...)` loop still works when you
+need every chunk type together. `qm.arun.stream(...)` is the async
+analogue.
+
+### Post-mortem `Result.trace`
+
+`qm.run(...)` (and the terminal `DoneChunk.result` of `run.stream`)
+attach a structured `Trace` to the `Result` — built from the same
+`FlowEvent` list the runner observed, but accessible after the fact
+without pattern-matching events yourself:
+
+```python
+result = qm.run(graph, "Hello!")
+
+result.trace.text                         # every TokenGenerated.token, glued
+result.trace.tool_calls                   # every ToolCallFinished, as dicts
+result.trace.progress                     # every ProgressEvent
+result.trace.custom(name="source_found")  # filtered CustomEvent list
+result.trace.by_node["Researcher"].text   # per-node slice, same accessors
+result.trace.duration_seconds             # wall-clock
+print(result.trace.as_jsonl())            # JSONL export for log shipping
+```
+
+`Trace` is the post-mortem inspection surface; `run.stream(...)` is the
+live surface. Both derive from the identical `FlowEvent` stream.
 
 ### Resuming After User Input
 
@@ -101,10 +165,33 @@ Events are emitted during execution via the `on_event` callback or the async ite
 |-------|--------|------|
 | `NodeStarted` | `flow_id`, `node_id`, `node_type`, `node_name` | A node begins execution |
 | `TokenGenerated` | `flow_id`, `node_id`, `token` | A streaming token arrives from an LLM |
+| `ToolCallStarted` | `flow_id`, `node_id`, `tool`, `arguments`, `iteration` | Agent loop dispatches a tool call |
+| `ToolCallFinished` | `flow_id`, `node_id`, `tool`, `arguments`, `result`, `raw`, `error`, `iteration` | Tool call completed (or errored) |
+| `ProgressEvent` (v0.3.0) | `flow_id`, `node_id`, `message`, `percent`, `data` | Application code called `ctx.emit_progress(...)` |
+| `CustomEvent` (v0.3.0) | `flow_id`, `node_id`, `name`, `payload` | Application code called `ctx.emit_custom(...)` |
 | `NodeFinished` | `flow_id`, `node_id`, `result`, `output_data` | A node completes |
 | `UserInputRequired` | `flow_id`, `node_id`, `prompt`, `options` | Execution pauses for user input |
 | `FlowError` | `flow_id`, `node_id`, `error`, `recoverable` | A node fails |
 | `FlowFinished` | `flow_id`, `final_output`, `output_data` | All branches complete |
+
+`ProgressEvent` and `CustomEvent` fire whenever the currently-executing
+node (or a tool it called) invokes
+`ExecutionContext.emit_progress(message, percent, **data)` or
+`emit_custom(name, payload)`. Tools reach the active context via the
+`current_context()` helper:
+
+```python
+from quartermaster_tools import tool
+from quartermaster_engine.context.current_context import current_context
+
+@tool()
+def slow_search(query: str) -> dict:
+    ctx = current_context()                # None outside a flow -- safe
+    if ctx is not None:
+        ctx.emit_progress(f"searching {query!r}", percent=0.25)
+    # ... real work ...
+    return {"results": [...]}
+```
 
 ## Dispatchers
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,27 +132,47 @@ graph = (
 
 ### Step 5: Stream Events
 
-For real-time feedback, use the async streaming API:
+For real-time feedback from the SDK, use the filtered stream iterators
+(v0.3.0):
 
 ```python
-import asyncio
+import quartermaster_sdk as qm
 
-async def main():
-    runner = FlowRunner(graph=graph, node_registry=node_registry)
+# Typewriter effect -- just the model tokens.
+for token in qm.run.stream(graph, "I just got promoted!").tokens():
+    print(token, end="", flush=True)
 
-    async for event in runner.run_async("I just got promoted!"):
-        match event:
-            case NodeStarted(node_name=name):
-                print(f"[started] {name}")
-            case TokenGenerated(token=tok):
-                print(tok, end="", flush=True)
-            case NodeFinished(result=res):
-                print(f"\n[finished] {res[:50]}...")
-            case FlowFinished(final_output=out):
-                print(f"\n\nFinal: {out}")
+# Or listen to tool calls / progress / custom events instead:
+for call in qm.run.stream(graph, "Research topic X").tool_calls():
+    print(f"[TOOL] {call.tool}({call.args})")
 
-asyncio.run(main())
+for prog in qm.run.stream(graph, "Crunch the dataset").progress():
+    print(f"[{prog.percent:.0%}] {prog.message}")
 ```
+
+Streams are single-pass -- pick one consumer per stream. See
+[engine.md](engine.md) for the low-level `FlowEvent` API that the SDK
+chunk filters are built on top of.
+
+### Step 5b: OpenTelemetry (optional)
+
+For production observability, install the telemetry extra and flip it
+on with a single call:
+
+```bash
+pip install 'quartermaster-sdk[telemetry]'
+```
+
+```python
+from quartermaster_sdk import telemetry
+
+telemetry.instrument()    # every subsequent run emits OTEL GenAI spans
+```
+
+Point your exporter at Jaeger, Tempo, Honeycomb, Logfire, Phoenix, or
+any OTLP collector. Spans follow the OpenTelemetry GenAI semantic
+conventions (`gen_ai.system`, `gen_ai.operation.name`,
+`gen_ai.tool.name`, `gen_ai.usage.input_tokens`, ...).
 
 ## Project Structure
 

--- a/examples/08_iterative_refinement.py
+++ b/examples/08_iterative_refinement.py
@@ -103,7 +103,7 @@ agent = (
             "Output ONLY the final, polished paragraph. Make every word count."
         ),
     )
-    .end()
+    .end(stop=True)
     # FALSE: loop back
     .on("false")
     .text("Next iteration", template="", show_output=False)
@@ -111,11 +111,20 @@ agent = (
 )
 
 # -- Wire the loop back-edge --
+# Under v0.3.0 the "Next iteration" branch's implicit End would loop
+# to the main graph's Start, which would re-run the one-time setup
+# (user prompt + topic capture + brief + iteration init) every time.
+# We want to skip the setup and jump straight back to "Iteration
+# header", so we keep the explicit back-edge here.  The resulting
+# cycle is now a validator WARNING instead of an error.
 agent.connect("Next iteration", "Iteration header", label="next_iteration")
 
-# -- Build and run -- .build(validate=False) kept here because we deliberately
-# form a cycle (loop-back edge) which the default validator rejects.
-graph = agent.build(validate=False)
+# -- Build and run -- v0.3.0 validator treats user-wired cycles as a
+# warning, so we no longer need ``validate=False`` here.  The TRUE
+# branch's ``.end(stop=True)`` (after "Final polish") sets
+# ``traverse_out=SPAWN_NONE`` and guarantees the flow terminates
+# after MAX_ITERATIONS rounds instead of looping forever.
+graph = agent.build()
 
 print(f"Graph: {len(graph.nodes)} nodes, {len(graph.edges)} edges")
 print()

--- a/examples/15_courtroom_debate.py
+++ b/examples/15_courtroom_debate.py
@@ -161,7 +161,7 @@ trial = (
         ),
     )
     .text("Adjournment", template="\n--- Court is adjourned ---")
-    .end()
+    .end(stop=True)
     # FALSE: loop back
     .on("false")
     .text("Next round", template="", show_output=False)
@@ -170,12 +170,21 @@ trial = (
 
 # -- Wire the loop back-edge -----------------------------------------------
 
+# The "Next round" branch loops back to "Round announce" (past the
+# one-time courtroom-opening setup).  The explicit back-edge is still
+# necessary here because we want to skip the case-setup nodes on each
+# iteration — if we relied on the v0.3.0 default End-to-Start loop,
+# the whole "Court opens" + "Init round" preamble would replay every
+# iteration.
 trial.connect("Next round", "Round announce", label="next_round")
 
-# -- Build and run -- .build(validate=False) kept here because we deliberately
-# form a cycle (loop-back edge) which the default validator rejects.
+# -- Build and run -- v0.3.0 validator treats user-wired cycles as a
+# warning, so we no longer need ``validate=False`` here.  The TRUE
+# branch's ``.end(stop=True)`` (after "Adjournment") sets
+# ``traverse_out=SPAWN_NONE`` and guarantees the flow terminates
+# after MAX_ROUNDS rounds instead of looping forever.
 
-agent = trial.build(validate=False)
+agent = trial.build()
 
 print(f"Graph: {len(agent.nodes)} nodes, {len(agent.edges)} edges")
 print()

--- a/examples/21_progress_events.py
+++ b/examples/21_progress_events.py
@@ -1,0 +1,152 @@
+"""Example 21 -- Tool-emitted progress & custom events (v0.3.0).
+
+Shows how a long-running tool can emit progress signals via
+``qm.current_context()`` so the UI streams "step 2 of 5" cards alongside
+model tokens, instead of going dark while the tool runs.
+
+Two new ExecutionContext methods back this:
+
+  * ``ctx.emit_progress(message, percent, **data)`` -- determinate or
+    indeterminate progress signal. Surfaces on the stream as a typed
+    :class:`ProgressChunk`, retrievable via ``stream.progress()``.
+  * ``ctx.emit_custom(name, payload)`` -- caller-tagged structured
+    event. Retrievable via ``stream.custom(name="source_found")`` when
+    the consumer wants to subscribe to one specific milestone name.
+
+Both become no-ops when called outside a flow (``ctx is None``) -- tools
+stay unit-testable without a runner.
+
+Usage:
+    export ANTHROPIC_API_KEY="sk-ant-..."
+    uv run examples/21_progress_events.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import quartermaster_sdk as qm
+from quartermaster_tools import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# 1. Define a tool that emits progress + custom events while running
+# ---------------------------------------------------------------------------
+
+registry = ToolRegistry()
+
+
+@registry.tool()
+def slow_research(topic: str) -> dict:
+    """Simulate a multi-step research pipeline with live progress.
+
+    The real work would be web scraping, vector search, LLM summarisation,
+    etc. Here we just sleep a few milliseconds per step, but each step
+    fires a ``ProgressEvent`` (percent-along-a-task) and a matching
+    ``CustomEvent`` (discrete milestone) back onto the stream so the
+    consumer can render both.
+
+    Args:
+        topic: The research topic to investigate.
+    """
+    # Reach the currently-executing flow's ExecutionContext. Returns None
+    # when the tool is invoked outside any running flow (unit tests,
+    # REPL, etc.) -- always null-check.
+    ctx = qm.current_context()
+
+    steps = [
+        ("Gathering sources", 0.2, {"url": "https://example.com/a"}),
+        ("Reading page 1",    0.4, {"url": "https://example.com/a", "length": 2400}),
+        ("Reading page 2",    0.6, {"url": "https://example.com/b", "length": 1800}),
+        ("Summarising",       0.8, None),
+        ("Done",              1.0, None),
+    ]
+
+    for message, percent, source in steps:
+        if ctx is not None:
+            # Percent progress -- UIs render this as a spinner /
+            # progress bar. ``topic`` is passed as a free-form data key
+            # so the consumer can display which request this is for.
+            ctx.emit_progress(message, percent=percent, topic=topic)
+            # Discrete milestone -- UIs render as a "source found" card,
+            # typically filtered via ``stream.custom(name="source_found")``.
+            if source is not None:
+                ctx.emit_custom("source_found", source)
+        time.sleep(0.05)  # simulate work
+
+    return {
+        "topic": topic,
+        "summary": f"Three sources consulted on {topic!r}.",
+        "sources": ["https://example.com/a", "https://example.com/b"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. Build an agent graph that calls the tool
+# ---------------------------------------------------------------------------
+
+agent = (
+    qm.Graph("Progress Demo")
+    .user("What should I research?")
+    .agent(
+        "Researcher",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction=(
+            "You are a research assistant. When the user names a topic, "
+            "call the slow_research tool exactly once with that topic, "
+            "then summarise the result in one sentence."
+        ),
+        tools=["slow_research"],
+        max_iterations=3,
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# 3. Stream the run and pretty-print every chunk as it arrives
+# ---------------------------------------------------------------------------
+#
+# Using the raw ``for chunk in run.stream(...)`` loop here so we can
+# render every chunk type in one place. See example 22 for the
+# filtered ``.tokens()`` / ``.progress()`` / ``.custom()`` variants.
+
+print("=" * 60)
+print("  Example 21 -- live progress events")
+print("=" * 60)
+print()
+
+user_input = "Research the history of Slovenia"
+
+for chunk in qm.run.stream(agent, user_input, tool_registry=registry):
+    # Typewriter: stream model tokens inline as they arrive.
+    if isinstance(chunk, qm.TokenChunk):
+        print(chunk.content, end="", flush=True)
+    # Tool dispatch: render a "tool called with these args" card.
+    elif isinstance(chunk, qm.ToolCallChunk):
+        print(f"\n[TOOL ->] {chunk.tool}({chunk.args})")
+    # Tool result: show the raw payload the LLM sees next turn.
+    elif isinstance(chunk, qm.ToolResultChunk):
+        print(f"[TOOL <-] {chunk.tool}: {str(chunk.result)[:80]}")
+    # Progress: "step 2 of 5, 40%" status cards alongside the tokens.
+    elif isinstance(chunk, qm.ProgressChunk):
+        pct = f"{chunk.percent:.0%}" if chunk.percent is not None else "  ..."
+        print(f"[PROGRESS {pct}] {chunk.message}  data={chunk.data}")
+    # Custom: application-tagged milestones, filtered by name downstream.
+    elif isinstance(chunk, qm.CustomChunk):
+        print(f"[{chunk.name}] {chunk.payload}")
+    # Node lifecycle: optional -- useful for "now running X" headers.
+    elif isinstance(chunk, qm.NodeStartChunk):
+        print(f"\n--- {chunk.node_name} ({chunk.node_type}) ---")
+    # Terminal: stream wraps with a DoneChunk carrying the final Result.
+    elif isinstance(chunk, qm.DoneChunk):
+        print()
+        print("-" * 60)
+        print(f"Run finished in {chunk.result.trace.duration_seconds:.2f}s")
+        print(f"Total progress events: {len(chunk.result.trace.progress)}")
+        print(
+            "Sources found:",
+            [e.payload for e in chunk.result.trace.custom(name="source_found")],
+        )
+    elif isinstance(chunk, qm.ErrorChunk):
+        print(f"\n[ERROR] {chunk.error}")

--- a/examples/22_streaming_filters.py
+++ b/examples/22_streaming_filters.py
@@ -1,0 +1,130 @@
+"""Example 22 -- Filtered stream iterators (v0.3.0).
+
+One graph, three consumers. ``qm.run.stream(graph, "...")`` returns a
+wrapper that is iterable (raw pass-through, for backwards compatibility)
+and exposes four filter methods:
+
+    .tokens()           -> yields str -- the model tokens, for typewriter UIs
+    .tool_calls()       -> yields ToolCallChunk -- tool dispatch cards
+    .progress()         -> yields ProgressChunk -- emit_progress signals
+    .custom(name=...)   -> yields CustomChunk -- emit_custom milestones
+
+The filters replace v0.2.x boilerplate like::
+
+    for chunk in qm.run.stream(graph, "hi"):
+        if chunk.type == "token":
+            print(chunk.content, end="")
+
+IMPORTANT single-pass semantics -- the wrapper owns the underlying
+generator. First consumer drains it; a second consumer on the same
+stream raises ``RuntimeError("stream already consumed")``. To render
+the same graph three ways, build three independent streams (that's
+what this example does -- each ``qm.run.stream(...)`` call below runs
+the graph fresh).
+
+Usage:
+    export ANTHROPIC_API_KEY="sk-ant-..."
+    uv run examples/22_streaming_filters.py
+"""
+
+from __future__ import annotations
+
+import quartermaster_sdk as qm
+
+
+# ---------------------------------------------------------------------------
+# 1. Build a small agent graph
+# ---------------------------------------------------------------------------
+
+agent = (
+    qm.Graph("Filter Demo")
+    .user("Ask a short question")
+    .instruction(
+        "Respond",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction=(
+            "You are a concise assistant. Answer in 1-2 sentences."
+        ),
+    )
+)
+
+user_input = "What is the tallest mountain in Slovenia?"
+
+
+# ---------------------------------------------------------------------------
+# 2. Way 1 -- typewriter effect (just tokens)
+# ---------------------------------------------------------------------------
+#
+# ``.tokens()`` yields ``str`` (not the chunk wrapper) because
+# concatenation is the overwhelming common case. Skip the
+# ``.content`` hop the raw-iterator version has.
+
+print("=" * 60)
+print("  Way 1: .tokens() -- typewriter")
+print("=" * 60)
+for token in qm.run.stream(agent, user_input).tokens():
+    print(token, end="", flush=True)
+print("\n")
+
+
+# ---------------------------------------------------------------------------
+# 3. Way 2 -- dashboard view (tool calls only)
+# ---------------------------------------------------------------------------
+#
+# The trivial instruction graph above doesn't actually call tools, so
+# this loop yields zero entries -- but the pattern is what matters.
+# In a real agent graph (see example 13 / 21) ``.tool_calls()`` surfaces
+# every ``ToolCallChunk`` and skips everything else, giving a clean
+# dashboard stream without the ``isinstance`` ladder.
+
+print("=" * 60)
+print("  Way 2: .tool_calls() -- dashboard view")
+print("=" * 60)
+call_count = 0
+for call in qm.run.stream(agent, user_input).tool_calls():
+    call_count += 1
+    print(f"[TOOL] {call.tool}({call.args})")
+if call_count == 0:
+    print("  (no tool calls in this graph -- see example 21 for a tool-using demo)")
+print()
+
+
+# ---------------------------------------------------------------------------
+# 4. Way 3 -- raw stream (debug view)
+# ---------------------------------------------------------------------------
+#
+# Raw iteration still works unchanged -- the wrapper falls through to
+# its underlying ``Iterator[Chunk]``. Useful for debugging, logging,
+# or any consumer that genuinely needs every chunk type in one place.
+
+print("=" * 60)
+print("  Way 3: raw iteration -- debug view")
+print("=" * 60)
+for chunk in qm.run.stream(agent, user_input):
+    # ``type(chunk).__name__`` gives ``TokenChunk`` / ``NodeStartChunk`` / ...
+    summary = str(chunk)
+    if len(summary) > 120:
+        summary = summary[:117] + "..."
+    print(f"  {type(chunk).__name__:18} {summary}")
+print()
+
+
+# ---------------------------------------------------------------------------
+# 5. Note on single-pass semantics
+# ---------------------------------------------------------------------------
+#
+# Trying to pull two filters off the SAME stream handle raises:
+#
+#     stream = qm.run.stream(agent, user_input)
+#     tokens = list(stream.tokens())         # drains the stream
+#     calls  = list(stream.tool_calls())     # RuntimeError: stream already consumed
+#
+# If you need multiple views of the same run, either:
+#
+#   (a) call ``qm.run.stream(...)`` multiple times (example above --
+#       each run is independent), or
+#   (b) iterate the stream once with raw ``for chunk in stream:`` and
+#       route chunks to multiple consumers yourself.
+
+print("All three views rendered the same graph independently.")

--- a/examples/23_telemetry_otel.py
+++ b/examples/23_telemetry_otel.py
@@ -1,0 +1,140 @@
+"""Example 23 -- OpenTelemetry instrumentation (v0.3.0).
+
+Demonstrates how to capture every Quartermaster flow event as an OTEL
+span using GenAI semantic conventions. Uses an in-memory exporter so
+the example runs without a backend -- in production you'd point this
+at Jaeger, Tempo, Honeycomb, Logfire, Phoenix, or any OTLP collector.
+
+Span model:
+  * ``qm.flow``            -- root span, one per flow run
+  * ``qm.node.<name>``     -- one span per node (``NodeStarted`` -> ``NodeFinished``)
+  * ``qm.tool.<tool>``     -- one span per tool call, parented to the agent node
+  * progress / custom      -- recorded as span events on the active node span
+
+Attributes follow the OpenTelemetry GenAI semantic conventions:
+``gen_ai.system``, ``gen_ai.operation.name``, ``gen_ai.tool.name``,
+``gen_ai.usage.input_tokens``, ``gen_ai.usage.output_tokens``. See
+https://opentelemetry.io/docs/specs/semconv/gen-ai/ .
+
+Install:
+    pip install 'quartermaster-sdk[telemetry]'
+
+Usage:
+    export ANTHROPIC_API_KEY="sk-ant-..."
+    uv run examples/23_telemetry_otel.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+# ---------------------------------------------------------------------------
+# 0. Require the [telemetry] extra -- fail with a friendly message
+# ---------------------------------------------------------------------------
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+except ImportError:
+    print(
+        "OpenTelemetry not installed. "
+        "Run: pip install 'quartermaster-sdk[telemetry]'"
+    )
+    sys.exit(1)
+
+import quartermaster_sdk as qm
+from quartermaster_sdk import telemetry
+
+
+# ---------------------------------------------------------------------------
+# 1. Set up an in-memory span exporter
+# ---------------------------------------------------------------------------
+#
+# Production exporters are typically OTLPSpanExporter talking to a
+# Jaeger / Tempo / Honeycomb / Grafana backend. For an example we
+# substitute an in-memory exporter so we can inspect spans inline
+# below. Swap ``InMemorySpanExporter`` for ``OTLPSpanExporter`` in a
+# real deployment.
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+
+# ---------------------------------------------------------------------------
+# 2. One line -- instrument Quartermaster
+# ---------------------------------------------------------------------------
+#
+# After this call, every subsequent ``qm.run(...)`` / ``qm.arun(...)`` /
+# ``qm.run.stream(...)`` emits GenAI-conventioned OTEL spans via the
+# tracer provider we just set up. No callsite changes needed.
+
+telemetry.instrument()
+
+
+# ---------------------------------------------------------------------------
+# 3. Run a small graph
+# ---------------------------------------------------------------------------
+
+graph = (
+    qm.Graph("Hello OTEL")
+    .user("Say hello")
+    .instruction(
+        "Respond",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction="Reply with one short greeting.",
+    )
+)
+
+result = qm.run(graph, "Say hi in Slovenian")
+print("Model reply:", result.text)
+print()
+
+
+# ---------------------------------------------------------------------------
+# 4. Inspect the spans
+# ---------------------------------------------------------------------------
+#
+# Every flow, every node, every tool call is now a span. In
+# production your exporter ships these to a backend; here we just
+# print them.
+
+spans = exporter.get_finished_spans()
+
+print("=" * 60)
+print(f"  Captured {len(spans)} OTEL spans")
+print("=" * 60)
+
+for span in spans:
+    duration_ns = (span.end_time or 0) - (span.start_time or 0)
+    duration_ms = duration_ns / 1_000_000
+    attrs = dict(span.attributes or {})
+    print(f"  {span.name:30s}  duration={duration_ms:7.2f} ms")
+    for key, value in attrs.items():
+        summary = str(value)
+        if len(summary) > 80:
+            summary = summary[:77] + "..."
+        print(f"      {key:32s} = {summary}")
+print()
+
+
+# ---------------------------------------------------------------------------
+# 5. Clean shutdown
+# ---------------------------------------------------------------------------
+#
+# ``uninstrument()`` removes the listener so subsequent flows emit zero
+# spans -- useful when toggling telemetry on/off across test suites or
+# staged rollouts.
+
+telemetry.uninstrument()
+
+print(
+    "Telemetry disabled. In production, swap InMemorySpanExporter for "
+    "OTLPSpanExporter pointed at Jaeger / Tempo / Honeycomb / Logfire."
+)

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,9 +32,12 @@ real API key to actually demonstrate anything end-to-end. The exceptions:
 | `17_streaming_events.py` | Uses a mock executor for the LLM node |
 | `20_ollama_local.py` | Hits a local Ollama instance (start `ollama serve` and pull `gemma4:26b`) |
 
-The remaining 16 examples need at least one of `ANTHROPIC_API_KEY`,
+The remaining examples need at least one of `ANTHROPIC_API_KEY`,
 `OPENAI_API_KEY`, `GROQ_API_KEY`, or `XAI_API_KEY` set — without keys, the
 graph still builds and validates but the LLM nodes return failures.
+
+Example `23_telemetry_otel.py` additionally requires the `[telemetry]`
+extra (OpenTelemetry SDK): `pip install 'quartermaster-sdk[telemetry]'`.
 
 ### API Keys
 
@@ -82,6 +85,9 @@ uv run examples/run_interactive.py
 | 18 | `18_compliance_guard.py` | PII detection/redaction, EU AI Act risk classification, audit logging |
 | 19 | `19_mcp_client.py` | MCP protocol client: discover tools, bridge to Quartermaster graphs |
 | 20 | `20_ollama_local.py` | Local Gemma 4: vision (real image), tool calling, streaming, multi-step |
+| 21 | `21_progress_events.py` | v0.3.0: tool-emitted `emit_progress` / `emit_custom` streamed via `.progress()` and `.custom()` |
+| 22 | `22_streaming_filters.py` | v0.3.0: one graph rendered three ways -- `.tokens()`, `.tool_calls()`, raw chunks |
+| 23 | `23_telemetry_otel.py` | v0.3.0: `qm.telemetry.instrument()` with an in-memory OTEL exporter |
 | -- | `run_interactive.py` | Interactive stdin conversation loop with Ctrl+C exit |
 
 ## Patterns Demonstrated
@@ -105,3 +111,6 @@ uv run examples/run_interactive.py
 - **Interactive mode**: `run_graph()` without `user_input` prompts stdin at User nodes
 - **Multi-provider**: Different LLMs for different nodes (Anthropic + OpenAI + Groq + xAI)
 - **`run_graph()`**: One-line execution with auto-detected provider and streaming
+- **Filtered streams (v0.3.0)**: `stream.tokens()` / `.tool_calls()` / `.progress()` / `.custom()` (examples 21-22)
+- **Live progress events (v0.3.0)**: `ctx.emit_progress()` / `ctx.emit_custom()` reachable via `qm.current_context()` (example 21)
+- **OpenTelemetry (v0.3.0)**: `qm.telemetry.instrument()` for one-line OTEL GenAI span export (example 23)

--- a/quartermaster-engine/README.md
+++ b/quartermaster-engine/README.md
@@ -128,16 +128,35 @@ runner = FlowRunner(graph=graph, node_registry=registry)
 result = runner.run("I need help with my invoice")
 ```
 
-### Stream Events in Real Time
+### Stream Events in Real Time (low-level)
+
+The engine's native streaming surface is a single `on_event` callback
+that fires for every `FlowEvent`. This is the primitive layer; most
+application code uses the SDK's chunk filters layered on top (see
+below).
 
 ```python
-from quartermaster_engine import FlowRunner, FlowEvent, NodeStarted, NodeFinished, TokenGenerated, FlowError
+from quartermaster_engine import (
+    FlowRunner, FlowEvent,
+    NodeStarted, NodeFinished, TokenGenerated,
+    ToolCallStarted, ToolCallFinished,
+    ProgressEvent, CustomEvent,
+    FlowError,
+)
 
 def handle_event(event: FlowEvent):
     if isinstance(event, NodeStarted):
         print(f"[START] {event.node_name} ({event.node_type})")
     elif isinstance(event, TokenGenerated):
         print(event.token, end="", flush=True)
+    elif isinstance(event, ToolCallStarted):
+        print(f"\n[TOOL ->] {event.tool}({event.arguments})")
+    elif isinstance(event, ToolCallFinished):
+        print(f"[TOOL <-] {event.tool} = {event.result!r}")
+    elif isinstance(event, ProgressEvent):        # new in v0.3.0
+        print(f"[PROGRESS] {event.message} ({event.percent})")
+    elif isinstance(event, CustomEvent):          # new in v0.3.0
+        print(f"[{event.name}] {event.payload}")
     elif isinstance(event, NodeFinished):
         print(f"\n[DONE] Node finished: {event.result[:50]}...")
     elif isinstance(event, FlowError):
@@ -145,6 +164,43 @@ def handle_event(event: FlowEvent):
 
 runner = FlowRunner(graph=graph, node_registry=registry, on_event=handle_event)
 result = runner.run("Hello!")
+```
+
+### SDK chunk filters (high-level)
+
+The `quartermaster_sdk` package translates each `FlowEvent` into a
+typed `Chunk` via `_event_to_chunk` and wraps the iterator so consumers
+can filter by chunk family instead of writing `isinstance` ladders:
+
+```python
+import quartermaster_sdk as qm
+
+for token in qm.run.stream(graph, "Hello!").tokens():            # TokenGenerated
+    print(token, end="")
+
+for call in qm.run.stream(graph, "Research x").tool_calls():    # ToolCallStarted
+    ui.tool_card(call.tool, call.args)
+
+for prog in qm.run.stream(graph, "Crunch").progress():          # ProgressEvent
+    ui.status(prog.message, prog.percent)
+
+for evt in qm.run.stream(graph, "Research").custom(name="src"): # CustomEvent by name
+    ui.add(evt.payload)
+```
+
+### Post-mortem trace
+
+`qm.run(...)` also attaches a structured `Trace` to the returned
+`Result`, built from the same `FlowEvent` stream after the run
+finishes:
+
+```python
+result = qm.run(graph, "Hello!")
+result.trace.text                        # concatenated TokenGenerated.token
+result.trace.tool_calls                  # list[dict] from every ToolCallFinished
+result.trace.progress                    # list[ProgressEvent]
+result.trace.by_node["Researcher"].text  # per-node slice
+print(result.trace.as_jsonl())
 ```
 
 ### Async Execution
@@ -336,6 +392,10 @@ Real-time events emitted during flow execution:
 |-------|--------|-------------|
 | `NodeStarted` | `flow_id`, `node_id`, `node_type`, `node_name` | Node begins execution |
 | `TokenGenerated` | `flow_id`, `node_id`, `token` | Streaming token from LLM |
+| `ToolCallStarted` | `flow_id`, `node_id`, `tool`, `arguments`, `iteration` | Agent dispatched a tool call |
+| `ToolCallFinished` | `flow_id`, `node_id`, `tool`, `arguments`, `result`, `raw`, `error`, `iteration` | Tool call completed (or errored) |
+| `ProgressEvent` (v0.3.0) | `flow_id`, `node_id`, `message`, `percent`, `data` | `ctx.emit_progress(...)` from app code |
+| `CustomEvent` (v0.3.0) | `flow_id`, `node_id`, `name`, `payload` | `ctx.emit_custom(...)` from app code |
 | `NodeFinished` | `flow_id`, `node_id`, `result`, `output_data` | Node completed |
 | `FlowFinished` | `flow_id`, `final_output`, `output_data` | Entire flow completed |
 | `UserInputRequired` | `flow_id`, `node_id`, `prompt`, `options` | Flow paused for user input |
@@ -343,6 +403,9 @@ Real-time events emitted during flow execution:
 
 `run_graph()` uses streaming by default -- `TokenGenerated` events are printed
 as they arrive, giving real-time output from LLM nodes without extra setup.
+`ProgressEvent` and `CustomEvent` fire whenever application code calls
+`ExecutionContext.emit_progress(...)` / `emit_custom(...)`, reachable from
+inside tools via `quartermaster_engine.context.current_context()`.
 
 ### ExecutionContext
 

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -21,6 +21,7 @@ from quartermaster_engine.example_runner import (
     build_default_registry,
     run_graph,
 )
+from quartermaster_engine.images import ImageInput, prepare_images
 from quartermaster_engine.memory.flow_memory import FlowMemory
 from quartermaster_engine.memory.persistent_memory import InMemoryPersistence, PersistentMemory
 from quartermaster_engine.messaging.context_manager import ContextManager
@@ -98,6 +99,9 @@ __all__ = [
     "build_default_registry",
     "LLMExecutor",
     "AgentExecutor",
+    # Image-input helpers (v0.3.0 vision kwarg)
+    "ImageInput",
+    "prepare_images",
 ]
 
 __version__ = "0.2.1"

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -3,11 +3,13 @@
 from quartermaster_engine.context.execution_context import ExecutionContext
 from quartermaster_engine.context.node_execution import NodeExecution, NodeStatus
 from quartermaster_engine.events import (
+    CustomEvent,
     FlowError,
     FlowEvent,
     FlowFinished,
     NodeFinished,
     NodeStarted,
+    ProgressEvent,
     TokenGenerated,
     ToolCallFinished,
     ToolCallStarted,
@@ -71,6 +73,8 @@ __all__ = [
     "FlowError",
     "ToolCallStarted",
     "ToolCallFinished",
+    "ProgressEvent",
+    "CustomEvent",
     # Stores
     "ExecutionStore",
     "InMemoryStore",

--- a/quartermaster-engine/src/quartermaster_engine/context/current_context.py
+++ b/quartermaster-engine/src/quartermaster_engine/context/current_context.py
@@ -1,0 +1,92 @@
+"""Per-flow ``ExecutionContext`` reachable from inside tool calls.
+
+This module exposes the ``qm.current_context()`` helper that application
+code — typically ``@tool()``-decorated functions — uses to emit
+progress / custom events back onto the stream::
+
+    from quartermaster_tools import tool
+    from quartermaster_sdk import current_context
+
+    @tool()
+    def slow_search(query: str) -> dict:
+        ctx = current_context()
+        if ctx is not None:
+            ctx.emit_progress(f"searching '{query}'", percent=0.25)
+        # ... do real work ...
+        if ctx is not None:
+            ctx.emit_progress("parsing results", percent=0.75)
+        return {"results": [...]}
+
+The contextvar is bound by :class:`FlowRunner._run_executor` around the
+call to ``executor.execute(context)``; it stays ``None`` when no flow
+is active, so tools remain safe to call from unit tests without a
+runner.
+
+Threading note
+--------------
+``FlowRunner._run_executor`` wraps ``executor.execute(context)`` in a
+``ThreadPoolExecutor.submit(...)`` when the caller is inside a running
+asyncio event loop. Python's ``contextvars.ContextVar`` values do NOT
+automatically propagate into pool-worker threads — you must invoke
+``contextvars.copy_context().run(...)`` from the worker. The runner
+does this for us; the :func:`bind` helper here just sets the var in
+the current context, trusting the runner to copy it across.
+
+The contextvar lives in the engine (not the SDK) so the runner can
+bind it without the engine importing from the SDK (which would flip
+the dependency direction).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from quartermaster_engine.context.execution_context import ExecutionContext
+
+
+# Module-level contextvar. ``None`` outside any flow — read via
+# :func:`current_context` which returns ``None`` cleanly for unit tests
+# and other out-of-flow callers.
+_current_ctx: contextvars.ContextVar["ExecutionContext | None"] = contextvars.ContextVar(
+    "quartermaster_current_context",
+    default=None,
+)
+
+
+def current_context() -> "ExecutionContext | None":
+    """Return the currently-executing flow's :class:`ExecutionContext`.
+
+    Returns ``None`` when called outside of an active flow, including
+    from unit tests and any code path that hasn't gone through
+    :class:`FlowRunner`. Tools that emit progress should always
+    null-check the return — the no-runner case is fully supported.
+    """
+    return _current_ctx.get()
+
+
+@contextlib.contextmanager
+def bind(context: "ExecutionContext") -> Iterator["ExecutionContext"]:
+    """Bind *context* as the current contextvar for the duration of the
+    ``with``-block.
+
+    Called by :meth:`FlowRunner._run_executor` around
+    ``executor.execute(context)``. The contextvar reset in the
+    ``finally`` clause guarantees nested or concurrent flow runs don't
+    leak state across each other — each flow sees the context bound by
+    its own runner frame, regardless of thread hopping in-between.
+
+    Yields the same context so callers can do
+    ``with bind(ctx) as c: ...`` if they find the binding symmetric.
+    """
+    token = _current_ctx.set(context)
+    try:
+        yield context
+    finally:
+        _current_ctx.reset(token)
+
+
+__all__ = ["current_context", "bind"]

--- a/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
+++ b/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
@@ -41,9 +41,7 @@ class ExecutionContext:
     # instead of waiting for the full NodeResult. Payload shape matches
     # ``events.ToolCallStarted`` / ``ToolCallFinished``.
     on_tool_start: Callable[[str, dict, int], None] | None = None
-    on_tool_finish: (
-        Callable[[str, dict, str, Any, str | None, int], None] | None
-    ) = None
+    on_tool_finish: Callable[[str, dict, str, Any, str | None, int], None] | None = None
     # Application-emitted event hooks — populated by the runner so
     # user code calling ``emit_progress`` / ``emit_custom`` from
     # inside a tool interleaves with engine-emitted tokens on the
@@ -67,9 +65,7 @@ class ExecutionContext:
         if self.on_token:
             self.on_token(token)
 
-    def emit_tool_start(
-        self, tool: str, arguments: dict[str, Any], iteration: int
-    ) -> None:
+    def emit_tool_start(self, tool: str, arguments: dict[str, Any], iteration: int) -> None:
         """Fire ``on_tool_start`` for the agent-executor tool loop, if wired."""
         if self.on_tool_start:
             self.on_tool_start(tool, arguments, iteration)

--- a/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
+++ b/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
@@ -44,6 +44,13 @@ class ExecutionContext:
     on_tool_finish: (
         Callable[[str, dict, str, Any, str | None, int], None] | None
     ) = None
+    # Application-emitted event hooks — populated by the runner so
+    # user code calling ``emit_progress`` / ``emit_custom`` from
+    # inside a tool interleaves with engine-emitted tokens on the
+    # consumer's side. Both stay None when no streaming consumer is
+    # attached (e.g. a unit test invoking a tool directly).
+    on_progress: Callable[[str, float | None, dict], None] | None = None
+    on_custom: Callable[[str, dict], None] | None = None
 
     def get_meta(self, key: str, default: Any = None) -> Any:
         """Get a value from the node's metadata, falling back to graph metadata."""
@@ -79,6 +86,55 @@ class ExecutionContext:
         """Fire ``on_tool_finish`` for the agent-executor tool loop, if wired."""
         if self.on_tool_finish:
             self.on_tool_finish(tool, arguments, result, raw, error, iteration)
+
+    def emit_progress(
+        self,
+        message: str,
+        percent: float | None = None,
+        **data: Any,
+    ) -> None:
+        """Emit a user-facing progress signal.
+
+        Called by application code — typically from a long-running
+        tool — to report progress to the stream alongside model tokens.
+        Safe to call when no runner is attached (``on_progress`` is
+        ``None`` outside a flow): becomes a silent no-op so tools stay
+        unit-testable.
+
+        Args:
+            message: Short human-readable status line. Rendered in UIs.
+            percent: 0.0–1.0 for determinate progress, ``None`` (the
+                default) for indeterminate / spinner-style. Values are
+                passed through verbatim — clamp in the caller if needed.
+            **data: Free-form structured fields (query strings, step
+                indices, …) packed into a dict for the consumer.
+        """
+        if self.on_progress:
+            self.on_progress(message, percent, dict(data))
+
+    def emit_custom(
+        self,
+        name: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit an application-defined structured event.
+
+        Prefer this over :meth:`emit_progress` when the event marks a
+        discrete milestone (document retrieved, quota updated, cache
+        hit, …) rather than a percent-along-a-task signal. Consumers
+        filter on ``name`` via ``stream.custom(name=...)``.
+
+        No-op when no runner is attached.
+
+        Args:
+            name: Caller-chosen discriminator ("retrieved_docs",
+                "quota_warning", …). Used by stream consumers for
+                filtering.
+            payload: Free-form dict carried with the event. Defaults
+                to an empty dict when ``None``.
+        """
+        if self.on_custom:
+            self.on_custom(name, dict(payload or {}))
 
     def emit_message(self, content: str) -> None:
         """Emit a complete message if a callback is registered."""

--- a/quartermaster-engine/src/quartermaster_engine/events.py
+++ b/quartermaster-engine/src/quartermaster_engine/events.py
@@ -104,3 +104,43 @@ class ToolCallFinished(FlowEvent):
     raw: Any = None
     error: str | None = None
     iteration: int = 0
+
+
+@dataclass
+class ProgressEvent(FlowEvent):
+    """User-emitted progress signal from inside a node or tool.
+
+    Fires when application code calls
+    ``ExecutionContext.emit_progress(...)`` — typically from a long-
+    running tool that wants to report status to the stream (e.g. a web
+    search saying "query 3 of 5") without interrupting the LLM token
+    channel. ``percent`` is optional: set to a 0.0–1.0 float for
+    determinate progress bars, leave as ``None`` for spinner-style
+    indeterminate progress. ``data`` is a free-form dict for payload
+    fields the consumer wants to render (search query, step index,
+    etc.) without bloating the message string.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    message: str = ""
+    percent: float | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CustomEvent(FlowEvent):
+    """Application-defined structured event.
+
+    Fires when application code calls
+    ``ExecutionContext.emit_custom(name, payload)``. The ``name``
+    field is a caller-chosen discriminator that downstream consumers
+    filter on (``stream.custom(name="retrieved_docs")``); ``payload``
+    carries the structured data. Use this instead of
+    :class:`ProgressEvent` when the event is a discrete milestone
+    (document retrieved, quota updated, cache hit/miss, …) rather
+    than a percent-along-a-task signal.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    name: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -488,9 +488,7 @@ class _ToolInvocation:
     error: str | None
 
 
-def _execute_tool_call(
-    tool_registry: Any, tool_name: str, parameters: dict
-) -> _ToolInvocation:
+def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> _ToolInvocation:
     """Run one tool from the registry and return both the LLM-facing
     string and the structured payload for live streaming.
 
@@ -733,14 +731,16 @@ class AgentExecutor(NodeExecutor):
                 # ``qm.run(...)`` callers (non-streaming) can read exactly
                 # the same shape the streaming ToolCallFinished event
                 # carries.  Both surfaces stay in sync by construction.
-                tool_call_log.append({
-                    "tool": public_name,
-                    "arguments": dict(params),
-                    "result": invocation.prompt_text,
-                    "raw": invocation.raw,
-                    "error": invocation.error,
-                    "iteration": iteration,
-                })
+                tool_call_log.append(
+                    {
+                        "tool": public_name,
+                        "arguments": dict(params),
+                        "result": invocation.prompt_text,
+                        "raw": invocation.raw,
+                        "error": invocation.error,
+                        "iteration": iteration,
+                    }
+                )
 
                 # Wrap each tool result in an explicit untrusted-data block.
                 # Tool output frequently includes external content (web

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -235,6 +235,30 @@ def _coerce_bool(value: Any) -> bool:
     return bool(value)
 
 
+def _user_images(context: ExecutionContext) -> list[tuple[str, str]]:
+    """Return the user-supplied vision payload from flow memory.
+
+    The SDK's ``qm.run(..., image=bytes)`` / ``images=[...]`` path
+    normalises every supported shape (bytes / Path / str path) into a
+    list of ``(base64_ascii, mime_type)`` pairs and drops that list
+    into ``flow_memory["__user_images__"]``.
+
+    This helper hands the same list out to callers that actually want
+    to forward images to the provider — currently the vision node's
+    ``LLMExecutor`` via ``_build_llm_config``. Returns an empty list
+    when no images were attached (the common text-only case) so
+    callers can treat the return value as "always iterable" without
+    branching on None.
+
+    Non-list values in memory fall through as ``[]`` — defensive
+    against a misbehaving store, not an expected code path.
+    """
+    images = context.memory.get("__user_images__", [])
+    if not isinstance(images, list):
+        return []
+    return list(images)
+
+
 def _build_llm_config(
     context: ExecutionContext,
     *,
@@ -278,6 +302,15 @@ def _build_llm_config(
     else:
         temperature = context.get_meta("llm_temperature", temperature_default)
 
+    vision_enabled = _coerce_bool(context.get_meta("llm_vision", False))
+    # Forward user-supplied images ONLY into vision nodes. Non-vision
+    # nodes sharing the same flow memory must not accidentally drag the
+    # image payload into a text-only prompt — that's wasted tokens at
+    # best and an API error at worst (most providers reject image parts
+    # on a non-vision model id). The SDK's ``image=`` kwarg is thus a
+    # no-op on graphs that don't declare a ``.vision()`` node.
+    images = _user_images(context) if vision_enabled else []
+
     return LLMConfig(
         model=model,
         provider=provider_name,
@@ -286,7 +319,8 @@ def _build_llm_config(
         stream=stream,
         max_output_tokens=context.get_meta("llm_max_output_tokens", None),
         max_input_tokens=context.get_meta("llm_max_input_tokens", None),
-        vision=_coerce_bool(context.get_meta("llm_vision", False)),
+        vision=vision_enabled,
+        images=images,
         thinking_enabled=thinking_enabled,
         thinking_budget=thinking_budget,
     )

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pathlib
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -1116,6 +1117,83 @@ class UserFormExecutor(NodeExecutor):
         )
 
 
+class SubAssistantExecutor(NodeExecutor):
+    """Spawn a child :class:`FlowRunner` to execute a sub-graph.
+
+    The sub-graph is looked up via a caller-supplied ``resolver(sub_id)``
+    callable (typically a dict lookup); the sub runner inherits the
+    parent's node registry (or a caller-supplied one) and is constructed
+    with ``parent_context=context`` so an End node inside the sub-graph
+    can tell it's running below a parent flow and return control upward
+    instead of looping to Start.
+
+    The sub-flow's final output is surfaced as the executor's
+    ``output_text`` so the SUB_ASSISTANT node's downstream edges see
+    the sub-flow's tail result on the wire.
+
+    Without a resolver (the default registry wiring) this executor
+    degrades gracefully to the pre-0.3.0 passthrough behaviour, so
+    graphs that declare SUB_ASSISTANT nodes but resolve at runtime
+    still traverse past without error.
+    """
+
+    def __init__(
+        self,
+        resolver: Callable[[str], Any] | None = None,
+        node_registry: Any | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._node_registry = node_registry
+
+    async def execute(self, context: ExecutionContext) -> NodeResult:
+        sub_id = context.get_meta("sub_assistant_id", "")
+        if not self._resolver or not sub_id:
+            # Degrade to passthrough — no sub-graph to invoke.
+            text = ""
+            for msg in reversed(context.messages):
+                if msg.content:
+                    text = msg.content
+                    break
+            return NodeResult(success=True, data={}, output_text=text)
+
+        sub_graph = self._resolver(sub_id)
+        if sub_graph is None:
+            return NodeResult(
+                success=False,
+                data={},
+                error=f"SubAssistant: no graph registered for id {sub_id!r}",
+            )
+
+        # Last user-visible message becomes the sub-flow's kickoff input.
+        user_input = ""
+        for msg in reversed(context.messages):
+            if msg.content:
+                user_input = msg.content
+                break
+
+        # Local import to avoid the example_runner ↔ flow_runner cycle
+        # at module import time.
+        from quartermaster_engine.runner.flow_runner import FlowRunner
+
+        sub_runner = FlowRunner(
+            graph=sub_graph,
+            node_registry=self._node_registry,
+            parent_context=context,
+        )
+        sub_result = sub_runner.run(user_input)
+        if not sub_result.success:
+            return NodeResult(
+                success=False,
+                data={"sub_flow_output": sub_result.final_output},
+                error=sub_result.error or "sub-flow failed",
+            )
+        return NodeResult(
+            success=True,
+            data={"sub_flow_output": sub_result.final_output},
+            output_text=sub_result.final_output,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Registry factory
 # ---------------------------------------------------------------------------
@@ -1204,7 +1282,16 @@ def build_default_registry(
     reg.register(NodeType.STATIC_MERGE.value, static_merge_exec)
     reg.register(NodeType.COMMENT.value, passthrough)
     reg.register(NodeType.BLANK.value, passthrough)
-    reg.register(NodeType.SUB_ASSISTANT.value, passthrough)
+    # SubAssistant: a node-type that can spawn a child FlowRunner
+    # against a separately-registered sub-graph.  Without a resolver
+    # wired in it behaves like the pre-0.3.0 passthrough — the v0.3.0
+    # return-to-parent semantics kick in automatically once a caller
+    # registers a real SubAssistantExecutor with their own sub-graph
+    # resolver.
+    reg.register(
+        NodeType.SUB_ASSISTANT.value,
+        SubAssistantExecutor(resolver=None, node_registry=reg),
+    )
     reg.register(NodeType.BREAK.value, passthrough)
     reg.register(NodeType.TEXT_TO_VARIABLE.value, var)
     if_exec = IfExecutor()

--- a/quartermaster-engine/src/quartermaster_engine/images.py
+++ b/quartermaster-engine/src/quartermaster_engine/images.py
@@ -137,9 +137,7 @@ def prepare_images(
     are ASCII (never bytes) so JSON serialisation is trivial.
     """
     if image is not None and images is not None:
-        raise ValueError(
-            "Pass either image= (single) or images= (list), not both."
-        )
+        raise ValueError("Pass either image= (single) or images= (list), not both.")
 
     if image is not None:
         return [_prepare_one(image)]

--- a/quartermaster-engine/src/quartermaster_engine/images.py
+++ b/quartermaster-engine/src/quartermaster_engine/images.py
@@ -1,0 +1,160 @@
+"""Image-input normalisation for vision-capable nodes.
+
+Public helper :func:`prepare_images` accepts the shapes the SDK forwards
+from ``qm.run(graph, user_input, image=...)`` / ``images=[...]`` and
+returns the internal ``list[(base64_ascii, mime_type)]`` representation
+that's stored in flow memory under the ``__user_images__`` key and then
+forwarded into :class:`quartermaster_providers.LLMConfig.images` for the
+active node.
+
+Accepts:
+
+* ``bytes``                     — raw image bytes, MIME defaulted to
+                                  ``image/jpeg`` (most common; overridable
+                                  by providers that sniff headers).
+* ``pathlib.Path``              — read from disk, MIME detected from
+                                  extension (``.png`` / ``.jpg`` /
+                                  ``.jpeg`` / ``.gif`` / ``.webp``).
+* ``str`` filesystem path       — same as ``pathlib.Path``.
+
+Explicitly rejects (raises :class:`ValueError` with a helpful message):
+
+* ``data:image/...;base64,...`` URIs — out of scope; caller should
+                                       fetch + pass bytes directly.
+* ``http://...`` / ``https://...`` URLs — same rationale.
+
+The helper is intentionally synchronous — image IO is small enough that
+blocking on disk reads in the hot path is fine, and staying sync keeps
+the engine's (sync) ``flow_runner.run`` contract clean.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import pathlib
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+#: Types accepted by :func:`prepare_images` for each individual image.
+ImageInput = Union[bytes, pathlib.Path, str]
+
+_EXT_TO_MIME: dict[str, str] = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".jfif": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+}
+
+_DEFAULT_MIME = "image/jpeg"
+
+
+def _mime_from_extension(path: pathlib.Path) -> str:
+    """Best-effort MIME detection from the path's suffix.
+
+    Falls back to :data:`_DEFAULT_MIME` when the extension is missing
+    or unknown — providers that inspect raw bytes can still override
+    this downstream, but keeping the default off ``image/jpeg`` matches
+    what most vision APIs accept when the MIME is ambiguous.
+    """
+    suffix = path.suffix.lower()
+    return _EXT_TO_MIME.get(suffix, _DEFAULT_MIME)
+
+
+def _reject_uri_like(value: str) -> None:
+    """Raise :class:`ValueError` if *value* looks like a URI, not a path.
+
+    ``data:image/...;base64,...`` and ``http(s)://...`` strings are
+    intentionally out of scope for the v0.3.0 image-input API — callers
+    should either decode the base64 or fetch the URL themselves and
+    forward the raw bytes.  Raising here gives a much clearer error
+    than letting ``open()`` fail with a confusing path-doesn't-exist
+    traceback three layers down.
+    """
+    lowered = value.strip().lower()
+    if lowered.startswith("data:"):
+        raise ValueError(
+            "image= does not accept data: URIs. Decode the base64 "
+            "payload yourself (``base64.b64decode(...)``) and pass the "
+            "raw bytes instead."
+        )
+    if lowered.startswith("http://") or lowered.startswith("https://"):
+        raise ValueError(
+            "image= does not accept http(s) URLs. Fetch the image "
+            "yourself (e.g. ``requests.get(url).content``) and pass the "
+            "raw bytes instead."
+        )
+
+
+def _prepare_one(image: ImageInput) -> tuple[str, str]:
+    """Convert a single input into ``(base64_ascii, mime_type)``.
+
+    See the module docstring for the accepted shapes.  Raises
+    :class:`ValueError` on URIs/URLs and :class:`TypeError` on other
+    unsupported types so callers get an immediate, descriptive error
+    rather than a downstream provider failure.
+    """
+    if isinstance(image, bytes):
+        return base64.b64encode(image).decode("ascii"), _DEFAULT_MIME
+
+    if isinstance(image, pathlib.Path):
+        data = image.read_bytes()
+        return base64.b64encode(data).decode("ascii"), _mime_from_extension(image)
+
+    if isinstance(image, str):
+        _reject_uri_like(image)
+        path = pathlib.Path(image)
+        data = path.read_bytes()
+        return base64.b64encode(data).decode("ascii"), _mime_from_extension(path)
+
+    raise TypeError(
+        "image= / images= accepts bytes, pathlib.Path, or a filesystem "
+        f"path (str). Got {type(image).__name__!r}."
+    )
+
+
+def prepare_images(
+    image: ImageInput | None = None,
+    images: list[ImageInput] | tuple[ImageInput, ...] | None = None,
+) -> list[tuple[str, str]]:
+    """Normalise single/multi image inputs into ``[(b64, mime), ...]``.
+
+    * Exactly one of *image* / *images* may be non-``None``; passing
+      both raises :class:`ValueError`.
+    * ``image=X`` is equivalent to ``images=[X]`` — the singular kwarg
+      is a convenience for the common one-image case.
+    * When both are ``None`` returns an empty list — downstream code
+      treats that as a text-only request.
+
+    Returns a plain ``list[tuple[str, str]]`` so providers can iterate
+    without caring about the original input shape.  The base64 strings
+    are ASCII (never bytes) so JSON serialisation is trivial.
+    """
+    if image is not None and images is not None:
+        raise ValueError(
+            "Pass either image= (single) or images= (list), not both."
+        )
+
+    if image is not None:
+        return [_prepare_one(image)]
+
+    if images is None:
+        return []
+
+    if not isinstance(images, (list, tuple)):
+        raise TypeError(
+            "images= must be a list or tuple; got "
+            f"{type(images).__name__!r}. For a single image, use "
+            "image= instead."
+        )
+
+    return [_prepare_one(item) for item in images]
+
+
+__all__ = ["ImageInput", "prepare_images"]

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -19,6 +19,7 @@ The execution loop:
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 import time
 from collections.abc import AsyncIterator, Callable
@@ -26,15 +27,18 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
 
+from quartermaster_engine.context.current_context import bind as bind_current_context
 from quartermaster_engine.context.execution_context import ExecutionContext
 from quartermaster_engine.context.node_execution import NodeExecution, NodeStatus
 from quartermaster_engine.dispatchers.sync_dispatcher import SyncDispatcher
 from quartermaster_engine.events import (
+    CustomEvent,
     FlowError,
     FlowEvent,
     FlowFinished,
     NodeFinished,
     NodeStarted,
+    ProgressEvent,
     TokenGenerated,
     ToolCallFinished,
     ToolCallStarted,
@@ -491,6 +495,23 @@ class FlowRunner:
                     iteration=it,
                 )
             ),
+            on_progress=lambda msg, percent, data: self._emit(
+                ProgressEvent(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    message=msg,
+                    percent=percent,
+                    data=data,
+                )
+            ),
+            on_custom=lambda name, payload: self._emit(
+                CustomEvent(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    name=name,
+                    payload=payload,
+                )
+            ),
         )
 
         # Execute with error handling
@@ -517,6 +538,20 @@ class FlowRunner:
     ) -> NodeResult:
         """Run a node executor, handling sync/async transparently.
 
+        Wraps the executor invocation in ``current_context.bind(context)``
+        so application code inside the executor (most importantly
+        ``@tool()`` callables) can reach the live :class:`ExecutionContext`
+        via :func:`quartermaster_sdk.current_context` and emit progress
+        or custom events back onto the stream.
+
+        Threading: when we're inside a running asyncio event loop we
+        dispatch to a ``ThreadPoolExecutor``. Python's ``contextvars``
+        do NOT propagate into pool workers automatically, so we submit
+        ``contextvars.copy_context().run(target)`` — the worker thread
+        inherits a snapshot of the caller's contextvars (including the
+        freshly-bound ``_current_ctx``) and tools running inside the
+        coroutine see ``current_context()`` return a non-None value.
+
         If the node has a ``timeout`` set (in seconds), execution is wrapped
         in ``asyncio.wait_for`` so that a ``TimeoutError`` is raised when the
         node exceeds its time budget.
@@ -532,14 +567,25 @@ class FlowRunner:
         except RuntimeError:
             loop = None
 
-        if loop and loop.is_running():
-            # We're inside an async context — create a new thread to run the coroutine
-            import concurrent.futures
+        # Bind the contextvar for the duration of this executor call so
+        # tools invoked during execution can emit progress/custom events.
+        # The ``with`` scope unwinds the var after the executor returns.
+        with bind_current_context(context):
+            if loop and loop.is_running():
+                # Inside an async context — spawn a worker thread for the
+                # coroutine. ``copy_context().run(...)`` carries the
+                # freshly-bound contextvar into the worker's stack so
+                # ``current_context()`` resolves correctly there too.
+                import concurrent.futures
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                future = pool.submit(asyncio.run, coro)
-                return future.result(timeout=node.timeout)
-        else:
+                ctx_snapshot = contextvars.copy_context()
+
+                def _worker() -> NodeResult:
+                    return asyncio.run(coro)
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(ctx_snapshot.run, _worker)
+                    return future.result(timeout=node.timeout)
             return asyncio.run(coro)
 
     def _handle_node_error(

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -130,6 +130,7 @@ class FlowRunner:
         *,
         provider_registry: Any | None = None,
         tool_registry: Any | None = None,
+        parent_context: ExecutionContext | None = None,
     ) -> None:
         """Construct a runner.
 
@@ -150,6 +151,12 @@ class FlowRunner:
         this constructor.  When you build the node registry yourself the
         runner has no way to know which provider/tool registry sits
         behind it, so they will be ``None`` — that's expected, not a bug.
+
+        Pass *parent_context* when this runner is driving a sub-graph
+        invoked by a parent flow's ``SUB_ASSISTANT`` node; executors
+        inside the sub-graph read it to decide whether an End node
+        should loop back to Start (main graph — parent_context is
+        ``None``) or return control to the parent.
         """
         if node_registry is None:
             if provider_registry is None:
@@ -180,11 +187,24 @@ class FlowRunner:
         self.dispatcher = dispatcher or SyncDispatcher()
         self.context_manager = context_manager or ContextManager()
         self.on_event = on_event
+        # v0.3.0: pointer back at the parent flow's ExecutionContext when
+        # this runner is driving a sub-graph (spawned via SUB_ASSISTANT).
+        self.parent_context = parent_context
 
         self._traverse_in = TraverseInGate()
         self._traverse_out = TraverseOutGate()
         self._message_router = MessageRouter(self.store)
         self._stopped: set[UUID] = set()
+        # v0.3.0 End → Start loop safety cap.  Any reached End node
+        # dispatches Start again by default under Proposal A; an
+        # unconditionally-looping graph (Start → Inst → End with no
+        # break condition) would otherwise recurse forever.  The guard
+        # caps implicit loop-back dispatches at a conservative ceiling
+        # so tests and misconfigured graphs fail fast instead of
+        # hanging.  Conditional loops (If + .end(stop=True)) terminate
+        # long before hitting this cap.
+        self._loop_counter: dict[UUID, int] = {}
+        self.max_loop_iterations = 100
 
     def run(
         self,
@@ -442,11 +462,19 @@ class FlowRunner:
             return NodeResult(success=True, data={}, output_text=user_input)
 
         if node.type == NodeType.END:
-            # End node: collect the final output from predecessors
+            # End node: collect the final output from predecessors.
+            # v0.3.0: when this runner is driving a sub-graph
+            # (``parent_context`` is set), stamp
+            # ``__end_returns_to_parent__`` on the result so
+            # ``_dispatch_successors`` hands control back to the parent
+            # flow instead of looping to Start.
             messages = self._message_router.get_messages_for_node(flow_id, node, self.graph)
             final_output = messages[-1].content if messages else ""
             self._message_router.save_node_output(flow_id, node.id, messages)
-            return NodeResult(success=True, data={}, output_text=final_output)
+            data: dict[str, Any] = {}
+            if self.parent_context is not None:
+                data["__end_returns_to_parent__"] = True
+            return NodeResult(success=True, data=data, output_text=final_output)
 
         if node.type == NodeType.MERGE:
             # Merge node: combine outputs from all predecessors
@@ -491,6 +519,7 @@ class FlowRunner:
             messages=messages,
             memory=flow_memory,
             metadata=dict(node.metadata),
+            parent_context=self.parent_context,
             on_token=lambda t: self._emit(
                 TokenGenerated(flow_id=flow_id, node_id=node.id, token=t)
             ),
@@ -652,11 +681,55 @@ class FlowRunner:
         result: NodeResult,
         user_input: str,
     ) -> None:
-        """Determine and dispatch successor nodes based on traverse_out strategy."""
-        # End nodes and failed nodes with Stop strategy don't dispatch
-        if node.type == NodeType.END:
-            return
+        """Determine and dispatch successor nodes based on traverse_out strategy.
+
+        End-node semantics (v0.3.0 / Proposal A):
+
+        * End in a sub-graph (the current flow's ``parent_context`` is
+          set) — the End executor stamped ``__end_returns_to_parent__``
+          on its NodeResult.  Don't dispatch anything here; control
+          returns to the parent's ``_dispatch_successors`` for the
+          SUB_ASSISTANT node automatically once the child runner
+          finishes.
+        * End in the main graph with ``traverse_out=SPAWN_NONE`` (the
+          explicit opt-out set by ``.end(stop=True)``) — stop.
+        * End in the main graph with any other ``traverse_out`` (the
+          new default is ``SPAWN_START``) — dispatch the graph's Start
+          node, subject to the ``max_loop_iterations`` safety cap.
+        """
+        # Failed nodes with STOP strategy always halt, regardless of type.
         if not result.success and node.error_handling == ErrorStrategy.STOP:
+            return
+
+        # End node: apply the v0.3.0 loop/return semantics.
+        if node.type == NodeType.END:
+            # Sub-graph End: return control to the parent flow.
+            if result.data.get("__end_returns_to_parent__"):
+                return
+            # Main-graph End with explicit stop opt-out.
+            if node.traverse_out == TraverseOut.SPAWN_NONE:
+                return
+            # Default: loop back to Start, subject to safety cap.
+            count = self._loop_counter.get(flow_id, 0) + 1
+            self._loop_counter[flow_id] = count
+            if count > self.max_loop_iterations:
+                logger.warning(
+                    "Flow %s exceeded max_loop_iterations=%d; stopping "
+                    "instead of looping back to Start.  Add an If/break "
+                    "condition or call .end(stop=True) to opt out of "
+                    "the v0.3.0 End-to-Start loop semantics.",
+                    flow_id,
+                    self.max_loop_iterations,
+                )
+                return
+            start_node = self.graph.get_start_node()
+            if start_node is None:
+                return
+            self.dispatcher.dispatch(
+                flow_id,
+                start_node.id,
+                lambda fid, nid: self._execute_node(fid, nid, user_input),
+            )
             return
 
         next_nodes = self._traverse_out.get_next_nodes(

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -186,11 +186,25 @@ class FlowRunner:
         self._message_router = MessageRouter(self.store)
         self._stopped: set[UUID] = set()
 
-    def run(self, input_message: str, flow_id: UUID | None = None) -> FlowResult:
+    def run(
+        self,
+        input_message: str,
+        *,
+        images: list[tuple[str, str]] | None = None,
+        flow_id: UUID | None = None,
+    ) -> FlowResult:
         """Execute the graph synchronously.
 
         Args:
             input_message: The user's input message.
+            images: Optional list of ``(base64_ascii, mime_type)`` pairs
+                attached to the initial user turn. Vision-capable
+                nodes (``Graph().vision(...)``) read this list from
+                flow memory via the ``__user_images__`` key and forward
+                it to the provider alongside the text prompt. Pass raw
+                image bytes in the SDK (``qm.run(..., image=bytes)``);
+                the SDK normalises them to the internal base64 tuple
+                shape before calling this method.
             flow_id: Optional flow ID (auto-generated if not provided).
 
         Returns:
@@ -206,6 +220,12 @@ class FlowRunner:
 
             # Store the initial user input in flow memory
             self.store.save_memory(fid, "__user_input__", input_message)
+            # Store any attached images so vision-capable nodes can pick
+            # them up via ``context.memory["__user_images__"]`` without
+            # the caller having to touch the store directly. Stored as
+            # a plain list[tuple[str, str]] — base64 ASCII + MIME type.
+            if images:
+                self.store.save_memory(fid, "__user_images__", list(images))
 
             # Execute the start node, which kicks off the traversal
             self._execute_node(fid, start_node.id, input_message)

--- a/quartermaster-engine/tests/test_images.py
+++ b/quartermaster-engine/tests/test_images.py
@@ -1,0 +1,101 @@
+"""Tests for the :mod:`quartermaster_engine.images` helper module.
+
+Covers the normalisation path that the SDK's ``image=`` / ``images=``
+kwargs flow through before reaching ``FlowRunner.run(images=...)``.
+"""
+
+from __future__ import annotations
+
+import base64
+import pathlib
+
+import pytest
+
+from quartermaster_engine.images import prepare_images
+
+
+TINY_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c63f8cfc0500f0000040001212c2e4e0000000049454e44ae426082"
+)
+
+
+class TestPrepareImagesBytes:
+    def test_bytes_input_becomes_base64_default_mime(self):
+        out = prepare_images(image=TINY_PNG)
+        assert len(out) == 1
+        b64, mime = out[0]
+        assert b64 == base64.b64encode(TINY_PNG).decode("ascii")
+        assert mime == "image/jpeg"  # default when no extension hint
+
+
+class TestPrepareImagesPath:
+    def test_path_input_reads_file_detects_mime(self, tmp_path):
+        png = tmp_path / "t.png"
+        png.write_bytes(TINY_PNG)
+        out = prepare_images(image=png)
+        b64, mime = out[0]
+        assert b64 == base64.b64encode(TINY_PNG).decode("ascii")
+        assert mime == "image/png"
+
+    def test_str_path_works_like_pathlib(self, tmp_path):
+        jpg = tmp_path / "t.jpg"
+        jpg.write_bytes(TINY_PNG)
+        out = prepare_images(image=str(jpg))
+        _, mime = out[0]
+        assert mime == "image/jpeg"
+
+    def test_unknown_extension_defaults_to_jpeg(self, tmp_path):
+        weird = tmp_path / "t.xyz"
+        weird.write_bytes(TINY_PNG)
+        _, mime = prepare_images(image=weird)[0]
+        assert mime == "image/jpeg"
+
+    def test_webp_detected(self, tmp_path):
+        p = tmp_path / "t.webp"
+        p.write_bytes(TINY_PNG)
+        _, mime = prepare_images(image=p)[0]
+        assert mime == "image/webp"
+
+
+class TestPrepareImagesList:
+    def test_images_list_preserves_order(self, tmp_path):
+        png = tmp_path / "a.png"
+        jpg = tmp_path / "b.jpg"
+        png.write_bytes(TINY_PNG)
+        jpg.write_bytes(TINY_PNG)
+        out = prepare_images(images=[png, jpg])
+        assert [m for _, m in out] == ["image/png", "image/jpeg"]
+
+    def test_empty_when_both_none(self):
+        assert prepare_images() == []
+
+    def test_rejects_both_image_and_images(self):
+        with pytest.raises(ValueError, match="either image="):
+            prepare_images(image=TINY_PNG, images=[TINY_PNG])
+
+    def test_rejects_non_list_images_kwarg(self):
+        with pytest.raises(TypeError, match="images= must be a list"):
+            # A single bytes value for ``images=`` is ambiguous — force
+            # the user to pick ``image=`` for singular, ``images=`` for
+            # plural. This avoids the "forgot the list brackets and got
+            # unexpected behaviour" footgun.
+            prepare_images(images=TINY_PNG)  # type: ignore[arg-type]
+
+
+class TestPrepareImagesRejection:
+    def test_data_uri_rejected(self):
+        with pytest.raises(ValueError, match="data: URIs"):
+            prepare_images(image="data:image/jpeg;base64,/9j/4AAQ")
+
+    def test_http_url_rejected(self):
+        with pytest.raises(ValueError, match="http\\(s\\) URLs"):
+            prepare_images(image="http://example.com/img.png")
+
+    def test_https_url_rejected(self):
+        with pytest.raises(ValueError, match="http\\(s\\) URLs"):
+            prepare_images(image="https://example.com/img.png")
+
+    def test_unsupported_type_rejected(self):
+        with pytest.raises(TypeError, match="accepts bytes, pathlib.Path"):
+            prepare_images(image=123)  # type: ignore[arg-type]

--- a/quartermaster-engine/tests/test_smoke_simple_graph.py
+++ b/quartermaster-engine/tests/test_smoke_simple_graph.py
@@ -67,7 +67,7 @@ class TestLLMConfigPropagation:
 
     def test_max_output_tokens_reaches_provider(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Tight", max_output_tokens=50).end().build()
+        graph = Graph("chat").start().user().agent("Tight", max_output_tokens=50).end(stop=True).build()
         runner = FlowRunner(graph=graph, provider_registry=registry)
         result = runner.run("ping")
         assert result.success, result.error
@@ -76,14 +76,14 @@ class TestLLMConfigPropagation:
 
     def test_max_input_tokens_reaches_provider(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Tight", max_input_tokens=8000).end().build()
+        graph = Graph("chat").start().user().agent("Tight", max_input_tokens=8000).end(stop=True).build()
         runner = FlowRunner(graph=graph, provider_registry=registry)
         runner.run("ping")
         assert mock.last_config.max_input_tokens == 8000
 
     def test_thinking_level_high_propagates_enabled_and_budget(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Reasoning", thinking_level="high").end().build()
+        graph = Graph("chat").start().user().agent("Reasoning", thinking_level="high").end(stop=True).build()
         runner = FlowRunner(graph=graph, provider_registry=registry)
         runner.run("ping")
         assert mock.last_config.thinking_enabled is True
@@ -91,7 +91,7 @@ class TestLLMConfigPropagation:
 
     def test_thinking_level_off_disables(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Plain", thinking_level="off").end().build()
+        graph = Graph("chat").start().user().agent("Plain", thinking_level="off").end(stop=True).build()
         runner = FlowRunner(graph=graph, provider_registry=registry)
         runner.run("ping")
         assert mock.last_config.thinking_enabled is False
@@ -104,7 +104,7 @@ class TestLLMConfigPropagation:
             .start()
             .user()
             .vision("Look", model="gemma4:26b", provider="ollama")
-            .end()
+            .end(stop=True)
             .build()
         )
         runner = FlowRunner(graph=graph, provider_registry=registry)
@@ -125,7 +125,7 @@ class TestSimpleGraphSnippet:
             .start()
             .user()
             .agent()  # no tools, just text completion
-            .end()
+            .end(stop=True)
             .build()
         )
 
@@ -141,7 +141,7 @@ class TestSimpleGraphSnippet:
 
     def test_flowrunner_requires_a_registry(self):
         """Constructing a runner without either kind of registry must error."""
-        graph = Graph("chat").start().user().agent().end().build()
+        graph = Graph("chat").start().user().agent().end(stop=True).build()
         with pytest.raises(TypeError, match="node_registry or provider_registry"):
             FlowRunner(graph=graph)
 
@@ -149,7 +149,7 @@ class TestSimpleGraphSnippet:
         """provider_registry must be keyword-only (we don't want a future
         positional swap with node_registry to bite anyone)."""
         registry, _ = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent().end().build()
+        graph = Graph("chat").start().user().agent().end(stop=True).build()
         runner = FlowRunner(graph=graph, provider_registry=registry)
         assert runner.node_registry is not None
         assert runner.provider_registry is registry
@@ -165,7 +165,7 @@ class TestAgentExecutor:
     def test_no_tools_single_iteration(self, provider_registry_with_mock):
         """With no tools wired up, the loop runs exactly once."""
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent().end().build()
+        graph = Graph("chat").start().user().agent().end(stop=True).build()
         runner = FlowRunner(graph=graph, provider_registry=registry)
         result = runner.run("ping")
         assert result.success
@@ -254,7 +254,7 @@ class TestAgentExecutor:
             .start()
             .user()
             .agent("Tooled", tools=["get_weather"])
-            .end()
+            .end(stop=True)
             .build()
         )
 
@@ -321,7 +321,7 @@ class TestAgentExecutor:
             .start()
             .user()
             .agent("Looping", tools=["loopy"], max_iterations=3)
-            .end()
+            .end(stop=True)
             .build()
         )
 
@@ -370,7 +370,7 @@ class TestPropagatesNodeFailure:
         reg.register(NodeType.USER.value, UserExecutor(interactive=False))
         reg.register(NodeType.STATIC.value, PassthroughExecutor())
 
-        graph = Graph("chat").start().user().agent().end().build()
+        graph = Graph("chat").start().user().agent().end(stop=True).build()
         runner = FlowRunner(graph=graph, node_registry=reg)
         result = runner.run("hello")
 

--- a/quartermaster-engine/tests/test_smoke_simple_graph.py
+++ b/quartermaster-engine/tests/test_smoke_simple_graph.py
@@ -67,7 +67,9 @@ class TestLLMConfigPropagation:
 
     def test_max_output_tokens_reaches_provider(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Tight", max_output_tokens=50).end(stop=True).build()
+        graph = (
+            Graph("chat").start().user().agent("Tight", max_output_tokens=50).end(stop=True).build()
+        )
         runner = FlowRunner(graph=graph, provider_registry=registry)
         result = runner.run("ping")
         assert result.success, result.error
@@ -76,14 +78,28 @@ class TestLLMConfigPropagation:
 
     def test_max_input_tokens_reaches_provider(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Tight", max_input_tokens=8000).end(stop=True).build()
+        graph = (
+            Graph("chat")
+            .start()
+            .user()
+            .agent("Tight", max_input_tokens=8000)
+            .end(stop=True)
+            .build()
+        )
         runner = FlowRunner(graph=graph, provider_registry=registry)
         runner.run("ping")
         assert mock.last_config.max_input_tokens == 8000
 
     def test_thinking_level_high_propagates_enabled_and_budget(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Reasoning", thinking_level="high").end(stop=True).build()
+        graph = (
+            Graph("chat")
+            .start()
+            .user()
+            .agent("Reasoning", thinking_level="high")
+            .end(stop=True)
+            .build()
+        )
         runner = FlowRunner(graph=graph, provider_registry=registry)
         runner.run("ping")
         assert mock.last_config.thinking_enabled is True
@@ -91,7 +107,9 @@ class TestLLMConfigPropagation:
 
     def test_thinking_level_off_disables(self, provider_registry_with_mock):
         registry, mock = provider_registry_with_mock
-        graph = Graph("chat").start().user().agent("Plain", thinking_level="off").end(stop=True).build()
+        graph = (
+            Graph("chat").start().user().agent("Plain", thinking_level="off").end(stop=True).build()
+        )
         runner = FlowRunner(graph=graph, provider_registry=registry)
         runner.run("ping")
         assert mock.last_config.thinking_enabled is False

--- a/quartermaster-engine/tests/test_v030_end_node_semantics.py
+++ b/quartermaster-engine/tests/test_v030_end_node_semantics.py
@@ -1,0 +1,500 @@
+"""Regression tests for v0.3.0 End-node semantics (Proposal A).
+
+Under Proposal A reaching an End node in the MAIN graph dispatches
+control back to the Start node (enabling recursive agent loops), while
+an End node inside a sub-graph (spawned via ``SUB_ASSISTANT``) returns
+control to the parent flow.  ``.end(stop=True)`` remains the explicit
+opt-out for the rare "stop here permanently" case, which sets
+``traverse_out=SPAWN_NONE`` on the End node.
+
+Every test in this module uses a HARD stopping condition (explicit
+``stop=True``, an If/break after N rounds, or the runner's
+``max_loop_iterations`` cap reduced to a small ceiling) so a regression
+cannot hang the test suite forever.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from quartermaster_engine.context.execution_context import ExecutionContext
+from quartermaster_engine.context.node_execution import NodeStatus
+from quartermaster_engine.nodes import NodeResult, SimpleNodeRegistry
+from quartermaster_engine.runner.flow_runner import FlowRunner
+from quartermaster_engine.types import (
+    GraphSpec,
+    GraphNode,
+    MessageType,
+    NodeType,
+    ThoughtType,
+    TraverseIn,
+    TraverseOut,
+)
+
+from tests.conftest import make_edge, make_graph, make_node
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+class _CountingExecutor:
+    """Increments a module-local counter on every ``execute`` call."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def execute(self, context: ExecutionContext) -> NodeResult:
+        self.call_count += 1
+        return NodeResult(
+            success=True,
+            data={"call_count": self.call_count},
+            output_text=f"n={self.call_count}",
+        )
+
+
+class _CounterBreakerExecutor:
+    """Increments a counter and, once it reaches *threshold*, picks the
+    ``exit`` branch.  Otherwise picks ``loop``.
+
+    Pairs with a Decision-like SPAWN_PICKED node in tests that need a
+    bounded loop without leaning on the runner's max_loop_iterations
+    safety cap.
+    """
+
+    def __init__(self, threshold: int) -> None:
+        self.call_count = 0
+        self._threshold = threshold
+
+    async def execute(self, context: ExecutionContext) -> NodeResult:
+        self.call_count += 1
+        picked = "exit" if self.call_count >= self._threshold else "loop"
+        return NodeResult(
+            success=True,
+            data={},
+            output_text=str(self.call_count),
+            picked_node=picked,
+        )
+
+
+# ── 1. main-graph End loops back to Start ───────────────────────────
+
+
+def test_end_loops_back_to_start_in_main_graph():
+    """Start → Counter → If(count >= N ? "exit" : "loop") → End(loop)/End(stop).
+
+    Verifies the NEW default End behaviour: reaching an End node without
+    ``stop=True`` dispatches the Start node, rerunning the whole flow
+    body.  The Counter executor must be called exactly THRESHOLD times
+    before the "exit" branch short-circuits via ``.end(stop=True)``.
+    """
+    threshold = 3
+
+    start = make_node(NodeType.START, name="Start")
+    counter = make_node(NodeType.INSTRUCTION, name="Counter")
+    decision = make_node(
+        NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED
+    )
+    # loop branch → End (default SPAWN_START loop)
+    end_loop = make_node(
+        NodeType.END,
+        name="EndLoop",
+        traverse_out=TraverseOut.SPAWN_START,
+    )
+    # exit branch → End (SPAWN_NONE stop)
+    end_stop = make_node(
+        NodeType.END,
+        name="EndStop",
+        traverse_out=TraverseOut.SPAWN_NONE,
+    )
+
+    graph = make_graph(
+        [start, counter, decision, end_loop, end_stop],
+        [
+            make_edge(start, counter),
+            make_edge(counter, decision),
+            make_edge(decision, end_loop, label="loop"),
+            make_edge(decision, end_stop, label="exit"),
+        ],
+        start,
+    )
+
+    counter_exec = _CountingExecutor()
+    decision_exec = _CounterBreakerExecutor(threshold)
+
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, counter_exec)
+    registry.register(NodeType.DECISION.value, decision_exec)
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    # Hard safety cap (separate from the test's own threshold).
+    runner.max_loop_iterations = 10
+
+    result = runner.run("go")
+    assert result.success, result.error
+    assert counter_exec.call_count == threshold, (
+        f"Counter should run exactly {threshold} times, got "
+        f"{counter_exec.call_count}"
+    )
+
+
+# ── 2. .end(stop=True) opt-out ─────────────────────────────────────
+
+
+def test_end_with_stop_kwarg_does_not_loop():
+    """An End node with ``traverse_out=SPAWN_NONE`` (set by
+    ``.end(stop=True)``) still behaves the pre-0.3.0 way — reached
+    once, then the flow terminates."""
+    start = make_node(NodeType.START, name="Start")
+    inst = make_node(NodeType.INSTRUCTION, name="Once")
+    end = make_node(
+        NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_NONE
+    )
+
+    graph = make_graph(
+        [start, inst, end],
+        [make_edge(start, inst), make_edge(inst, end)],
+        start,
+    )
+
+    counter_exec = _CountingExecutor()
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, counter_exec)
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    runner.max_loop_iterations = 3
+    result = runner.run("once")
+    assert result.success, result.error
+    assert counter_exec.call_count == 1, (
+        f"Instruction should run exactly once with stop=True End, got "
+        f"{counter_exec.call_count}"
+    )
+
+
+# ── 3. graph without End auto-stops at last node ───────────────────
+
+
+def test_no_end_auto_stops_at_last_node():
+    """A graph with no End node reaches its last node and stops — the
+    pre-0.3.0 "implicit auto-stop" behaviour is unchanged."""
+    start = make_node(NodeType.START, name="Start")
+    inst = make_node(NodeType.INSTRUCTION, name="OneShot")
+
+    graph = make_graph(
+        [start, inst],
+        [make_edge(start, inst)],
+        start,
+    )
+
+    counter_exec = _CountingExecutor()
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, counter_exec)
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    runner.max_loop_iterations = 3
+    result = runner.run("once")
+    assert result.success, result.error
+    # The last node's output becomes final_output.
+    assert "n=1" in result.final_output
+    assert counter_exec.call_count == 1
+
+
+# ── 4. sub-graph End returns to parent ─────────────────────────────
+
+
+def test_sub_graph_end_returns_to_parent():
+    """A SUB_ASSISTANT node spawns a child FlowRunner with
+    ``parent_context=<caller ExecutionContext>``; the child's End node
+    detects the parent_context and stamps
+    ``__end_returns_to_parent__`` on its NodeResult instead of looping
+    back to the sub-graph's Start.  The parent's SUB_ASSISTANT node
+    then dispatches its own successors.
+    """
+    from quartermaster_engine.example_runner import SubAssistantExecutor
+
+    # ── Sub-graph: Start → ChildNode → End ──
+    sub_start = make_node(NodeType.START, name="SubStart")
+    child = make_node(NodeType.INSTRUCTION, name="ChildNode")
+    # The sub-graph's End has SPAWN_START by default — but because
+    # parent_context is set the runner short-circuits the loop and
+    # returns to the parent instead, regardless of SPAWN_START vs
+    # SPAWN_NONE.  Keep the default SPAWN_START to prove this.
+    sub_end = make_node(
+        NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START
+    )
+    sub_graph = make_graph(
+        [sub_start, child, sub_end],
+        [make_edge(sub_start, child), make_edge(child, sub_end)],
+        sub_start,
+    )
+
+    child_exec = _CountingExecutor()
+    child_registry = SimpleNodeRegistry()
+    child_registry.register(NodeType.INSTRUCTION.value, child_exec)
+
+    # ── Main graph: Start → SubAssistant → SecondNode → End(stop=True) ──
+    main_start = make_node(NodeType.START, name="MainStart")
+    sub = make_node(
+        NodeType.SUB_ASSISTANT,
+        name="InvokeChild",
+        metadata={"sub_assistant_id": "child"},
+    )
+    second = make_node(NodeType.INSTRUCTION, name="SecondNode")
+    main_end = make_node(
+        NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE
+    )
+
+    main_graph = make_graph(
+        [main_start, sub, second, main_end],
+        [
+            make_edge(main_start, sub),
+            make_edge(sub, second),
+            make_edge(second, main_end),
+        ],
+        main_start,
+    )
+
+    second_exec = _CountingExecutor()
+    # The SubAssistantExecutor needs a resolver → sub-graph lookup, and
+    # a node_registry for the child FlowRunner to use.  Keep the
+    # registries separate to prove the executors are NOT shared state.
+    resolver = lambda sid: sub_graph if sid == "child" else None
+    main_registry = SimpleNodeRegistry()
+    main_registry.register(NodeType.INSTRUCTION.value, second_exec)
+    main_registry.register(
+        NodeType.SUB_ASSISTANT.value,
+        SubAssistantExecutor(resolver=resolver, node_registry=child_registry),
+    )
+
+    runner = FlowRunner(graph=main_graph, node_registry=main_registry)
+    runner.max_loop_iterations = 3
+    result = runner.run("hello")
+    assert result.success, result.error
+
+    assert child_exec.call_count == 1, (
+        f"Child node should run exactly once in the sub-graph "
+        f"(parent_context should suppress the loop), got "
+        f"{child_exec.call_count}"
+    )
+    assert second_exec.call_count == 1, (
+        f"Parent's SecondNode should run exactly once after the "
+        f"sub-graph returns, got {second_exec.call_count}"
+    )
+
+
+# ── 5. parent_context is propagated into the sub-graph ──────────────
+
+
+def test_parent_context_propagated_into_subgraph():
+    """The sub-graph's ExecutionContext must carry a non-None
+    ``parent_context`` pointing at the parent's live ExecutionContext —
+    without that wiring the sub-graph's End wouldn't know to return to
+    its caller.
+    """
+    from quartermaster_engine.example_runner import SubAssistantExecutor
+
+    captured: dict = {}
+    parent_seen: list[ExecutionContext] = []
+
+    class _ParentCapturingExecutor:
+        """Runs in the parent — records its own context so the test can
+        assert it matches what the child sees via parent_context."""
+
+        async def execute(self, context: ExecutionContext) -> NodeResult:
+            parent_seen.append(context)
+            return NodeResult(success=True, data={}, output_text="parent-ran")
+
+    class _ChildCapturingExecutor:
+        """Runs in the sub-graph — records its own parent_context."""
+
+        async def execute(self, context: ExecutionContext) -> NodeResult:
+            captured["parent_context"] = context.parent_context
+            return NodeResult(success=True, data={}, output_text="child-ran")
+
+    sub_start = make_node(NodeType.START, name="SubStart")
+    child = make_node(NodeType.INSTRUCTION, name="ChildPeek")
+    sub_end = make_node(
+        NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START
+    )
+    sub_graph = make_graph(
+        [sub_start, child, sub_end],
+        [make_edge(sub_start, child), make_edge(child, sub_end)],
+        sub_start,
+    )
+
+    child_registry = SimpleNodeRegistry()
+    child_registry.register(
+        NodeType.INSTRUCTION.value, _ChildCapturingExecutor()
+    )
+
+    main_start = make_node(NodeType.START, name="MainStart")
+    sub = make_node(
+        NodeType.SUB_ASSISTANT,
+        name="InvokeChild",
+        metadata={"sub_assistant_id": "child"},
+    )
+    # Extra parent-side logic node to have something capture its own
+    # ExecutionContext — keeps parent_seen populated for the identity
+    # check below.
+    parent_peek = make_node(NodeType.INSTRUCTION, name="ParentPeek")
+    main_end = make_node(
+        NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE
+    )
+    main_graph = make_graph(
+        [main_start, parent_peek, sub, main_end],
+        [
+            make_edge(main_start, parent_peek),
+            make_edge(parent_peek, sub),
+            make_edge(sub, main_end),
+        ],
+        main_start,
+    )
+
+    resolver = lambda sid: sub_graph if sid == "child" else None
+    main_registry = SimpleNodeRegistry()
+    main_registry.register(
+        NodeType.INSTRUCTION.value, _ParentCapturingExecutor()
+    )
+    main_registry.register(
+        NodeType.SUB_ASSISTANT.value,
+        SubAssistantExecutor(resolver=resolver, node_registry=child_registry),
+    )
+
+    runner = FlowRunner(graph=main_graph, node_registry=main_registry)
+    runner.max_loop_iterations = 3
+    result = runner.run("hi")
+    assert result.success, result.error
+
+    assert captured.get("parent_context") is not None, (
+        "child's current_node.parent_context must not be None; it should "
+        "point at the parent's live ExecutionContext"
+    )
+    # The parent_context the child sees must be a real ExecutionContext
+    # instance.  Identity against ``parent_seen`` isn't guaranteed
+    # because the SUB_ASSISTANT node itself has a separate
+    # ExecutionContext from ParentPeek's; what matters is that the
+    # child saw SOME parent context instead of ``None``.
+    assert isinstance(captured["parent_context"], ExecutionContext)
+
+
+# ── 6. validator allows implicit End → Start cycles ────────────────
+
+
+def test_validator_allows_implicit_end_to_start_cycle():
+    """Building a graph that ends in a SPAWN_START End (the v0.3.0
+    default) must NOT be rejected by the validator — the End → Start
+    back-edge lives in the runner, not in ``graph.edges``.
+    """
+    import quartermaster_sdk as qm
+
+    # This graph has no user-written cycle in its edge list — just a
+    # plain Start → user → instruction → End, with End's traverse_out
+    # pointing back to Start implicitly.  The validator should accept
+    # it without `validate=False`.
+    graph = (
+        qm.Graph("loopy")
+        .instruction("Tick")
+        .end()
+        .build()
+    )
+    # Sanity: the End node was produced with SPAWN_START (the new
+    # default), not SPAWN_NONE.
+    end_nodes = [n for n in graph.nodes if n.type == NodeType.END]
+    assert end_nodes, "graph must have an End node"
+    assert end_nodes[-1].traverse_out == TraverseOut.SPAWN_START
+
+
+# ── 7. existing loop-style example (08/15) still terminates ────────
+
+
+def test_existing_loop_examples_still_work():
+    """Sanity check — a classic "loop N times then exit" graph using
+    the new .end() semantics (no .connect() back-edge) must produce a
+    final output without hitting max_loop_iterations.
+
+    Mimics the structure of ``examples/08_iterative_refinement.py``
+    and ``examples/15_courtroom_debate.py`` after migration: an If
+    node decides between "loop" (default End, SPAWN_START) and "exit"
+    (End(stop=True)).
+    """
+    threshold = 3
+
+    start = make_node(NodeType.START, name="Start")
+    body = make_node(NodeType.INSTRUCTION, name="Body")
+    decision = make_node(
+        NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED
+    )
+    loop_end = make_node(
+        NodeType.END,
+        name="LoopEnd",
+        traverse_out=TraverseOut.SPAWN_START,
+    )
+    exit_end = make_node(
+        NodeType.END,
+        name="ExitEnd",
+        traverse_out=TraverseOut.SPAWN_NONE,
+    )
+    graph = make_graph(
+        [start, body, decision, loop_end, exit_end],
+        [
+            make_edge(start, body),
+            make_edge(body, decision),
+            make_edge(decision, loop_end, label="loop"),
+            make_edge(decision, exit_end, label="exit"),
+        ],
+        start,
+    )
+
+    body_exec = _CountingExecutor()
+    decision_exec = _CounterBreakerExecutor(threshold)
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, body_exec)
+    registry.register(NodeType.DECISION.value, decision_exec)
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    # Cap well below an infinite loop but above threshold so a
+    # regression against the loop-guard surfaces as a FAIL rather
+    # than "test takes too long".
+    runner.max_loop_iterations = threshold + 5
+    result = runner.run("loop")
+    assert result.success, result.error
+    assert body_exec.call_count == threshold, (
+        f"Body should have run exactly {threshold} times, got "
+        f"{body_exec.call_count}"
+    )
+
+
+# ── 8. max_loop_iterations safety cap ──────────────────────────────
+
+
+def test_loop_safety_cap_prevents_infinite_recursion():
+    """A graph with an End that loops back and NO break condition
+    must stop once ``max_loop_iterations`` is hit rather than
+    recursing forever.  This is the safety rail for accidentally-
+    looping graphs.
+    """
+    start = make_node(NodeType.START, name="Start")
+    body = make_node(NodeType.INSTRUCTION, name="Body")
+    end = make_node(
+        NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_START
+    )
+
+    graph = make_graph(
+        [start, body, end],
+        [make_edge(start, body), make_edge(body, end)],
+        start,
+    )
+
+    counter_exec = _CountingExecutor()
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, counter_exec)
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    runner.max_loop_iterations = 5
+    result = runner.run("runaway")
+    # The cap was hit — the flow still returns (doesn't raise) and
+    # the counter is bounded by the cap.
+    assert result.success, result.error
+    assert counter_exec.call_count == runner.max_loop_iterations + 1, (
+        f"Body should have run exactly max_loop_iterations+1 times "
+        f"(initial run + N loop-backs), got {counter_exec.call_count}"
+    )

--- a/quartermaster-engine/tests/test_v030_end_node_semantics.py
+++ b/quartermaster-engine/tests/test_v030_end_node_semantics.py
@@ -91,9 +91,7 @@ def test_end_loops_back_to_start_in_main_graph():
 
     start = make_node(NodeType.START, name="Start")
     counter = make_node(NodeType.INSTRUCTION, name="Counter")
-    decision = make_node(
-        NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED
-    )
+    decision = make_node(NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED)
     # loop branch → End (default SPAWN_START loop)
     end_loop = make_node(
         NodeType.END,
@@ -132,8 +130,7 @@ def test_end_loops_back_to_start_in_main_graph():
     result = runner.run("go")
     assert result.success, result.error
     assert counter_exec.call_count == threshold, (
-        f"Counter should run exactly {threshold} times, got "
-        f"{counter_exec.call_count}"
+        f"Counter should run exactly {threshold} times, got {counter_exec.call_count}"
     )
 
 
@@ -146,9 +143,7 @@ def test_end_with_stop_kwarg_does_not_loop():
     once, then the flow terminates."""
     start = make_node(NodeType.START, name="Start")
     inst = make_node(NodeType.INSTRUCTION, name="Once")
-    end = make_node(
-        NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_NONE
-    )
+    end = make_node(NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_NONE)
 
     graph = make_graph(
         [start, inst, end],
@@ -165,8 +160,7 @@ def test_end_with_stop_kwarg_does_not_loop():
     result = runner.run("once")
     assert result.success, result.error
     assert counter_exec.call_count == 1, (
-        f"Instruction should run exactly once with stop=True End, got "
-        f"{counter_exec.call_count}"
+        f"Instruction should run exactly once with stop=True End, got {counter_exec.call_count}"
     )
 
 
@@ -218,9 +212,7 @@ def test_sub_graph_end_returns_to_parent():
     # parent_context is set the runner short-circuits the loop and
     # returns to the parent instead, regardless of SPAWN_START vs
     # SPAWN_NONE.  Keep the default SPAWN_START to prove this.
-    sub_end = make_node(
-        NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START
-    )
+    sub_end = make_node(NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START)
     sub_graph = make_graph(
         [sub_start, child, sub_end],
         [make_edge(sub_start, child), make_edge(child, sub_end)],
@@ -239,9 +231,7 @@ def test_sub_graph_end_returns_to_parent():
         metadata={"sub_assistant_id": "child"},
     )
     second = make_node(NodeType.INSTRUCTION, name="SecondNode")
-    main_end = make_node(
-        NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE
-    )
+    main_end = make_node(NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE)
 
     main_graph = make_graph(
         [main_start, sub, second, main_end],
@@ -312,9 +302,7 @@ def test_parent_context_propagated_into_subgraph():
 
     sub_start = make_node(NodeType.START, name="SubStart")
     child = make_node(NodeType.INSTRUCTION, name="ChildPeek")
-    sub_end = make_node(
-        NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START
-    )
+    sub_end = make_node(NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START)
     sub_graph = make_graph(
         [sub_start, child, sub_end],
         [make_edge(sub_start, child), make_edge(child, sub_end)],
@@ -322,9 +310,7 @@ def test_parent_context_propagated_into_subgraph():
     )
 
     child_registry = SimpleNodeRegistry()
-    child_registry.register(
-        NodeType.INSTRUCTION.value, _ChildCapturingExecutor()
-    )
+    child_registry.register(NodeType.INSTRUCTION.value, _ChildCapturingExecutor())
 
     main_start = make_node(NodeType.START, name="MainStart")
     sub = make_node(
@@ -336,9 +322,7 @@ def test_parent_context_propagated_into_subgraph():
     # ExecutionContext — keeps parent_seen populated for the identity
     # check below.
     parent_peek = make_node(NodeType.INSTRUCTION, name="ParentPeek")
-    main_end = make_node(
-        NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE
-    )
+    main_end = make_node(NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE)
     main_graph = make_graph(
         [main_start, parent_peek, sub, main_end],
         [
@@ -351,9 +335,7 @@ def test_parent_context_propagated_into_subgraph():
 
     resolver = lambda sid: sub_graph if sid == "child" else None
     main_registry = SimpleNodeRegistry()
-    main_registry.register(
-        NodeType.INSTRUCTION.value, _ParentCapturingExecutor()
-    )
+    main_registry.register(NodeType.INSTRUCTION.value, _ParentCapturingExecutor())
     main_registry.register(
         NodeType.SUB_ASSISTANT.value,
         SubAssistantExecutor(resolver=resolver, node_registry=child_registry),
@@ -390,12 +372,7 @@ def test_validator_allows_implicit_end_to_start_cycle():
     # plain Start → user → instruction → End, with End's traverse_out
     # pointing back to Start implicitly.  The validator should accept
     # it without `validate=False`.
-    graph = (
-        qm.Graph("loopy")
-        .instruction("Tick")
-        .end()
-        .build()
-    )
+    graph = qm.Graph("loopy").instruction("Tick").end().build()
     # Sanity: the End node was produced with SPAWN_START (the new
     # default), not SPAWN_NONE.
     end_nodes = [n for n in graph.nodes if n.type == NodeType.END]
@@ -420,9 +397,7 @@ def test_existing_loop_examples_still_work():
 
     start = make_node(NodeType.START, name="Start")
     body = make_node(NodeType.INSTRUCTION, name="Body")
-    decision = make_node(
-        NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED
-    )
+    decision = make_node(NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED)
     loop_end = make_node(
         NodeType.END,
         name="LoopEnd",
@@ -458,8 +433,7 @@ def test_existing_loop_examples_still_work():
     result = runner.run("loop")
     assert result.success, result.error
     assert body_exec.call_count == threshold, (
-        f"Body should have run exactly {threshold} times, got "
-        f"{body_exec.call_count}"
+        f"Body should have run exactly {threshold} times, got {body_exec.call_count}"
     )
 
 
@@ -474,9 +448,7 @@ def test_loop_safety_cap_prevents_infinite_recursion():
     """
     start = make_node(NodeType.START, name="Start")
     body = make_node(NodeType.INSTRUCTION, name="Body")
-    end = make_node(
-        NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_START
-    )
+    end = make_node(NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_START)
 
     graph = make_graph(
         [start, body, end],

--- a/quartermaster-engine/tests/test_v030_events_and_context.py
+++ b/quartermaster-engine/tests/test_v030_events_and_context.py
@@ -1,0 +1,461 @@
+"""Regression tests for v0.3.0 ``ProgressEvent`` / ``CustomEvent`` and
+the ``current_context()`` contextvar plumbing.
+
+Surface under test (engine-side):
+
+* ``quartermaster_engine.events.ProgressEvent`` /
+  ``quartermaster_engine.events.CustomEvent`` — the two new typed
+  flow events fired when application code calls
+  ``ExecutionContext.emit_progress(...)`` / ``.emit_custom(...)``.
+* ``ExecutionContext.emit_progress`` / ``.emit_custom`` —
+  including the no-callback no-op contract that lets tools stay
+  unit-testable without a runner.
+* ``quartermaster_engine.context.current_context.current_context()``
+  / ``bind(...)`` — the contextvar that tools reach for to grab the
+  live :class:`ExecutionContext`.
+* ``FlowRunner._run_executor`` plumbing — both the synchronous path
+  and the ``ThreadPoolExecutor`` path used when the runner is
+  invoked from inside a running asyncio event loop. The latter is
+  the **regression guard** for the
+  ``contextvars.copy_context().run(...)`` snapshot — without it
+  ``current_context()`` would resolve to ``None`` in the worker
+  thread.
+* End-to-end via the public SDK surface: a ``@tool()``-decorated
+  function calling ``qm.current_context().emit_progress(...)``
+  surfaces a ``ProgressChunk`` from ``qm.run.stream(...)`` interleaved
+  between ``ToolCallChunk`` and ``ToolResultChunk``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from quartermaster_engine.context.current_context import current_context
+from quartermaster_engine.context.execution_context import ExecutionContext
+from quartermaster_engine.events import (
+    CustomEvent,
+    FlowEvent,
+    ProgressEvent,
+)
+from quartermaster_engine.nodes import NodeResult, SimpleNodeRegistry
+from quartermaster_engine.runner.flow_runner import FlowRunner
+from quartermaster_engine.types import (
+    GraphSpec,
+    GraphNode,
+    NodeType,
+    TraverseOut,
+)
+
+from tests.conftest import make_edge, make_graph, make_node
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _build_one_node_graph(
+    executor: Any,
+) -> tuple[GraphSpec, GraphNode, SimpleNodeRegistry]:
+    """Build a tiny ``Start → Inst → End`` graph wired to *executor*.
+
+    Returns the graph spec, the instruction node (so tests can assert
+    on its ``id``), and the registry.
+    """
+    start = make_node(NodeType.START, name="Start")
+    inst = make_node(NodeType.INSTRUCTION, name="Worker")
+    end = make_node(NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_NONE)
+
+    graph = make_graph(
+        [start, inst, end],
+        [make_edge(start, inst), make_edge(inst, end)],
+        start,
+    )
+
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, executor)
+    return graph, inst, registry
+
+
+# ── 1. ProgressEvent ─────────────────────────────────────────────────
+
+
+class TestProgressEvent:
+    """``ExecutionContext.emit_progress`` fires a ``ProgressEvent``
+    on the runner's ``on_event`` hook with the right shape, and is a
+    safe no-op when no callback is wired."""
+
+    def test_progress_event_emitted_when_node_emits(self):
+        """One ``emit_progress`` call → exactly one ``ProgressEvent`` with
+        matching message / percent / data / node_id."""
+
+        class _ProgressExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                context.emit_progress("loading", percent=0.5, query="hello")
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, inst, registry = _build_one_node_graph(_ProgressExecutor())
+
+        events: list[FlowEvent] = []
+        runner = FlowRunner(
+            graph=graph, node_registry=registry, on_event=events.append
+        )
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        progress = [e for e in events if isinstance(e, ProgressEvent)]
+        assert len(progress) == 1, f"expected exactly 1 ProgressEvent, got {progress}"
+
+        ev = progress[0]
+        assert ev.message == "loading"
+        assert ev.percent == 0.5
+        assert ev.data == {"query": "hello"}
+        assert ev.node_id == inst.id
+
+    def test_progress_event_no_op_when_no_callback(self):
+        """Calling ``emit_progress`` on a freshly-built ``ExecutionContext``
+        with ``on_progress=None`` must not raise and must not produce any
+        observable side effect — tools stay unit-testable without a runner."""
+        node = make_node(NodeType.INSTRUCTION, name="Standalone")
+        graph = make_graph([node], [], node)
+        ctx = ExecutionContext(
+            flow_id=uuid4(),
+            node_id=node.id,
+            graph=graph,
+            current_node=node,
+        )
+        assert ctx.on_progress is None
+
+        # Must not raise — and the callback is None so there's nothing
+        # to invoke.  Verify by re-asserting the callback is still None
+        # afterwards (no mutation as a side effect).
+        ctx.emit_progress("x")
+        ctx.emit_progress("y", percent=0.25, foo="bar")
+        assert ctx.on_progress is None
+
+
+# ── 2. CustomEvent ───────────────────────────────────────────────────
+
+
+class TestCustomEvent:
+    """``ExecutionContext.emit_custom`` fires a ``CustomEvent`` with the
+    caller-supplied name and payload; payload defaults to an empty dict."""
+
+    def test_custom_event_emitted_when_node_emits(self):
+        class _CustomExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                context.emit_custom("retrieved_docs", {"count": 3})
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, inst, registry = _build_one_node_graph(_CustomExecutor())
+
+        events: list[FlowEvent] = []
+        runner = FlowRunner(
+            graph=graph, node_registry=registry, on_event=events.append
+        )
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        customs = [e for e in events if isinstance(e, CustomEvent)]
+        assert len(customs) == 1, f"expected exactly 1 CustomEvent, got {customs}"
+
+        ev = customs[0]
+        assert ev.name == "retrieved_docs"
+        assert ev.payload == {"count": 3}
+        assert ev.node_id == inst.id
+
+    def test_custom_event_payload_defaults_to_empty_dict(self):
+        """``emit_custom("ping")`` (no payload arg) → ``CustomEvent`` with
+        ``payload={}``, not ``None``."""
+
+        class _PingExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                context.emit_custom("ping")
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(_PingExecutor())
+
+        events: list[FlowEvent] = []
+        runner = FlowRunner(
+            graph=graph, node_registry=registry, on_event=events.append
+        )
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        customs = [e for e in events if isinstance(e, CustomEvent)]
+        assert len(customs) == 1
+        assert customs[0].name == "ping"
+        assert customs[0].payload == {}
+
+
+# ── 3. current_context contextvar ────────────────────────────────────
+
+
+class TestCurrentContext:
+    """The ``_current_ctx`` contextvar is bound by ``FlowRunner._run_executor``
+    around ``executor.execute(context)`` and reset on the way out — so
+    out-of-flow callers see ``None`` and in-flow tools see the live context.
+
+    The ``test_current_context_propagates_into_thread_pool_executor`` case
+    is the regression guard for the
+    ``contextvars.copy_context().run(...)`` snapshot used when the runner
+    dispatches into a worker thread from inside a running asyncio loop;
+    without it the contextvar wouldn't propagate and tools would see
+    ``None`` mid-flow.
+    """
+
+    def test_current_context_is_none_outside_flow(self):
+        """No runner active → ``current_context()`` returns ``None``."""
+        assert current_context() is None
+
+    def test_current_context_is_set_inside_executor(self):
+        """Inside the executor body, ``current_context()`` returns the
+        same ``ExecutionContext`` instance the runner passed in."""
+        captured: list[Any] = []
+        seen_context: list[Any] = []
+
+        class _CapturingExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                seen_context.append(context)
+                captured.append(current_context())
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(_CapturingExecutor())
+
+        runner = FlowRunner(graph=graph, node_registry=registry)
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        assert len(captured) == 1
+        assert captured[0] is not None, "current_context() returned None inside flow"
+        # Identity check — must be the very same object the runner passed.
+        assert captured[0] is seen_context[0]
+
+    def test_current_context_unset_after_run_completes(self):
+        """After the run finishes, ``current_context()`` is back to ``None``
+        at the top level — the contextvar was reset by ``bind``'s
+        ``finally`` clause."""
+
+        class _NoopExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                # Just confirm we have a context in-flight.
+                assert current_context() is context
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(_NoopExecutor())
+
+        runner = FlowRunner(graph=graph, node_registry=registry)
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        # Top-level contextvar state must be clean.
+        assert current_context() is None
+
+    def test_current_context_propagates_into_thread_pool_executor(self):
+        """REGRESSION GUARD: when the runner dispatches via the
+        ``ThreadPoolExecutor`` path (running asyncio loop active), the
+        worker thread must see the bound contextvar via
+        ``contextvars.copy_context().run(...)`` — otherwise
+        ``current_context()`` would return ``None`` inside the executor.
+
+        We force the thread-pool path by running the runner from inside
+        a coroutine: ``asyncio.get_running_loop()`` succeeds and
+        ``loop.is_running()`` is ``True``, so ``_run_executor`` takes
+        the worker-thread branch.
+        """
+        captured: dict[str, Any] = {}
+
+        class _ThreadPoolCapturingExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                # This runs inside the worker thread spawned by
+                # _run_executor's asyncio.run(coro) — without
+                # contextvars.copy_context().run(...) the contextvar
+                # would be unset here and current_context() would be
+                # None.
+                seen = current_context()
+                captured["seen"] = seen
+                captured["is_same"] = seen is context
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(
+            _ThreadPoolCapturingExecutor()
+        )
+        runner = FlowRunner(graph=graph, node_registry=registry)
+
+        async def _make_runner_call_from_async() -> Any:
+            # Calling runner.run from inside a coroutine forces
+            # _run_executor to take the ThreadPoolExecutor branch
+            # because ``asyncio.get_running_loop()`` resolves and
+            # ``loop.is_running()`` is True.
+            return runner.run("kickoff")
+
+        result = asyncio.run(_make_runner_call_from_async())
+        assert result.success, result.error
+
+        assert captured.get("seen") is not None, (
+            "current_context() returned None in the ThreadPoolExecutor "
+            "worker — contextvars.copy_context().run(...) plumbing in "
+            "FlowRunner._run_executor regressed."
+        )
+        assert captured["is_same"] is True, (
+            "current_context() in the worker did not match the "
+            "ExecutionContext the runner passed in."
+        )
+
+        # And cleanup still holds at the top level.
+        assert current_context() is None
+
+
+# ── 4. End-to-end via the public SDK surface ─────────────────────────
+
+
+class TestEmitFromTool:
+    """End-to-end: a ``@tool()`` function calling
+    ``qm.current_context().emit_progress(...)`` from inside an agent's
+    tool loop surfaces a ``ProgressChunk`` on ``qm.run.stream(...)``,
+    interleaved between the matching ``ToolCallChunk`` and
+    ``ToolResultChunk``.
+
+    Lifts the ``MockProvider`` / ``_OkTool`` / ``_ToolRegistry`` shim
+    pattern from ``quartermaster-sdk/tests/test_v022_tool_streaming.py``
+    so the agent loop terminates cleanly after one tool call.
+    """
+
+    def test_tool_inside_agent_can_emit_progress(self):
+        # Imported here so the rest of this engine-side test module
+        # stays importable even if the SDK happens to be missing in some
+        # downstream environment. With the workspace layout in this
+        # repo, both packages are always present.
+        import quartermaster_sdk as qm
+        from quartermaster_providers import ProviderRegistry
+        from quartermaster_providers.testing import MockProvider
+        from quartermaster_providers.types import (
+            NativeResponse,
+            TokenResponse,
+            ToolCall,
+        )
+        from quartermaster_tools import tool
+
+        # ── Define a tool that emits a progress event mid-execution.
+        # The decorator builds a ``FunctionTool``; the agent executor
+        # will call ``.safe_run(**args)`` which delegates to ``run``
+        # which calls our wrapped function.  Inside the function the
+        # contextvar is set (the agent executor runs inside the runner's
+        # ``bind_current_context(...)`` scope).
+        @tool()
+        def slow_search(q: str) -> dict:
+            """Pretend to do a slow search and emit a progress signal."""
+            ctx = qm.current_context()
+            assert ctx is not None, (
+                "current_context() returned None inside the @tool body — "
+                "the contextvar was not propagated into the tool call."
+            )
+            ctx.emit_progress("searching", percent=0.5)
+            return {"ok": True, "q": q}
+
+        # ── Mock provider: turn 1 returns a tool call, turn 2 ends.
+        mock = MockProvider(
+            responses=[TokenResponse(content="Done.", stop_reason="stop")],
+            native_responses=[
+                NativeResponse(
+                    text_content="",
+                    thinking=[],
+                    tool_calls=[
+                        ToolCall(
+                            tool_name="slow_search",
+                            tool_id="call_1",
+                            parameters={"q": "hello"},
+                        )
+                    ],
+                    stop_reason="tool_calls",
+                ),
+                NativeResponse(
+                    text_content="Done.",
+                    thinking=[],
+                    tool_calls=[],
+                    stop_reason="stop",
+                ),
+            ],
+        )
+        provider_reg = ProviderRegistry(auto_configure=False)
+        provider_reg.register_instance("mock", mock)
+        provider_reg.set_default_provider("mock")
+        provider_reg.set_default_model("mock", "test-model")
+
+        # ── ToolRegistry shim matching the agent executor's interface
+        # (``.get(name)`` + ``.to_openai_tools()``). We bypass
+        # ``quartermaster_tools.ToolRegistry`` to keep the test focused
+        # on the contextvar + event plumbing — the registry shape mirrors
+        # the one in test_v022_tool_streaming.py.
+        class _ToolRegistry:
+            def __init__(self, t: Any):
+                self._t = t
+
+            def get(self, name: str) -> Any:
+                if name != "slow_search":
+                    raise KeyError(name)
+                return self._t
+
+            def to_openai_tools(self) -> list[dict]:
+                return [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "slow_search",
+                            "description": "stub",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "q": {"type": "string"}
+                                },
+                            },
+                        },
+                    }
+                ]
+
+        # The agent executor calls ``.safe_run(**args)`` on the tool —
+        # ``FunctionTool`` inherits this from ``AbstractTool``. The
+        # tool's body runs synchronously inside the agent's tool loop,
+        # which itself runs inside ``bind_current_context(...)``, so
+        # ``current_context()`` resolves correctly.
+        tool_reg = _ToolRegistry(slow_search)
+
+        qm.reset_config()
+        try:
+            qm.configure(registry=provider_reg)
+
+            graph = (
+                qm.Graph("chat")
+                .user()
+                .agent("Tooled", tools=["slow_search"], capture_as="agent")
+                .build()
+            )
+
+            chunks = list(
+                qm.run.stream(graph, "hi", tool_registry=tool_reg)
+            )
+        finally:
+            qm.reset_config()
+
+        types_seq = [c.type for c in chunks]
+
+        # The progress chunk must arrive AND must sit between the
+        # matching tool_call and tool_result chunks — that's the whole
+        # point of the contextvar plumbing: live status from inside
+        # tools, interleaved with the agent loop.
+        assert "tool_call" in types_seq, f"no tool_call in {types_seq}"
+        assert "tool_result" in types_seq, f"no tool_result in {types_seq}"
+        assert "progress" in types_seq, f"no progress chunk in {types_seq}"
+
+        tool_call_idx = types_seq.index("tool_call")
+        progress_idx = types_seq.index("progress")
+        tool_result_idx = types_seq.index("tool_result")
+        assert tool_call_idx < progress_idx < tool_result_idx, (
+            f"progress chunk must sit between tool_call and tool_result; "
+            f"got order {types_seq}"
+        )
+
+        progress_chunk = next(c for c in chunks if c.type == "progress")
+        assert isinstance(progress_chunk, qm.ProgressChunk)
+        assert progress_chunk.message == "searching"
+        assert progress_chunk.percent == 0.5

--- a/quartermaster-engine/tests/test_v030_events_and_context.py
+++ b/quartermaster-engine/tests/test_v030_events_and_context.py
@@ -97,9 +97,7 @@ class TestProgressEvent:
         graph, inst, registry = _build_one_node_graph(_ProgressExecutor())
 
         events: list[FlowEvent] = []
-        runner = FlowRunner(
-            graph=graph, node_registry=registry, on_event=events.append
-        )
+        runner = FlowRunner(graph=graph, node_registry=registry, on_event=events.append)
         result = runner.run("kickoff")
         assert result.success, result.error
 
@@ -150,9 +148,7 @@ class TestCustomEvent:
         graph, inst, registry = _build_one_node_graph(_CustomExecutor())
 
         events: list[FlowEvent] = []
-        runner = FlowRunner(
-            graph=graph, node_registry=registry, on_event=events.append
-        )
+        runner = FlowRunner(graph=graph, node_registry=registry, on_event=events.append)
         result = runner.run("kickoff")
         assert result.success, result.error
 
@@ -176,9 +172,7 @@ class TestCustomEvent:
         graph, _inst, registry = _build_one_node_graph(_PingExecutor())
 
         events: list[FlowEvent] = []
-        runner = FlowRunner(
-            graph=graph, node_registry=registry, on_event=events.append
-        )
+        runner = FlowRunner(graph=graph, node_registry=registry, on_event=events.append)
         result = runner.run("kickoff")
         assert result.success, result.error
 
@@ -277,9 +271,7 @@ class TestCurrentContext:
                 captured["is_same"] = seen is context
                 return NodeResult(success=True, data={}, output_text="ok")
 
-        graph, _inst, registry = _build_one_node_graph(
-            _ThreadPoolCapturingExecutor()
-        )
+        graph, _inst, registry = _build_one_node_graph(_ThreadPoolCapturingExecutor())
         runner = FlowRunner(graph=graph, node_registry=registry)
 
         async def _make_runner_call_from_async() -> Any:
@@ -405,9 +397,7 @@ class TestEmitFromTool:
                             "description": "stub",
                             "parameters": {
                                 "type": "object",
-                                "properties": {
-                                    "q": {"type": "string"}
-                                },
+                                "properties": {"q": {"type": "string"}},
                             },
                         },
                     }
@@ -431,9 +421,7 @@ class TestEmitFromTool:
                 .build()
             )
 
-            chunks = list(
-                qm.run.stream(graph, "hi", tool_registry=tool_reg)
-            )
+            chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
         finally:
             qm.reset_config()
 
@@ -451,8 +439,7 @@ class TestEmitFromTool:
         progress_idx = types_seq.index("progress")
         tool_result_idx = types_seq.index("tool_result")
         assert tool_call_idx < progress_idx < tool_result_idx, (
-            f"progress chunk must sit between tool_call and tool_result; "
-            f"got order {types_seq}"
+            f"progress chunk must sit between tool_call and tool_result; got order {types_seq}"
         )
 
         progress_chunk = next(c for c in chunks if c.type == "progress")

--- a/quartermaster-graph/src/quartermaster_graph/builder.py
+++ b/quartermaster-graph/src/quartermaster_graph/builder.py
@@ -1017,15 +1017,37 @@ class _BranchBuilder:
     # Termination
     # ------------------------------------------------------------------
 
-    def end(self) -> Any:
+    def end(self, stop: bool = False) -> Any:
         """End this branch and return to the parent.
 
         Records the branch endpoint so that a subsequent ``.merge()``
         or auto-merge can connect all branches.
 
+        When ``stop=True`` (v0.3.0+) the branch receives an explicit
+        ``NodeType.END`` node with ``traverse_out=SPAWN_NONE`` right
+        now — so even under the new default loop semantics, *this*
+        branch stops cleanly.  Use it for the "we're done refining,
+        exit the loop" arm of an if/decision.
+
         Returns the parent — either a ``GraphBuilder`` or another
         ``_BranchBuilder`` for nested control flow.
         """
+        if stop:
+            end_node = GraphNode(
+                type=NodeType.END,
+                name="End",
+                traverse_out=TraverseOut.SPAWN_NONE,
+                thought_type=ThoughtType.SKIP,
+                message_type=MessageType.VARIABLE,
+                position=self._parent._advance_position(),
+            )
+            self._graph._nodes.append(end_node)
+            if self._last_node_id is not None:
+                self._graph._edges.append(
+                    GraphEdge(source_id=self._last_node_id, target_id=end_node.id)
+                )
+            # Don't register as a branch endpoint — this End is terminal.
+            return self._parent
         if self._last_node_id is not None:
             self._parent._branch_endpoints.append(self._last_node_id)
         return self._parent
@@ -1253,16 +1275,30 @@ class GraphBuilder:
         self._create_start_node()
         return self
 
-    def end(self) -> GraphBuilder:
+    def end(self, stop: bool = False) -> GraphBuilder:
         """Add an End node.
 
-        If there are pending branch endpoints, auto-merges them first so
-        the End node is reachable from all branches.
+        v0.3.0 semantics (Proposal A):
+
+        * In the **main graph**, reaching an End node loops control
+          back to the ``Start`` node by default, enabling recursive
+          agent loops.  Implemented by setting
+          ``traverse_out=SPAWN_START`` on the End node.
+        * In a **sub-graph** (spawned via a ``SUB_ASSISTANT`` node) the
+          same End node signals "return to parent" instead of looping;
+          the runner inspects ``ExecutionContext.parent_context`` at
+          run time to tell the two cases apart.
+        * Pass ``stop=True`` for the rare "stop here permanently"
+          opt-out — sets ``traverse_out=SPAWN_NONE`` so the runner
+          never dispatches anything after this node.
+
+        If there are pending branch endpoints, auto-merges them first
+        so the End node is reachable from all branches.
         """
         node = GraphNode(
             type=NodeType.END,
             name="End",
-            traverse_out=TraverseOut.SPAWN_NONE,
+            traverse_out=TraverseOut.SPAWN_NONE if stop else TraverseOut.SPAWN_START,
             thought_type=ThoughtType.SKIP,
             message_type=MessageType.VARIABLE,
         )

--- a/quartermaster-graph/src/quartermaster_graph/validation.py
+++ b/quartermaster-graph/src/quartermaster_graph/validation.py
@@ -152,10 +152,26 @@ def validate_graph(version: GraphSpec) -> list[ValidationError]:  # type: ignore
                     queue_cycle.append(succ)
 
         if visited_count < len(version.nodes):
+            # v0.3.0: End → Start back-edges are implicit (they live in
+            # the runner's dispatch logic, not in ``version.edges``),
+            # so a graph that uses the new loop semantics passes
+            # without effort.  User-written cycles via explicit edges
+            # are still flagged, but only as a WARNING because the
+            # runner has a ``_is_loop_target`` / ``max_loop_iterations``
+            # guard that makes intentional back-edges safe at run time.
             errors.append(
                 ValidationError(
                     code="cycle_detected",
-                    message="Graph contains a cycle (not a DAG)",
+                    message=(
+                        "Graph contains a cycle via explicit edges. "
+                        "Intentional loops are supported at run time "
+                        "(``FlowRunner.max_loop_iterations`` caps the "
+                        "dispatches), and the default v0.3.0 End-node "
+                        "semantics loop back to Start implicitly — so "
+                        "you rarely need an explicit back-edge.  "
+                        "Consider replacing the cycle with .end()."
+                    ),
+                    severity="warning",
                 )
             )
 

--- a/quartermaster-graph/tests/test_validation.py
+++ b/quartermaster-graph/tests/test_validation.py
@@ -176,6 +176,13 @@ class TestOrphanDetection:
 
 class TestCycleDetection:
     def test_cycle_detected(self, agent):
+        """v0.3.0: cycle detection now emits a WARNING, not an error.
+
+        Intentional loops are supported at run time via the runner's
+        ``max_loop_iterations`` safety cap, and the default End-node
+        semantics loop back to Start implicitly — so explicit
+        edge-level cycles are a soft signal, not a validation failure.
+        """
         start = GraphNode(type=NodeType.START, name="Start")
         a = GraphNode(type=NodeType.INSTRUCTION, name="A")
         b = GraphNode(type=NodeType.INSTRUCTION, name="B")
@@ -195,6 +202,8 @@ class TestCycleDetection:
         errors = validate_graph(version)
         codes = [e.code for e in errors]
         assert "cycle_detected" in codes
+        warning_codes = {e.code for e in errors if e.severity == "warning"}
+        assert "cycle_detected" in warning_codes
 
 
 class TestDecisionEdgeLabels:

--- a/quartermaster-graph/tests/test_validation_integration.py
+++ b/quartermaster-graph/tests/test_validation_integration.py
@@ -165,7 +165,14 @@ class TestCycleDetection:
     """Validation must detect cycles in the graph."""
 
     def test_simple_cycle(self, agent: Agent) -> None:
-        """A -> B -> A cycle produces cycle_detected error."""
+        """A -> B -> A cycle produces a cycle_detected warning.
+
+        v0.3.0: under Proposal A the default End-node semantics loop
+        back to Start implicitly, so user-defined cycles via explicit
+        edges are now a WARNING — the runtime has a loop guard
+        (``FlowRunner.max_loop_iterations``) and intentional cycles
+        are fully supported.
+        """
         start = GraphNode(type=NodeType.START, name="Start")
         a = GraphNode(type=NodeType.INSTRUCTION, name="A")
         b = GraphNode(type=NodeType.INSTRUCTION, name="B")
@@ -183,11 +190,13 @@ class TestCycleDetection:
             edges=edges,
         )
         errors = validate_graph(version)
+        warning_codes = {e.code for e in errors if e.severity == "warning"}
         error_codes = {e.code for e in errors if e.severity == "error"}
-        assert "cycle_detected" in error_codes
+        assert "cycle_detected" in warning_codes
+        assert "cycle_detected" not in error_codes
 
     def test_self_loop(self, agent: Agent) -> None:
-        """A node pointing to itself creates a cycle."""
+        """A node pointing to itself creates a cycle (warning in v0.3.0)."""
         start = GraphNode(type=NodeType.START, name="Start")
         inst = GraphNode(type=NodeType.INSTRUCTION, name="Self-Loop")
         end = GraphNode(type=NodeType.END, name="End")
@@ -203,8 +212,10 @@ class TestCycleDetection:
             edges=edges,
         )
         errors = validate_graph(version)
+        warning_codes = {e.code for e in errors if e.severity == "warning"}
         error_codes = {e.code for e in errors if e.severity == "error"}
-        assert "cycle_detected" in error_codes
+        assert "cycle_detected" in warning_codes
+        assert "cycle_detected" not in error_codes
 
 
 class TestInvalidEdges:

--- a/quartermaster-providers/src/quartermaster_providers/config.py
+++ b/quartermaster-providers/src/quartermaster_providers/config.py
@@ -5,7 +5,7 @@ all LLM providers, allowing consistent parameter passing regardless of which
 provider is used.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -22,6 +22,14 @@ class LLMConfig:
         max_output_tokens: Maximum tokens in the response.
         max_messages: Maximum number of messages to include in conversation context.
         vision: Whether the request includes vision/image understanding.
+        images: Optional list of ``(base64_data, mime_type)`` pairs to send
+            alongside the prompt for vision-capable models. ``base64_data``
+            is the raw image bytes encoded as ASCII base64 (no ``data:``
+            URI prefix); ``mime_type`` is e.g. ``"image/jpeg"`` /
+            ``"image/png"`` / ``"image/webp"``. Populated by the v0.3.0
+            engine path that reads ``flow_memory["__user_images__"]``;
+            providers that support vision consume this list when building
+            the request payload. Empty/``None`` means a text-only request.
         thinking_enabled: Whether to enable extended thinking mode (e.g., Claude thinking).
         thinking_budget: Maximum tokens allowed for thinking/reasoning.
         top_p: Nucleus sampling parameter (alternative to temperature).
@@ -39,6 +47,7 @@ class LLMConfig:
     max_output_tokens: int | None = None
     max_messages: int | None = None
     vision: bool = False
+    images: list[tuple[str, str]] = field(default_factory=list)
     thinking_enabled: bool = False
     thinking_budget: int | None = None
     top_p: float | None = None
@@ -118,6 +127,7 @@ class LLMConfig:
             "max_output_tokens": self.max_output_tokens,
             "max_messages": self.max_messages,
             "vision": self.vision,
+            "images": list(self.images),
             "thinking_enabled": self.thinking_enabled,
             "thinking_budget": self.thinking_budget,
             "top_p": self.top_p,

--- a/quartermaster-providers/src/quartermaster_providers/providers/anthropic.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/anthropic.py
@@ -164,9 +164,7 @@ class AnthropicProvider(AbstractLLMProvider):
         """Build Anthropic API request parameters."""
         params: dict[str, Any] = {
             "model": config.model,
-            "messages": [
-                {"role": "user", "content": self._build_user_content(prompt, config)}
-            ],
+            "messages": [{"role": "user", "content": self._build_user_content(prompt, config)}],
             "max_tokens": config.max_output_tokens or DEFAULT_MAX_TOKENS,
         }
 

--- a/quartermaster-providers/src/quartermaster_providers/providers/anthropic.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/anthropic.py
@@ -124,6 +124,37 @@ class AnthropicProvider(AbstractLLMProvider):
             raise ServiceUnavailableError(str(e), provider=self.PROVIDER_NAME) from e
         raise ProviderError(str(e), provider=self.PROVIDER_NAME) from e
 
+    def _build_user_content(
+        self,
+        prompt: str,
+        config: LLMConfig,
+    ) -> str | list[dict[str, Any]]:
+        """Build the user-turn ``content`` field for the Anthropic API.
+
+        Plain text requests use the string shortcut (``content: "..."``)
+        so we don't bloat payloads for the common case. When the caller
+        attached images via ``LLMConfig.images`` we switch to the
+        structured list form and emit an ``image`` block per attachment
+        before the text prompt — the order Anthropic documents for
+        vision tool use.
+        """
+        if not config.images:
+            return prompt
+        blocks: list[dict[str, Any]] = []
+        for b64_data, mime_type in config.images:
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime_type or "image/jpeg",
+                        "data": b64_data,
+                    },
+                }
+            )
+        blocks.append({"type": "text", "text": prompt})
+        return blocks
+
     def _build_params(
         self,
         prompt: str,
@@ -133,7 +164,9 @@ class AnthropicProvider(AbstractLLMProvider):
         """Build Anthropic API request parameters."""
         params: dict[str, Any] = {
             "model": config.model,
-            "messages": [{"role": "user", "content": prompt}],
+            "messages": [
+                {"role": "user", "content": self._build_user_content(prompt, config)}
+            ],
             "max_tokens": config.max_output_tokens or DEFAULT_MAX_TOKENS,
         }
 

--- a/quartermaster-providers/src/quartermaster_providers/providers/google.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/google.py
@@ -103,6 +103,30 @@ class GoogleProvider(AbstractLLMProvider):
             system_instruction=system_instruction,
         )
 
+    def _build_content_parts(self, prompt: str, config: LLMConfig) -> str | list[Any]:
+        """Build the user-turn content for Google's ``generate_content_async``.
+
+        Plain-text requests pass the prompt string directly so we don't bloat
+        small payloads. When ``LLMConfig.images`` carries one or more
+        ``(base64_data, mime_type)`` tuples we decode each back to raw bytes
+        and emit Google's image-part dict shape (``{mime_type, data}``)
+        before the text prompt — the order Gemini documents for vision.
+        """
+        if not config.images:
+            return prompt
+        import base64
+
+        parts: list[Any] = []
+        for b64_data, mime_type in config.images:
+            parts.append(
+                {
+                    "mime_type": mime_type or "image/jpeg",
+                    "data": base64.b64decode(b64_data),
+                }
+            )
+        parts.append(prompt)
+        return parts
+
     def _handle_api_error(self, e: Exception) -> NoReturn:
         """Translate Google SDK exceptions to quartermaster-providers exceptions."""
         msg = str(e).lower()
@@ -178,11 +202,12 @@ class GoogleProvider(AbstractLLMProvider):
     ) -> TokenResponse | AsyncIterator[TokenResponse]:
         model = self._get_model(config)
 
+        content = self._build_content_parts(prompt, config)
         try:
             if config.stream:
-                return self._stream_text(model, prompt)
+                return self._stream_text(model, content)
             else:
-                response = await model.generate_content_async(prompt)
+                response = await model.generate_content_async(content)
                 text = response.text if response.text else ""
                 return TokenResponse(
                     content=text,
@@ -193,9 +218,11 @@ class GoogleProvider(AbstractLLMProvider):
         except Exception as e:
             self._handle_api_error(e)
 
-    async def _stream_text(self, model: Any, prompt: str) -> AsyncIterator[TokenResponse]:
+    async def _stream_text(
+        self, model: Any, content: str | list[Any]
+    ) -> AsyncIterator[TokenResponse]:
         try:
-            response = await model.generate_content_async(prompt, stream=True)
+            response = await model.generate_content_async(content, stream=True)
             async for chunk in response:
                 if chunk.text:
                     yield TokenResponse(content=chunk.text)
@@ -217,10 +244,11 @@ class GoogleProvider(AbstractLLMProvider):
         prepared = [self.prepare_tool(t) for t in tools]
 
         google_tools = [genai.types.Tool(function_declarations=prepared)]
+        content = self._build_content_parts(prompt, config)
 
         try:
             response = await model.generate_content_async(
-                prompt,
+                content,
                 tools=google_tools,
             )
 
@@ -270,8 +298,9 @@ class GoogleProvider(AbstractLLMProvider):
             prepared = [self.prepare_tool(t) for t in tools]
             kwargs["tools"] = [genai.types.Tool(function_declarations=prepared)]
 
+        content = self._build_content_parts(prompt, config)
         try:
-            response = await model.generate_content_async(prompt, **kwargs)
+            response = await model.generate_content_async(content, **kwargs)
 
             text_parts = []
             tool_calls = []
@@ -325,9 +354,10 @@ class GoogleProvider(AbstractLLMProvider):
             f"{prompt}\n\nRespond with valid JSON and nothing else. "
             f"The JSON must match this schema: {json.dumps(schema_dict)}"
         )
+        content = self._build_content_parts(json_prompt, config)
 
         try:
-            response = await model.generate_content_async(json_prompt)
+            response = await model.generate_content_async(content)
             raw_output = response.text if response.text else ""
 
             try:

--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -158,9 +158,7 @@ class OpenAIProvider(AbstractLLMProvider):
             raise ServiceUnavailableError(str(e), provider=self.PROVIDER_NAME) from e
         raise ProviderError(str(e), provider=self.PROVIDER_NAME) from e
 
-    def _build_user_content(
-        self, prompt: str, config: LLMConfig
-    ) -> str | list[dict[str, Any]]:
+    def _build_user_content(self, prompt: str, config: LLMConfig) -> str | list[dict[str, Any]]:
         """Build the user-turn ``content`` field for the Chat Completions API.
 
         Text-only requests keep the plain string shortcut so tokens /

--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -158,12 +158,41 @@ class OpenAIProvider(AbstractLLMProvider):
             raise ServiceUnavailableError(str(e), provider=self.PROVIDER_NAME) from e
         raise ProviderError(str(e), provider=self.PROVIDER_NAME) from e
 
+    def _build_user_content(
+        self, prompt: str, config: LLMConfig
+    ) -> str | list[dict[str, Any]]:
+        """Build the user-turn ``content`` field for the Chat Completions API.
+
+        Text-only requests keep the plain string shortcut so tokens /
+        payloads stay unchanged for 99% of callsites. When the caller
+        attached images via ``LLMConfig.images`` we emit the structured
+        content-part list the OpenAI SDK expects: each image becomes an
+        ``image_url`` part with a ``data:<mime>;base64,<data>`` URL, and
+        the original text prompt comes last.
+        """
+        if not config.images:
+            return prompt
+        parts: list[dict[str, Any]] = []
+        for b64_data, mime_type in config.images:
+            # Wrap as a data URI — cheapest path that works with every
+            # OpenAI-compatible server (including Ollama's /v1 proxy).
+            parts.append(
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:{mime_type or 'image/jpeg'};base64,{b64_data}",
+                    },
+                }
+            )
+        parts.append({"type": "text", "text": prompt})
+        return parts
+
     def _build_messages(self, prompt: str, config: LLMConfig) -> list[dict[str, Any]]:
         """Build OpenAI messages array from prompt and config."""
         messages: list[dict[str, Any]] = []
         if config.system_message and not _is_o_series(config.model):
             messages.append({"role": "system", "content": config.system_message})
-        messages.append({"role": "user", "content": prompt})
+        messages.append({"role": "user", "content": self._build_user_content(prompt, config)})
         return messages
 
     def _build_params(

--- a/quartermaster-providers/tests/test_v030_vision_all_providers.py
+++ b/quartermaster-providers/tests/test_v030_vision_all_providers.py
@@ -1,0 +1,255 @@
+"""v0.3.0 vision regression: every provider that claims vision support
+must actually forward ``LLMConfig.images`` into its API request.
+
+Anthropic and OpenAI got vision wired in the v0.3.0 vision commit.
+Groq + xAI inherit ``OpenAIProvider._build_user_content`` unchanged,
+so they get vision via inheritance. Google has its own implementation
+and needed explicit wiring (see ``GoogleProvider._build_content_parts``).
+
+These tests don't hit real APIs; they patch each provider's underlying
+client and assert the request payload carries the image data in the
+shape the upstream API expects. This is the regression guard that
+prevents a refactor from silently dropping image parts again.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from quartermaster_providers.config import LLMConfig
+
+# Tiny payload (10 bytes). We don't need it to be a valid PNG — providers
+# don't decode it, they just forward the base64 (or raw bytes for Google)
+# to the upstream API.
+_FAKE_IMG_B64 = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode("ascii")
+_FAKE_IMG_BYTES = base64.b64decode(_FAKE_IMG_B64)
+
+
+def _cfg(
+    provider: str,
+    model: str,
+    images: list[tuple[str, str]] | None = None,
+) -> LLMConfig:
+    """Build a minimal LLMConfig with the v0.3.0 ``images`` field set."""
+    return LLMConfig(
+        provider=provider,
+        model=model,
+        temperature=0.1,
+        max_output_tokens=64,
+        images=images or [],
+    )
+
+
+# ── Anthropic ───────────────────────────────────────────────────────────
+
+
+class TestAnthropicVision:
+    def test_image_block_emitted_in_user_content(self) -> None:
+        from quartermaster_providers.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="sk-test")
+        config = _cfg(
+            "anthropic",
+            "claude-haiku-4-5-20251001",
+            [(_FAKE_IMG_B64, "image/png")],
+        )
+
+        content = provider._build_user_content("describe this", config)
+
+        assert isinstance(content, list)
+        assert content[0]["type"] == "image"
+        assert content[0]["source"]["media_type"] == "image/png"
+        assert content[0]["source"]["data"] == _FAKE_IMG_B64
+        assert content[-1]["type"] == "text"
+        assert content[-1]["text"] == "describe this"
+
+    def test_no_image_returns_plain_string(self) -> None:
+        from quartermaster_providers.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="sk-test")
+        config = _cfg("anthropic", "claude-haiku-4-5-20251001")
+
+        content = provider._build_user_content("plain text only", config)
+
+        assert content == "plain text only"
+
+
+# ── OpenAI ──────────────────────────────────────────────────────────────
+
+
+class TestOpenAIVision:
+    def test_image_url_part_emitted_in_user_content(self) -> None:
+        from quartermaster_providers.providers.openai import OpenAIProvider
+
+        provider = OpenAIProvider(api_key="sk-test")
+        config = _cfg(
+            "openai",
+            "gpt-4o-mini",
+            [(_FAKE_IMG_B64, "image/png")],
+        )
+
+        content = provider._build_user_content("describe this", config)
+
+        assert isinstance(content, list)
+        # OpenAI uses a data: URI under image_url.url
+        image_part = next(p for p in content if p.get("type") == "image_url")
+        assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+        assert _FAKE_IMG_B64 in image_part["image_url"]["url"]
+        text_part = next(p for p in content if p.get("type") == "text")
+        assert text_part["text"] == "describe this"
+
+
+# ── Groq (inherits OpenAI; verify no override broke it) ─────────────────
+
+
+class TestGroqVisionInheritance:
+    def test_groq_inherits_openai_vision_path(self) -> None:
+        from quartermaster_providers.providers.groq import GroqProvider
+
+        provider = GroqProvider(api_key="gsk-test")
+        config = _cfg(
+            "groq",
+            "llama-3.2-90b-vision-preview",
+            [(_FAKE_IMG_B64, "image/jpeg")],
+        )
+
+        content = provider._build_user_content("what is in this picture", config)
+
+        # Groq doesn't override _build_user_content — should match OpenAI shape.
+        assert isinstance(content, list)
+        assert any(p.get("type") == "image_url" for p in content)
+
+
+# ── xAI (inherits OpenAI; verify no override broke it) ──────────────────
+
+
+class TestXAIVisionInheritance:
+    def test_xai_inherits_openai_vision_path(self) -> None:
+        from quartermaster_providers.providers.xai import XAIProvider
+
+        provider = XAIProvider(api_key="xai-test")
+        config = _cfg(
+            "xai",
+            "grok-2-vision-1212",
+            [(_FAKE_IMG_B64, "image/jpeg")],
+        )
+
+        content = provider._build_user_content("what is in this picture", config)
+
+        assert isinstance(content, list)
+        assert any(p.get("type") == "image_url" for p in content)
+
+
+# ── Google ──────────────────────────────────────────────────────────────
+
+
+class TestGoogleVision:
+    """Google takes a different shape than Anthropic/OpenAI — the
+    ``generate_content_async`` call accepts a list of parts where each
+    image is a ``{mime_type, data}`` dict and the text is a plain str.
+    Our ``_build_content_parts`` produces this list; these tests pin
+    the conversion (base64 -> raw bytes) and ordering (images first,
+    text last)."""
+
+    def _provider(self):
+        # Google provider validates the SDK is installed at __init__.
+        try:
+            import google.generativeai  # noqa: F401
+        except ImportError:
+            pytest.skip("google-generativeai not installed in this env")
+        from quartermaster_providers.providers.google import GoogleProvider
+
+        return GoogleProvider(api_key="AIza-test")
+
+    def test_image_part_emitted_with_decoded_bytes(self) -> None:
+        provider = self._provider()
+        config = _cfg(
+            "google",
+            "gemini-1.5-flash",
+            [(_FAKE_IMG_B64, "image/png")],
+        )
+
+        parts = provider._build_content_parts("describe this", config)
+
+        assert isinstance(parts, list)
+        assert len(parts) == 2
+        # First part: image dict with raw decoded bytes (NOT base64).
+        assert parts[0]["mime_type"] == "image/png"
+        assert parts[0]["data"] == _FAKE_IMG_BYTES
+        # Last part: prompt string.
+        assert parts[1] == "describe this"
+
+    def test_no_image_returns_plain_string(self) -> None:
+        provider = self._provider()
+        config = _cfg("google", "gemini-1.5-flash")
+
+        parts = provider._build_content_parts("plain text only", config)
+
+        assert parts == "plain text only"
+
+    def test_default_mime_type_when_none(self) -> None:
+        """An image with no mime_type defaults to image/jpeg."""
+        provider = self._provider()
+        config = _cfg(
+            "google",
+            "gemini-1.5-flash",
+            [(_FAKE_IMG_B64, "")],
+        )
+
+        parts = provider._build_content_parts("describe this", config)
+
+        assert isinstance(parts, list)
+        assert parts[0]["mime_type"] == "image/jpeg"
+
+    def test_multiple_images_preserved_in_order(self) -> None:
+        provider = self._provider()
+        img2_b64 = base64.b64encode(b"second image bytes").decode("ascii")
+        config = _cfg(
+            "google",
+            "gemini-1.5-flash",
+            [
+                (_FAKE_IMG_B64, "image/png"),
+                (img2_b64, "image/webp"),
+            ],
+        )
+
+        parts = provider._build_content_parts("compare these two", config)
+
+        assert isinstance(parts, list)
+        assert len(parts) == 3
+        assert parts[0]["mime_type"] == "image/png"
+        assert parts[1]["mime_type"] == "image/webp"
+        assert parts[2] == "compare these two"
+
+    @pytest.mark.asyncio
+    async def test_generate_text_response_passes_content_parts(self) -> None:
+        """Integration-style: patch the model and assert the call site
+        forwards the structured parts (not the raw prompt string)."""
+        provider = self._provider()
+        config = _cfg(
+            "google",
+            "gemini-1.5-flash",
+            [(_FAKE_IMG_B64, "image/png")],
+        )
+
+        fake_response = MagicMock()
+        fake_response.text = "I see a tiny image"
+        fake_response.candidates = []
+        fake_response.usage_metadata = None
+
+        with patch.object(provider, "_get_model") as get_model:
+            mock_model = MagicMock()
+            mock_model.generate_content_async = AsyncMock(return_value=fake_response)
+            get_model.return_value = mock_model
+
+            await provider.generate_text_response("describe", config)
+
+        # The arg passed to generate_content_async should be the list of parts
+        # we'd get from _build_content_parts (not the bare prompt string).
+        called_with = mock_model.generate_content_async.await_args.args[0]
+        assert isinstance(called_with, list)
+        assert called_with[0]["mime_type"] == "image/png"
+        assert called_with[1] == "describe"

--- a/quartermaster-sdk/README.md
+++ b/quartermaster-sdk/README.md
@@ -66,15 +66,96 @@ result["notes"].output_text    # agent's free-text research
 result["data"].output_text     # extracted JSON
 ```
 
-## Streaming
+## Streaming (v0.3.0 filtered iterators)
+
+`qm.run.stream(...)` returns a wrapper you can iterate raw or pipe
+through a filter — one helper per chunk family:
+
+| Filter | Yields | Use for |
+|---|---|---|
+| `.tokens()` | `str` (the token text) | Typewriter UI — just the text |
+| `.tool_calls()` | `ToolCallChunk` | Dashboard cards: `call.tool`, `call.args` |
+| `.progress()` | `ProgressChunk` | `prog.message`, `prog.percent`, `prog.data` |
+| `.custom(name=...)` | `CustomChunk` | Application-defined milestones |
+| (raw `for chunk in ...`) | `Chunk` union | Debugging, pass-through consumers |
 
 ```python
-for chunk in qm.run.stream(qm.Graph("chat").user().agent(), "Tell me a story"):
-    if chunk.type == "token":
-        print(chunk.content, end="", flush=True)
-    elif chunk.type == "done":
-        final = chunk.result    # qm.Result
+# Typewriter effect -- tokens only.
+for token in qm.run.stream(graph, "Tell me a story").tokens():
+    print(token, end="", flush=True)
+
+# Dashboard view -- just the tool calls.
+for call in qm.run.stream(graph, "Research Slovenia").tool_calls():
+    ui.tool_card(call.tool, call.args)
+
+# Progress cards interleaved with model tokens.
+for prog in qm.run.stream(graph, "Crunch the dataset").progress():
+    ui.status(prog.message, prog.percent)
+
+# Subscribe to one milestone name only.
+for evt in qm.run.stream(graph, "Research").custom(name="source_found"):
+    ui.add_source(evt.payload["url"])
 ```
+
+Streams are **single-pass** — the wrapper owns its underlying generator,
+so picking a second filter (or raw-iterating after a filter) raises
+`RuntimeError("stream already consumed")`. Pick one consumer per stream.
+
+The async analogue is available via `qm.arun.stream(...)` with the same
+four filter helpers, returning `AsyncIterator[...]`.
+
+## Post-mortem `Result.trace`
+
+Every `Result` (sync or the terminal `DoneChunk.result` of a stream)
+carries a structured `Trace` built from the full `FlowEvent` stream:
+
+```python
+result = qm.run(graph, "Hello!")
+
+result.trace.text                        # concatenated model output
+result.trace.tool_calls                  # list[dict] across every agent node
+result.trace.progress                    # list[ProgressEvent]
+result.trace.custom(name="source_found") # filtered CustomEvent list
+result.trace.by_node["Researcher"].text  # tokens for a single node
+print(result.trace.as_jsonl())           # JSONL export for logs / fixtures
+```
+
+## Progress events from inside tools
+
+Long-running tools reach the flow's `ExecutionContext` via
+`qm.current_context()` and emit structured events that stream back to
+the UI alongside model tokens:
+
+```python
+from quartermaster_tools import tool
+
+@tool()
+def slow_research(topic: str) -> dict:
+    ctx = qm.current_context()      # None when called outside a flow -- safe
+    if ctx is not None:
+        ctx.emit_progress("Gathering sources", percent=0.25, topic=topic)
+        ctx.emit_custom("source_found", {"url": "https://example.com"})
+    # ... do real work ...
+    return {"summary": "..."}
+```
+
+## OpenTelemetry instrumentation
+
+```bash
+pip install 'quartermaster-sdk[telemetry]'
+```
+
+```python
+from quartermaster_sdk import telemetry
+
+telemetry.instrument()     # uses the global tracer provider
+qm.run(graph, "Hello!")    # every node + tool call is now a span
+```
+
+Spans follow the OpenTelemetry GenAI semantic conventions
+(`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`,
+`gen_ai.usage.input_tokens`, …). Point your exporter at Jaeger, Tempo,
+Honeycomb, Logfire, Phoenix, or any OTLP collector.
 
 ## Quick Start (cloud provider)
 

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -57,9 +57,15 @@ tools-all = ["quartermaster-tools[all]"]
 mcp = ["quartermaster-mcp-client>=0.2.1"]
 code-runner = ["quartermaster-code-runner>=0.2.1"]
 
+# OpenTelemetry instrumentation (qm.telemetry.instrument())
+telemetry = [
+    "opentelemetry-api>=1.25",
+    "opentelemetry-sdk>=1.25",
+]
+
 # Everything
 all = [
-    "quartermaster-sdk[providers-all,tools-all,mcp,code-runner]",
+    "quartermaster-sdk[providers-all,tools-all,mcp,code-runner,telemetry]",
 ]
 
 # Development

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -46,6 +46,9 @@ from quartermaster_engine import (  # noqa: F401
     build_default_registry,
     run_graph,
 )
+from quartermaster_engine.context.current_context import (  # noqa: F401
+    current_context,
+)
 from quartermaster_graph import (  # noqa: F401
     AgentGraph,  # deprecated alias for GraphSpec — kept for backward compat
     Graph,
@@ -63,10 +66,12 @@ from quartermaster_providers import (  # noqa: F401
 from ._chunks import (  # noqa: F401
     AwaitInputChunk,
     Chunk,
+    CustomChunk,
     DoneChunk,
     ErrorChunk,
     NodeFinishChunk,
     NodeStartChunk,
+    ProgressChunk,
     TokenChunk,
     ToolCallChunk,
     ToolResultChunk,
@@ -81,6 +86,7 @@ from ._async_runner import arun  # noqa: F401
 from ._helpers import instruction, instruction_form  # noqa: F401
 from ._result import Result  # noqa: F401
 from ._runner import run  # noqa: F401
+from ._trace import NodeTrace, Trace  # noqa: F401
 
 
 __all__ = [
@@ -93,6 +99,9 @@ __all__ = [
     "instruction",
     "instruction_form",
     "Result",
+    # Structured post-mortem trace — v0.3.0
+    "Trace",
+    "NodeTrace",
     # Typed streaming chunks
     "Chunk",
     "TokenChunk",
@@ -101,8 +110,12 @@ __all__ = [
     "ToolCallChunk",
     "ToolResultChunk",
     "AwaitInputChunk",
+    "ProgressChunk",
+    "CustomChunk",
     "DoneChunk",
     "ErrorChunk",
+    # Context reach — tools call current_context() to emit progress
+    "current_context",
     # Graph builder + spec
     "Graph",
     "GraphBuilder",

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -33,7 +33,7 @@ import time
 from typing import TYPE_CHECKING, Any, AsyncIterator
 from uuid import uuid4
 
-from quartermaster_engine import FlowEvent, FlowRunner
+from quartermaster_engine import FlowEvent, FlowRunner, ImageInput, prepare_images
 
 from . import _listeners
 from ._chunks import Chunk, DoneChunk, ErrorChunk
@@ -64,6 +64,8 @@ class _ARunCallable:
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
+        image: ImageInput | None = None,
+        images: list[ImageInput] | None = None,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
     ) -> Result:
@@ -73,6 +75,11 @@ class _ARunCallable:
             graph: Either a :class:`GraphBuilder` (auto-finalised) or
                 a pre-built :class:`GraphSpec`.
             user_input: Primary user message injected into the graph.
+            image: Optional single image input for vision-capable graphs.
+                Accepts raw ``bytes``, a :class:`pathlib.Path`, or a
+                filesystem path string. Mutually exclusive with *images*.
+            images: Optional list of image inputs. Mutually exclusive
+                with *image*.
             provider_registry: Override the configured default registry.
             tool_registry: Optional :class:`quartermaster_tools.ToolRegistry`
                 made available to ``agent()``-type nodes that specify
@@ -85,6 +92,7 @@ class _ARunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+        prepared_images = prepare_images(image=image, images=images)
 
         # v0.3.0 trace: accumulate every FlowEvent on the worker
         # thread so we can build a ``Trace`` and attach it to the
@@ -114,7 +122,15 @@ class _ARunCallable:
 
         started = time.perf_counter()
         try:
-            fr = await asyncio.to_thread(runner.run, user_input, flow_id=flow_id)
+            # ``asyncio.to_thread`` forwards *args and **kwargs — keep
+            # the image payload as a kwarg so the engine picks it up
+            # via its named ``images=`` parameter.
+            fr = await asyncio.to_thread(
+                runner.run,
+                user_input,
+                images=prepared_images or None,
+                flow_id=flow_id,
+            )
         except asyncio.CancelledError:
             # ``asyncio.to_thread`` can't actually interrupt the worker
             # thread — the thread keeps executing until it voluntarily
@@ -142,6 +158,8 @@ class _ARunCallable:
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
+        image: ImageInput | None = None,
+        images: list[ImageInput] | None = None,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
     ) -> _AsyncStream:
@@ -172,6 +190,8 @@ class _ARunCallable:
         return _AsyncStream(self._aiter_chunks(
             graph=graph,
             user_input=user_input,
+            image=image,
+            images=images,
             provider_registry=provider_registry,
             tool_registry=tool_registry,
         ))
@@ -181,6 +201,8 @@ class _ARunCallable:
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
+        image: ImageInput | None = None,
+        images: list[ImageInput] | None = None,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
     ) -> AsyncIterator[Chunk]:
@@ -191,6 +213,7 @@ class _ARunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+        prepared_images = prepare_images(image=image, images=images)
 
         # Capture the consumer's loop so the thread can marshal events
         # back to it via ``call_soon_threadsafe``.  ``run_coroutine_threadsafe``
@@ -228,7 +251,11 @@ class _ARunCallable:
         def _run_sync() -> None:
             """Runs on the ``to_thread`` worker — synchronous engine loop."""
             try:
-                fr = runner.run(user_input, flow_id=flow_id)
+                fr = runner.run(
+                    user_input,
+                    images=prepared_images or None,
+                    flow_id=flow_id,
+                )
                 holder["result"] = fr
             except Exception as exc:  # pragma: no cover — defensive
                 logger.exception("arun.stream: runner.run raised")

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -85,6 +85,19 @@ class _ARunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+
+        # v0.3.0 trace: accumulate every FlowEvent on the worker
+        # thread so we can build a ``Trace`` and attach it to the
+        # returned ``Result``. The list is populated from inside the
+        # engine's worker thread and only READ after ``await
+        # asyncio.to_thread`` resolves, so no cross-thread sync is
+        # required.
+        trace_events: list[FlowEvent] = []
+
+        def _collect(event: FlowEvent) -> None:
+            trace_events.append(event)
+            _listeners.dispatch(event)
+
         runner = FlowRunner(
             graph=spec,
             provider_registry=registry,
@@ -93,12 +106,13 @@ class _ARunCallable:
             # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
             # observes the same FlowEvent stream the streaming runner
             # gets — even though there's no consumer queue here.
-            on_event=_listeners.dispatch,
+            on_event=_collect,
         )
         # Pre-generate so the async cancel handler has something to stop,
         # even if the to_thread() call hasn't entered ``runner.run`` yet.
         flow_id = uuid4()
 
+        started = time.perf_counter()
         try:
             fr = await asyncio.to_thread(runner.run, user_input, flow_id=flow_id)
         except asyncio.CancelledError:
@@ -114,8 +128,14 @@ class _ARunCallable:
             except Exception:  # pragma: no cover — defensive
                 logger.exception("arun: runner.stop(%s) raised", flow_id)
             raise
+        elapsed = time.perf_counter() - started
 
-        return Result.from_flow_result(fr)
+        result = Result.from_flow_result(fr)
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        return result
 
     def stream(
         self,
@@ -181,11 +201,18 @@ class _ARunCallable:
         holder: dict[str, Any] = {}
         flow_id = uuid4()
 
+        # v0.3.0 trace: accumulate events as they fire (on the engine
+        # worker thread) so we can build a ``Trace`` before yielding
+        # the terminal ``DoneChunk``. Append-only from the engine
+        # thread, read-only once ``run_task`` has finished.
+        trace_events: list[FlowEvent] = []
+
         def on_event(event: FlowEvent) -> None:
             # Fan out to bolt-on instrumentation (telemetry, custom
             # listeners, etc.) on the engine's worker thread BEFORE
             # marshalling the event back to the consumer's loop.
             _listeners.dispatch(event)
+            trace_events.append(event)
             # Called from the engine's worker threads.  Hop back to the
             # consumer's loop so Queue.put() touches only loop-owned
             # state — ``asyncio.Queue`` is not thread-safe.
@@ -210,6 +237,7 @@ class _ARunCallable:
                 # Sentinel — unblocks the async iterator even on crash.
                 loop.call_soon_threadsafe(q.put_nowait, None)
 
+        started = time.perf_counter()
         run_task = asyncio.create_task(
             asyncio.to_thread(_run_sync), name="qm-arun-stream"
         )
@@ -267,7 +295,18 @@ class _ARunCallable:
             yield ErrorChunk(error="arun.stream: runner produced no result")
             return
 
-        yield DoneChunk(result=Result.from_flow_result(fr))
+        elapsed = time.perf_counter() - started
+        result = Result.from_flow_result(fr)
+        # v0.3.0: populate the structured trace from every FlowEvent
+        # the engine dispatched. The ``on_event`` hook on the engine
+        # thread appended each event as it fired; we build the
+        # bucketed view once the run has finished and hand it to the
+        # caller as part of the DoneChunk's Result.
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        yield DoneChunk(result=result)
 
 
 #: Publicly exported async runner.  ``await qm.arun(graph, input)`` runs

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -187,14 +187,16 @@ class _ARunCallable:
         loops unwind within a bounded time instead of leaking API costs
         after the consumer goes away.
         """
-        return _AsyncStream(self._aiter_chunks(
-            graph=graph,
-            user_input=user_input,
-            image=image,
-            images=images,
-            provider_registry=provider_registry,
-            tool_registry=tool_registry,
-        ))
+        return _AsyncStream(
+            self._aiter_chunks(
+                graph=graph,
+                user_input=user_input,
+                image=image,
+                images=images,
+                provider_registry=provider_registry,
+                tool_registry=tool_registry,
+            )
+        )
 
     async def _aiter_chunks(
         self,
@@ -288,21 +290,15 @@ class _ARunCallable:
                 try:
                     runner.stop(flow_id)
                 except Exception:  # pragma: no cover — defensive
-                    logger.exception(
-                        "arun.stream: runner.stop(%s) raised", flow_id
-                    )
+                    logger.exception("arun.stream: runner.stop(%s) raised", flow_id)
                 # Wait (bounded) for the worker thread to observe the
                 # ``_stopped`` flag and return.  If it overshoots we let
                 # the task leak rather than blocking the event loop
                 # indefinitely — matches the 5s join() on the sync side.
                 try:
-                    await asyncio.wait_for(
-                        asyncio.shield(run_task), timeout=5.0
-                    )
+                    await asyncio.wait_for(asyncio.shield(run_task), timeout=5.0)
                 except asyncio.TimeoutError:  # pragma: no cover — defensive
-                    logger.warning(
-                        "arun.stream: runner thread did not exit within 5s"
-                    )
+                    logger.warning("arun.stream: runner thread did not exit within 5s")
                 except asyncio.CancelledError:
                     # Expected when the outer task was cancelled — let
                     # the shielded run_task keep going in the background

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -29,15 +29,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING, Any, AsyncIterator
 from uuid import uuid4
 
 from quartermaster_engine import FlowEvent, FlowRunner
 
+from . import _listeners
 from ._chunks import Chunk, DoneChunk, ErrorChunk
 from ._config import get_default_registry
 from ._result import Result
 from ._runner import _event_to_chunk, _resolve_graph
+from ._stream_filters import _AsyncStream
+from ._trace import Trace
 
 if TYPE_CHECKING:
     from quartermaster_graph import GraphBuilder, GraphSpec
@@ -85,6 +89,11 @@ class _ARunCallable:
             graph=spec,
             provider_registry=registry,
             tool_registry=tool_registry,
+            # Forward every event to the global listener registry so
+            # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
+            # observes the same FlowEvent stream the streaming runner
+            # gets — even though there's no consumer queue here.
+            on_event=_listeners.dispatch,
         )
         # Pre-generate so the async cancel handler has something to stop,
         # even if the to_thread() call hasn't entered ``runner.run`` yet.
@@ -108,15 +117,22 @@ class _ARunCallable:
 
         return Result.from_flow_result(fr)
 
-    async def stream(
+    def stream(
         self,
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
-    ) -> AsyncIterator[Chunk]:
+    ) -> _AsyncStream:
         """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Returns an :class:`_AsyncStream` wrapper that is itself
+        async-iterable (so existing ``async for chunk in
+        qm.arun.stream(...)`` loops work unchanged) and exposes filter
+        helpers — ``.tokens()``, ``.tool_calls()``, ``.progress()``,
+        ``.custom(name=...)`` — for the common "pluck one chunk type
+        out of the stream" patterns.
 
         Terminates with a :class:`DoneChunk` (on success) or
         :class:`ErrorChunk` (on unrecoverable failure).  The graph
@@ -133,6 +149,26 @@ class _ARunCallable:
         loops unwind within a bounded time instead of leaking API costs
         after the consumer goes away.
         """
+        return _AsyncStream(self._aiter_chunks(
+            graph=graph,
+            user_input=user_input,
+            provider_registry=provider_registry,
+            tool_registry=tool_registry,
+        ))
+
+    async def _aiter_chunks(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> AsyncIterator[Chunk]:
+        """Inner async generator that powers :meth:`stream`.
+
+        Kept private: callers always go through ``stream()`` which
+        wraps the result in :class:`_AsyncStream` for filter support.
+        """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
 
@@ -146,6 +182,10 @@ class _ARunCallable:
         flow_id = uuid4()
 
         def on_event(event: FlowEvent) -> None:
+            # Fan out to bolt-on instrumentation (telemetry, custom
+            # listeners, etc.) on the engine's worker thread BEFORE
+            # marshalling the event back to the consumer's loop.
+            _listeners.dispatch(event)
             # Called from the engine's worker threads.  Hop back to the
             # consumer's loop so Queue.put() touches only loop-owned
             # state — ``asyncio.Queue`` is not thread-safe.

--- a/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
@@ -90,6 +90,42 @@ class AwaitInputChunk:
 
 
 @dataclass
+class ProgressChunk:
+    """Application-emitted progress signal.
+
+    Fires whenever code inside a node or tool called
+    :meth:`ExecutionContext.emit_progress` — typically a long-running
+    tool (``web_search``, OCR, multi-step lookup) reporting status to
+    the UI alongside model tokens. ``percent`` is ``None`` for
+    indeterminate / spinner-style progress or a 0.0–1.0 float for a
+    determinate progress bar. ``data`` is a free-form dict for
+    structured payload fields.
+    """
+
+    message: str
+    percent: float | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+    type: Literal["progress"] = "progress"
+
+
+@dataclass
+class CustomChunk:
+    """Application-defined structured event.
+
+    Fires when node/tool code calls
+    :meth:`ExecutionContext.emit_custom`. Use this over
+    :class:`ProgressChunk` when the signal is a discrete milestone
+    ("retrieved_docs", "cache_hit", "quota_warning") rather than a
+    percent-along-a-task signal. Consumers filter on ``name`` via
+    ``stream.custom(name=...)``.
+    """
+
+    name: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    type: Literal["custom"] = "custom"
+
+
+@dataclass
 class DoneChunk:
     """The flow finished — carries the final :class:`Result`."""
 
@@ -113,6 +149,8 @@ Chunk = Union[
     ToolCallChunk,
     ToolResultChunk,
     AwaitInputChunk,
+    ProgressChunk,
+    CustomChunk,
     DoneChunk,
     ErrorChunk,
 ]
@@ -132,6 +170,8 @@ __all__ = [
     "ToolCallChunk",
     "ToolResultChunk",
     "AwaitInputChunk",
+    "ProgressChunk",
+    "CustomChunk",
     "DoneChunk",
     "ErrorChunk",
 ]

--- a/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
@@ -15,6 +15,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, TypeVar
 
+from quartermaster_engine import ImageInput
 from quartermaster_graph import Graph
 
 from ._config import get_default_model
@@ -61,6 +62,8 @@ def instruction(
     temperature: float = 0.7,
     max_output_tokens: int | None = None,
     thinking_level: str = "off",
+    image: ImageInput | None = None,
+    images: list[ImageInput] | None = None,
     provider_registry: ProviderRegistry | None = None,
 ) -> str:
     """Single-shot prompt → text.
@@ -80,6 +83,13 @@ def instruction(
         max_output_tokens: Hard cap on output tokens.
         thinking_level: ``off``/``low``/``medium``/``high`` — forwarded
             to reasoning-capable models.
+        image: Optional single image input (``bytes``,
+            :class:`pathlib.Path`, or path string). When set, the
+            one-node graph is built as a ``.vision()`` node so the
+            image is forwarded to the model alongside the text prompt.
+            Mutually exclusive with *images*.
+        images: Optional list of image inputs (same per-item types as
+            *image*). Mutually exclusive with *image*.
         provider_registry: Override the module-level default registry.
 
     Returns:
@@ -93,9 +103,26 @@ def instruction(
             "quartermaster_sdk.configure(default_model=...) at app boot."
         )
 
-    graph = (
-        Graph("instruction")
-        .instruction(
+    # Pick the right single-node graph based on whether the caller
+    # supplied any images. A ``.vision()`` node is identical to an
+    # ``.instruction()`` node except it sets ``vision=True`` in metadata,
+    # which is what the engine uses to decide whether to forward the
+    # flow-memory ``__user_images__`` list into the provider config.
+    has_image = image is not None or images is not None
+
+    builder = Graph("instruction")
+    if has_image:
+        builder = builder.vision(
+            "Vision",
+            model=resolved_model,
+            provider=provider,
+            temperature=temperature,
+            system_instruction=system,
+            max_output_tokens=max_output_tokens,
+            thinking_level=thinking_level,
+        )
+    else:
+        builder = builder.instruction(
             "Instruction",
             model=resolved_model,
             provider=provider,
@@ -104,10 +131,15 @@ def instruction(
             max_output_tokens=max_output_tokens,
             thinking_level=thinking_level,
         )
-        .build()
-    )
+    graph = builder.build()
 
-    result = run(graph, user, provider_registry=provider_registry)
+    result = run(
+        graph,
+        user,
+        image=image,
+        images=images,
+        provider_registry=provider_registry,
+    )
     if not result.success:
         raise RuntimeError(f"instruction() failed: {result.error}")
     return result.text
@@ -122,6 +154,8 @@ def instruction_form(
     provider: str = "",
     temperature: float = 0.1,
     max_output_tokens: int | None = None,
+    image: ImageInput | None = None,
+    images: list[ImageInput] | None = None,
     provider_registry: ProviderRegistry | None = None,
 ) -> T:
     """Single-shot prompt → Pydantic model.
@@ -205,6 +239,8 @@ def instruction_form(
         temperature=temperature,
         max_output_tokens=max_output_tokens,
         thinking_level="off",
+        image=image,
+        images=images,
         provider_registry=provider_registry,
     )
 

--- a/quartermaster-sdk/src/quartermaster_sdk/_listeners.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_listeners.py
@@ -1,0 +1,83 @@
+"""Process-global ``FlowEvent`` listener registry.
+
+Lets the SDK fan out a single :class:`FlowEvent` to many subscribers
+without each subscriber needing to thread its own ``on_event=`` callback
+through every ``run`` / ``arun`` / ``run.stream`` call site.
+
+This is the seam :mod:`quartermaster_sdk.telemetry` (and any other
+bolt-on instrumentation) hooks into via :func:`register` / :func:`unregister`.
+The two SDK runners (:mod:`._runner` and :mod:`._async_runner`) call
+:func:`dispatch` from inside the existing ``on_event`` callback they
+already pass to :class:`FlowRunner`, so we never have to reach into the
+engine itself to install a global handler.
+
+**Scope:** single-process. The list lives in module-level state guarded
+by a :class:`threading.Lock`; cross-process fan-out (e.g. distributed
+tracing across worker pools) is the responsibility of whatever exporter
+the listener wires up to.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable
+
+from quartermaster_engine import FlowEvent
+
+logger = logging.getLogger(__name__)
+
+#: Registered listeners. Mutated under :data:`_lock`; read under the
+#: lock too, then iterated outside the critical section so a slow
+#: handler can't stall a concurrent ``register`` / ``unregister`` call.
+_global_listeners: list[Callable[[FlowEvent], None]] = []
+_lock = threading.Lock()
+
+
+def register(fn: Callable[[FlowEvent], None]) -> None:
+    """Add *fn* to the process-global listener list.
+
+    Idempotent: registering the same callable twice is a no-op so
+    callers don't accidentally double-subscribe (which would emit
+    duplicate spans on every event).
+    """
+    with _lock:
+        if fn not in _global_listeners:
+            _global_listeners.append(fn)
+
+
+def unregister(fn: Callable[[FlowEvent], None]) -> None:
+    """Remove *fn* from the listener list. Silent if not registered."""
+    with _lock:
+        try:
+            _global_listeners.remove(fn)
+        except ValueError:
+            pass
+
+
+def dispatch(event: FlowEvent) -> None:
+    """Fan out *event* to every registered listener.
+
+    Exceptions raised by a listener are logged and swallowed — one
+    misbehaving subscriber must not break the SDK runner or starve
+    other subscribers of the same event.
+    """
+    # Snapshot under the lock so we never iterate a list someone is
+    # mutating; emit outside the lock so a slow listener can't block
+    # ``register`` / ``unregister`` from the instrumenting code.
+    with _lock:
+        listeners = list(_global_listeners)
+    for fn in listeners:
+        try:
+            fn(event)
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("Listener %r raised on %r", fn, type(event).__name__)
+
+
+def clear() -> None:
+    """Drop every listener. Test-only helper; not part of the public API."""
+    with _lock:
+        _global_listeners.clear()
+
+
+__all__ = ["register", "unregister", "dispatch", "clear"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_result.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_result.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from ._trace import Trace
+
 if TYPE_CHECKING:
     from quartermaster_engine import FlowResult
     from quartermaster_engine.nodes import NodeResult
@@ -49,6 +51,14 @@ class Result:
         error: Concatenated error messages from any failed node, or
             ``None`` on success.
         duration_seconds: Wall-clock time the flow took to execute.
+        trace: Structured :class:`Trace` carrying every
+            :class:`FlowEvent` emitted during the run — tokens, tool
+            calls, progress, custom events, per-node buckets, and a
+            JSONL exporter.  Populated by the runner (both sync and
+            streaming paths install an ``on_event`` collector); defaults
+            to an empty :class:`Trace` when a :class:`Result` is built
+            from just a :class:`FlowResult` without runner-captured
+            events.
         raw: The underlying :class:`FlowResult` — escape hatch when you
             need UUID-keyed ``node_results`` or the full ``output_data``
             maps.
@@ -59,6 +69,7 @@ class Result:
     success: bool = True
     error: str | None = None
     duration_seconds: float = 0.0
+    trace: Trace = field(default_factory=Trace)
     raw: FlowResult | None = None
 
     def __getitem__(self, name: str) -> NodeResult:

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -192,14 +192,16 @@ class _RunCallable:
         nodes are dispatched, so long agent loops unwind within a
         bounded time instead of leaking API costs in the background.
         """
-        return _Stream(self._iter_chunks(
-            graph=graph,
-            user_input=user_input,
-            image=image,
-            images=images,
-            provider_registry=provider_registry,
-            tool_registry=tool_registry,
-        ))
+        return _Stream(
+            self._iter_chunks(
+                graph=graph,
+                user_input=user_input,
+                image=image,
+                images=images,
+                provider_registry=provider_registry,
+                tool_registry=tool_registry,
+            )
+        )
 
     def _iter_chunks(
         self,

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -22,35 +22,43 @@ from __future__ import annotations
 import logging
 import queue
 import threading
+import time
 from typing import TYPE_CHECKING, Any, Iterator
 from uuid import uuid4
 
 from quartermaster_engine import (
+    CustomEvent,
     FlowError,
     FlowEvent,
     FlowFinished,
     FlowRunner,
     NodeFinished,
     NodeStarted,
+    ProgressEvent,
     TokenGenerated,
     ToolCallFinished,
     ToolCallStarted,
     UserInputRequired,
 )
 
+from . import _listeners
 from ._chunks import (
     AwaitInputChunk,
     Chunk,
+    CustomChunk,
     DoneChunk,
     ErrorChunk,
     NodeFinishChunk,
     NodeStartChunk,
+    ProgressChunk,
     TokenChunk,
     ToolCallChunk,
     ToolResultChunk,
 )
 from ._config import get_default_registry
 from ._result import Result
+from ._stream_filters import _Stream
+from ._trace import Trace
 
 if TYPE_CHECKING:
     from quartermaster_graph import GraphBuilder, GraphSpec
@@ -94,13 +102,40 @@ class _RunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+
+        # v0.3.0 trace: accumulate every FlowEvent into a local list
+        # so we can build a ``Trace`` and attach it to the returned
+        # ``Result``. Fires alongside the global listener dispatch so
+        # bolt-on instrumentation still sees the same stream.
+        trace_events: list[FlowEvent] = []
+
+        def _collect(event: FlowEvent) -> None:
+            trace_events.append(event)
+            _listeners.dispatch(event)
+
         runner = FlowRunner(
             graph=spec,
             provider_registry=registry,
             tool_registry=tool_registry,
+            # Forward every event to the global listener registry so
+            # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
+            # observes the same FlowEvent stream the streaming runner
+            # gets — even though there's no consumer queue here.
+            on_event=_collect,
         )
+        started = time.perf_counter()
         fr = runner.run(user_input)
-        return Result.from_flow_result(fr)
+        elapsed = time.perf_counter() - started
+
+        result = Result.from_flow_result(fr)
+        # FlowResult's ``duration_seconds`` is authoritative when
+        # populated; fall back to our wall-clock measurement for the
+        # trace if the engine left it at 0.
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        return result
 
     def stream(
         self,
@@ -109,8 +144,15 @@ class _RunCallable:
         *,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
-    ) -> Iterator[Chunk]:
+    ) -> _Stream:
         """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Returns a :class:`_Stream` wrapper that is itself iterable (so
+        existing ``for chunk in qm.run.stream(...)`` loops work
+        unchanged) and exposes filter helpers — ``.tokens()``,
+        ``.tool_calls()``, ``.progress()``, ``.custom(name=...)`` —
+        for the common "pluck one chunk type out of the stream"
+        patterns.
 
         Terminates with a :class:`DoneChunk` (on success) or
         :class:`ErrorChunk` (on unrecoverable failure).  The graph
@@ -126,6 +168,26 @@ class _RunCallable:
         nodes are dispatched, so long agent loops unwind within a
         bounded time instead of leaking API costs in the background.
         """
+        return _Stream(self._iter_chunks(
+            graph=graph,
+            user_input=user_input,
+            provider_registry=provider_registry,
+            tool_registry=tool_registry,
+        ))
+
+    def _iter_chunks(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Iterator[Chunk]:
+        """Inner generator that powers :meth:`stream`.
+
+        Kept private: callers always go through ``stream()`` which
+        wraps the result in :class:`_Stream` for filter support.
+        """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
 
@@ -140,7 +202,18 @@ class _RunCallable:
         # reaching into a private attribute.
         flow_id = uuid4()
 
+        # v0.3.0 trace: same collector the sync path uses, populated in
+        # arrival order on the runner thread. Safe to append from the
+        # event thread and read from the iterator thread because the
+        # final ``Trace`` is only built AFTER the runner thread joins.
+        trace_events: list[FlowEvent] = []
+
         def on_event(event: FlowEvent) -> None:
+            # Fan out to bolt-on instrumentation (telemetry, custom
+            # listeners, etc.) BEFORE queuing for the iterator — keeps
+            # the listener wall-clock close to the original event time.
+            _listeners.dispatch(event)
+            trace_events.append(event)
             q.put(event)
 
         runner = FlowRunner(
@@ -166,6 +239,7 @@ class _RunCallable:
                 q.put(None)
 
         thread = threading.Thread(target=_run_thread, name="qm-run-stream", daemon=True)
+        started = time.perf_counter()
         thread.start()
 
         try:
@@ -206,7 +280,17 @@ class _RunCallable:
             yield ErrorChunk(error="run.stream: runner produced no result")
             return
 
-        yield DoneChunk(result=Result.from_flow_result(fr))
+        elapsed = time.perf_counter() - started
+        result = Result.from_flow_result(fr)
+        # v0.3.0: populate the structured trace from the accumulated
+        # event stream. The collector callback appended every FlowEvent
+        # as it fired; we build the bucketed/by-node view once and
+        # attach before handing the caller the DoneChunk.
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        yield DoneChunk(result=result)
 
 
 def _event_to_chunk(event: FlowEvent) -> Chunk | None:
@@ -243,6 +327,24 @@ def _event_to_chunk(event: FlowEvent) -> Chunk | None:
             tool=event.tool,
             result=event.raw if event.raw is not None else event.result,
             error=event.error,
+        )
+    if isinstance(event, ProgressEvent):
+        # Application-emitted progress signal (e.g. from inside a
+        # long-running tool). Interleaves with TokenChunk on the
+        # consumer's iterator — UIs can render "searching…" /
+        # "parsing…" cards without interrupting the model tokens.
+        return ProgressChunk(
+            message=event.message,
+            percent=event.percent,
+            data=dict(event.data),
+        )
+    if isinstance(event, CustomEvent):
+        # Caller-tagged structured event — consumers filter via
+        # ``stream.custom(name="retrieved_docs")`` for the specific
+        # milestone they care about.
+        return CustomChunk(
+            name=event.name,
+            payload=dict(event.payload),
         )
     if isinstance(event, UserInputRequired):
         return AwaitInputChunk(

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -32,6 +32,7 @@ from quartermaster_engine import (
     FlowEvent,
     FlowFinished,
     FlowRunner,
+    ImageInput,
     NodeFinished,
     NodeStarted,
     ProgressEvent,
@@ -39,6 +40,7 @@ from quartermaster_engine import (
     ToolCallFinished,
     ToolCallStarted,
     UserInputRequired,
+    prepare_images,
 )
 
 from . import _listeners
@@ -86,6 +88,8 @@ class _RunCallable:
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
+        image: ImageInput | None = None,
+        images: list[ImageInput] | None = None,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
     ) -> Result:
@@ -95,6 +99,18 @@ class _RunCallable:
             graph: Either a :class:`GraphBuilder` (auto-finalised) or
                 a pre-built :class:`GraphSpec`.
             user_input: Primary user message injected into the graph.
+            image: Optional single image input for vision-capable graphs.
+                Accepts raw ``bytes``, a :class:`pathlib.Path`, or a
+                filesystem path string. When set, the graph's
+                ``.vision()`` node receives the image alongside
+                *user_input*. Mutually exclusive with *images*. On
+                graphs that don't declare a vision node this is a
+                no-op — the image is silently ignored so callers don't
+                need branch on "is this graph vision-enabled?".
+            images: Optional list of image inputs (same per-item types
+                as *image*). Use this when the graph's vision node
+                should see multiple images in a single turn. Mutually
+                exclusive with *image*.
             provider_registry: Override the configured default registry.
             tool_registry: Optional :class:`quartermaster_tools.ToolRegistry`
                 made available to ``agent()``-type nodes that specify
@@ -102,6 +118,7 @@ class _RunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+        prepared_images = prepare_images(image=image, images=images)
 
         # v0.3.0 trace: accumulate every FlowEvent into a local list
         # so we can build a ``Trace`` and attach it to the returned
@@ -124,7 +141,7 @@ class _RunCallable:
             on_event=_collect,
         )
         started = time.perf_counter()
-        fr = runner.run(user_input)
+        fr = runner.run(user_input, images=prepared_images or None)
         elapsed = time.perf_counter() - started
 
         result = Result.from_flow_result(fr)
@@ -142,6 +159,8 @@ class _RunCallable:
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
+        image: ImageInput | None = None,
+        images: list[ImageInput] | None = None,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
     ) -> _Stream:
@@ -153,6 +172,11 @@ class _RunCallable:
         ``.tool_calls()``, ``.progress()``, ``.custom(name=...)`` —
         for the common "pluck one chunk type out of the stream"
         patterns.
+
+        Accepts the same *image* / *images* kwargs as :meth:`__call__` —
+        pass a single image (``bytes`` / :class:`pathlib.Path` / path
+        string) via *image*, or a list of images via *images*. They're
+        forwarded to the vision node's ``LLMExecutor`` via flow memory.
 
         Terminates with a :class:`DoneChunk` (on success) or
         :class:`ErrorChunk` (on unrecoverable failure).  The graph
@@ -171,6 +195,8 @@ class _RunCallable:
         return _Stream(self._iter_chunks(
             graph=graph,
             user_input=user_input,
+            image=image,
+            images=images,
             provider_registry=provider_registry,
             tool_registry=tool_registry,
         ))
@@ -180,6 +206,8 @@ class _RunCallable:
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
+        image: ImageInput | None = None,
+        images: list[ImageInput] | None = None,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
     ) -> Iterator[Chunk]:
@@ -190,6 +218,7 @@ class _RunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+        prepared_images = prepare_images(image=image, images=images)
 
         q: queue.Queue[FlowEvent | None] = queue.Queue()
         holder_lock = threading.Lock()
@@ -225,7 +254,11 @@ class _RunCallable:
 
         def _run_thread() -> None:
             try:
-                fr = runner.run(user_input, flow_id=flow_id)
+                fr = runner.run(
+                    user_input,
+                    images=prepared_images or None,
+                    flow_id=flow_id,
+                )
                 with holder_lock:
                     holder["result"] = fr
             except Exception as exc:  # pragma: no cover — defensive

--- a/quartermaster-sdk/src/quartermaster_sdk/_stream_filters.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_stream_filters.py
@@ -1,0 +1,207 @@
+"""Filtered stream iterators for :func:`run.stream` / :func:`arun.stream`.
+
+v0.2.x callers wrote the same boilerplate over and over to pull specific
+chunk types out of the raw :class:`Chunk` stream::
+
+    for chunk in qm.run.stream(graph, "hi"):
+        if chunk.type == "token":
+            print(chunk.content, end="")
+
+v0.3.0 wraps the underlying iterator in a small object that exposes
+filter methods so consumers write::
+
+    for token in qm.run.stream(graph, "hi").tokens():
+        print(token, end="")
+
+    for call in qm.run.stream(graph, "hi").tool_calls():
+        ui.show_tool_card(call)
+
+    for prog in qm.run.stream(graph, "hi").progress():
+        ui.update_status(prog.message, prog.percent)
+
+    for c in qm.run.stream(graph, "hi").custom(name="docs"):
+        ui.add_doc(c.payload)
+
+Raw iteration continues to work unchanged — the wrapper is itself an
+iterator / async-iterator, so every existing ``for chunk in
+run.stream(...)`` call site keeps its exact semantics::
+
+    for chunk in qm.run.stream(graph, "hi"):   # still fine
+        ...
+
+Single-pass semantics
+---------------------
+The wrappers own the underlying generator. Calling a filter method
+(or raw iteration) drains it — there is no replay. Calling a second
+filter after the first, or raw-iterating after a filter, raises
+:class:`RuntimeError` so the mistake surfaces loudly instead of
+silently yielding zero chunks.
+
+Design decision: ``tokens()`` yields ``str``
+---------------------------------------------
+All other filters yield the full chunk object because they carry
+fields the consumer needs (``tool``, ``args``, ``message``,
+``percent``, ``payload``, ``name``, …). ``tokens()`` is the one case
+where the consumer almost always wants a bare string to concatenate
+into a UI — the whole point of "30 chars to get streamed text" is to
+cut out the ``.content`` hop. Callers who want the chunk itself can
+still pattern-match on the raw stream.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, Iterator
+
+from ._chunks import (
+    Chunk,
+    CustomChunk,
+    ProgressChunk,
+    TokenChunk,
+    ToolCallChunk,
+)
+
+
+_ALREADY_CONSUMED_MSG = "stream already consumed"
+
+
+class _Stream:
+    """Synchronous wrapper around the raw :class:`Chunk` generator.
+
+    Exposes ``.tokens()``, ``.tool_calls()``, ``.progress()``,
+    ``.custom(name=...)`` helpers plus a default ``__iter__`` that
+    yields every chunk unmodified.
+
+    The wrapper is single-pass: whichever consumer starts reading
+    first wins, and any second consumer raises :class:`RuntimeError`.
+    """
+
+    __slots__ = ("_source", "_consumed")
+
+    def __init__(self, source: Iterator[Chunk]) -> None:
+        self._source = source
+        self._consumed = False
+
+    def _claim(self) -> None:
+        """Mark the stream as claimed by the first consumer; raise on re-use.
+
+        Must be called before any consumer starts reading. Keeps every
+        entry point (``__iter__``, ``tokens``, ``tool_calls``,
+        ``progress``, ``custom``) in sync on a single flag.
+        """
+        if self._consumed:
+            raise RuntimeError(_ALREADY_CONSUMED_MSG)
+        self._consumed = True
+
+    # ── Raw iteration (preserves pre-v0.3.0 behaviour) ────────────────
+    def __iter__(self) -> Iterator[Chunk]:
+        self._claim()
+        return self._source
+
+    # ── Filter methods ────────────────────────────────────────────────
+    def tokens(self) -> Iterator[str]:
+        """Yield ``chunk.content`` for every :class:`TokenChunk`.
+
+        Yields ``str`` (not the chunk itself) because concatenation is
+        the overwhelming common case.
+        """
+        self._claim()
+        return self._yield_tokens()
+
+    def _yield_tokens(self) -> Iterator[str]:
+        for chunk in self._source:
+            if isinstance(chunk, TokenChunk):
+                yield chunk.content
+
+    def tool_calls(self) -> Iterator[ToolCallChunk]:
+        """Yield every :class:`ToolCallChunk` as it fires."""
+        self._claim()
+        return self._yield_type(ToolCallChunk)
+
+    def progress(self) -> Iterator[ProgressChunk]:
+        """Yield every :class:`ProgressChunk` as it fires."""
+        self._claim()
+        return self._yield_type(ProgressChunk)
+
+    def custom(self, name: str | None = None) -> Iterator[CustomChunk]:
+        """Yield :class:`CustomChunk` events, optionally filtered by ``name``.
+
+        ``name=None`` (the default) yields every custom chunk; passing
+        a specific ``name`` yields only the matching ones so UIs can
+        subscribe to a single milestone stream without inspecting
+        every payload.
+        """
+        self._claim()
+        return self._yield_custom(name)
+
+    # ── Internal helpers ──────────────────────────────────────────────
+    def _yield_type(self, chunk_cls: type) -> Iterator:
+        for chunk in self._source:
+            if isinstance(chunk, chunk_cls):
+                yield chunk
+
+    def _yield_custom(self, name: str | None) -> Iterator[CustomChunk]:
+        for chunk in self._source:
+            if isinstance(chunk, CustomChunk) and (name is None or chunk.name == name):
+                yield chunk
+
+
+class _AsyncStream:
+    """Async analogue of :class:`_Stream`.
+
+    Filter methods return async generators so consumers can write
+    ``async for token in qm.arun.stream(...).tokens(): ...`` without
+    materialising the whole stream first. Same single-pass guarantee
+    as the sync variant — :class:`RuntimeError` on double consumption.
+    """
+
+    __slots__ = ("_source", "_consumed")
+
+    def __init__(self, source: AsyncIterator[Chunk]) -> None:
+        self._source = source
+        self._consumed = False
+
+    def _claim(self) -> None:
+        if self._consumed:
+            raise RuntimeError(_ALREADY_CONSUMED_MSG)
+        self._consumed = True
+
+    # ── Raw async iteration ──────────────────────────────────────────
+    def __aiter__(self) -> AsyncIterator[Chunk]:
+        self._claim()
+        return self._source
+
+    # ── Filter methods ────────────────────────────────────────────────
+    def tokens(self) -> AsyncIterator[str]:
+        self._claim()
+        return self._yield_tokens()
+
+    async def _yield_tokens(self) -> AsyncIterator[str]:
+        async for chunk in self._source:
+            if isinstance(chunk, TokenChunk):
+                yield chunk.content
+
+    def tool_calls(self) -> AsyncIterator[ToolCallChunk]:
+        self._claim()
+        return self._yield_type(ToolCallChunk)
+
+    def progress(self) -> AsyncIterator[ProgressChunk]:
+        self._claim()
+        return self._yield_type(ProgressChunk)
+
+    def custom(self, name: str | None = None) -> AsyncIterator[CustomChunk]:
+        self._claim()
+        return self._yield_custom(name)
+
+    # ── Internal helpers ──────────────────────────────────────────────
+    async def _yield_type(self, chunk_cls: type) -> AsyncIterator:
+        async for chunk in self._source:
+            if isinstance(chunk, chunk_cls):
+                yield chunk
+
+    async def _yield_custom(self, name: str | None) -> AsyncIterator[CustomChunk]:
+        async for chunk in self._source:
+            if isinstance(chunk, CustomChunk) and (name is None or chunk.name == name):
+                yield chunk
+
+
+__all__ = ["_Stream", "_AsyncStream"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_trace.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_trace.py
@@ -1,0 +1,320 @@
+"""Structured post-mortem trace for a Quartermaster flow run.
+
+Every :class:`quartermaster_sdk.Result` returned from :func:`run` or the
+terminal :class:`DoneChunk.result` of :func:`run.stream` carries a
+:class:`Trace` built from the full :class:`FlowEvent` stream the runner
+observed.  The trace gives the caller post-mortem access to everything
+that happened during the run — tokens, tool calls, progress, custom
+events — without having to re-iterate the event stream themselves::
+
+    result = qm.run(graph, "hi")
+    result.trace.text                       # full model output
+    result.trace.tool_calls                 # list[dict] tool-call records
+    result.trace.progress                   # list[ProgressEvent]
+    result.trace.custom(name="docs")        # filtered custom events
+    result.trace.by_node["research"].text   # tokens for a single node
+    result.trace.as_jsonl()                 # JSONL export for logs / fixtures
+
+The same shape is populated for streaming runs — the runner installs an
+``on_event`` collector that appends every :class:`FlowEvent` to a list,
+then builds the trace from that list once the run completes.
+
+Per-node bucketing
+------------------
+:attr:`Trace.by_node` is keyed by node *name* (the ``node_name`` string
+on :class:`NodeStarted` / :class:`NodeFinished`), not by UUID.  Events
+that carry a ``node_name`` (``NodeStarted``, ``NodeFinished``,
+``TokenGenerated``, ``ToolCallStarted``, ``ToolCallFinished``,
+``ProgressEvent``, ``CustomEvent``) are attributed to the node that was
+active when they fired.  Flow-scoped events (``FlowFinished``,
+``FlowError``) don't belong to any single node and land in a synthetic
+``"_flow"`` bucket so they're still reachable without polluting the
+per-node views.
+
+The "active node" is tracked by walking events in arrival order and
+latching ``NodeStarted.node_name`` until the matching
+``NodeFinished.node_name`` closes it — events that fire between those
+bookends (tokens, tool calls, progress, custom) inherit that node's
+name.  Events emitted *before* any ``NodeStarted`` (rare, but possible
+for flow-level setup) land in ``"_flow"`` as well.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING
+
+from quartermaster_engine import (
+    CustomEvent,
+    FlowError,
+    FlowEvent,
+    FlowFinished,
+    NodeFinished,
+    NodeStarted,
+    ProgressEvent,
+    TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
+    UserInputRequired,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+#: Synthetic bucket key for events that don't belong to any single node
+#: (flow-level events like :class:`FlowFinished` / :class:`FlowError`,
+#: and any event fired before the first :class:`NodeStarted`).
+_FLOW_BUCKET = "_flow"
+
+
+def _extract_tool_call(event: ToolCallFinished) -> dict:
+    """Translate a :class:`ToolCallFinished` event into the public dict
+    shape used by :attr:`Trace.tool_calls` and
+    :attr:`NodeTrace.tool_calls`.
+
+    Mirrors the ``tool_calls`` entry already written to
+    :attr:`NodeResult.data` by ``AgentExecutor`` so that both surfaces
+    (post-hoc trace inspection and in-flight capture introspection)
+    carry identical keys.
+    """
+    return {
+        "tool": event.tool,
+        "arguments": dict(event.arguments),
+        "result": event.result,
+        "raw": event.raw,
+        "error": event.error,
+        "iteration": event.iteration,
+    }
+
+
+@dataclass
+class NodeTrace:
+    """Per-node slice of a :class:`Trace`.
+
+    Scoped to a single node (the one whose name keys it in
+    :attr:`Trace.by_node`).  Same accessor shape as :class:`Trace` so
+    callers can write ``result.trace.by_node["research"].text`` the same
+    way they write ``result.trace.text``.
+
+    Attributes:
+        node_name: The ``node_name`` string this trace belongs to.
+        events: Every :class:`FlowEvent` attributed to this node, in
+            arrival order.
+    """
+
+    node_name: str
+    events: list[FlowEvent] = field(default_factory=list)
+
+    @property
+    def text(self) -> str:
+        """Concatenation of every :class:`TokenGenerated.token` for this node."""
+        return "".join(
+            event.token for event in self.events if isinstance(event, TokenGenerated)
+        )
+
+    @property
+    def tool_calls(self) -> list[dict]:
+        """Tool-call records derived from this node's
+        :class:`ToolCallFinished` events.
+
+        Each dict has keys ``tool``, ``arguments``, ``result``, ``raw``,
+        ``error``, ``iteration`` — identical shape to the entries in
+        ``result["<agent_node>"].data["tool_calls"]`` so downstream code
+        can move between the trace and the capture without remapping.
+        """
+        return [
+            _extract_tool_call(event)
+            for event in self.events
+            if isinstance(event, ToolCallFinished)
+        ]
+
+    @property
+    def progress(self) -> list[ProgressEvent]:
+        """Every :class:`ProgressEvent` emitted from inside this node."""
+        return [event for event in self.events if isinstance(event, ProgressEvent)]
+
+    def custom(self, name: str | None = None) -> list[CustomEvent]:
+        """Return every :class:`CustomEvent` for this node, optionally
+        filtered by ``name``.
+
+        ``name=None`` (the default) returns every custom event; a
+        specific ``name`` returns only the matching ones so callers can
+        subscribe to a single milestone stream without inspecting every
+        payload.
+        """
+        return [
+            event
+            for event in self.events
+            if isinstance(event, CustomEvent)
+            and (name is None or event.name == name)
+        ]
+
+
+@dataclass
+class Trace:
+    """Structured view of everything that happened during a flow run.
+
+    Populated automatically on every :class:`Result` — both sync
+    (:func:`run`) and streaming (:class:`DoneChunk.result`) surfaces
+    attach the same object so downstream code doesn't branch on the
+    run mode.  Events are captured via the runner's ``on_event``
+    callback, which fires for every :class:`FlowEvent` the engine
+    emits.
+
+    Attributes:
+        events: Every :class:`FlowEvent` in arrival order.  This is the
+            source of truth — all aggregate views derive from it.
+        by_node: Per-node slices of :attr:`events`, keyed by
+            ``node_name``.  Flow-scoped events (no ``node_name``) are
+            collected into a synthetic ``"_flow"`` bucket so the caller
+            can still reach them without them clogging the per-node
+            views.
+        duration_seconds: Wall-clock duration of the run, mirroring
+            :attr:`Result.duration_seconds`.
+    """
+
+    events: list[FlowEvent] = field(default_factory=list)
+    by_node: dict[str, NodeTrace] = field(default_factory=dict)
+    duration_seconds: float = 0.0
+
+    @property
+    def text(self) -> str:
+        """Concatenation of every :class:`TokenGenerated.token`, in order.
+
+        Equivalent to walking the event stream and gluing ``token``
+        strings together — the "full model output" view regardless of
+        how many nodes contributed tokens.
+        """
+        return "".join(
+            event.token for event in self.events if isinstance(event, TokenGenerated)
+        )
+
+    @property
+    def tool_calls(self) -> list[dict]:
+        """Every tool-call record across every node.
+
+        Each dict has keys ``tool``, ``arguments``, ``result``, ``raw``,
+        ``error``, ``iteration``.  Use :attr:`NodeTrace.tool_calls`
+        via :attr:`by_node` if you need to scope to a single agent.
+        """
+        return [
+            _extract_tool_call(event)
+            for event in self.events
+            if isinstance(event, ToolCallFinished)
+        ]
+
+    @property
+    def progress(self) -> list[ProgressEvent]:
+        """Every :class:`ProgressEvent` across the whole run."""
+        return [event for event in self.events if isinstance(event, ProgressEvent)]
+
+    def custom(self, name: str | None = None) -> list[CustomEvent]:
+        """Return every :class:`CustomEvent`, optionally filtered by ``name``.
+
+        ``name=None`` yields every custom event; a specific ``name``
+        yields only the matching ones so UIs can subscribe to a single
+        milestone stream without inspecting every payload.
+        """
+        return [
+            event
+            for event in self.events
+            if isinstance(event, CustomEvent)
+            and (name is None or event.name == name)
+        ]
+
+    def as_jsonl(self) -> str:
+        """Return the trace serialised as JSONL (one event per line).
+
+        Uses ``dataclasses.asdict`` to flatten each event, then
+        ``json.dumps(..., default=str)`` to coerce ``UUID`` /
+        ``datetime`` / enum values to strings.  The output is suitable
+        for log shipping and test fixtures — every line is an
+        independent JSON object keyed by the dataclass field names.
+        """
+        lines = []
+        for event in self.events:
+            lines.append(json.dumps(asdict(event), default=str))
+        return "\n".join(lines)
+
+    @classmethod
+    def from_events(
+        cls, events: list[FlowEvent], duration_seconds: float = 0.0
+    ) -> Trace:
+        """Build a :class:`Trace` from a list of :class:`FlowEvent`.
+
+        Walks ``events`` in arrival order, latching the currently-active
+        node name from :class:`NodeStarted` / :class:`NodeFinished` so
+        events fired between those bookends (tokens, tool calls,
+        progress, custom) are attributed to the right
+        :class:`NodeTrace` in :attr:`by_node`.
+
+        Flow-scoped events (:class:`FlowFinished`, :class:`FlowError`,
+        :class:`UserInputRequired` — they have no ``node_name``) land
+        in the synthetic ``"_flow"`` bucket alongside any events fired
+        before the first :class:`NodeStarted`.
+        """
+        by_node: dict[str, NodeTrace] = {}
+        current_node: str | None = None
+
+        def bucket(name: str) -> NodeTrace:
+            """Fetch-or-create the :class:`NodeTrace` for ``name``."""
+            if name not in by_node:
+                by_node[name] = NodeTrace(node_name=name)
+            return by_node[name]
+
+        for event in events:
+            # Decide which bucket this event belongs to.
+            #
+            # NodeStarted sets the "active" node for subsequent events
+            # (tokens, tool calls, progress, custom) and is itself
+            # stored under that node.  NodeFinished closes the bucket
+            # and lands in it too.  Anything that carries an explicit
+            # node_name (rare — most events use the latched value) wins
+            # over the latched state.
+            if isinstance(event, NodeStarted):
+                current_node = event.node_name
+                bucket(current_node).events.append(event)
+            elif isinstance(event, NodeFinished):
+                # NodeFinished has ``node_name`` on the engine side —
+                # but defensively fall back to the latched value if an
+                # older engine event is missing it.
+                name = getattr(event, "node_name", None) or current_node
+                if name:
+                    bucket(name).events.append(event)
+                else:
+                    bucket(_FLOW_BUCKET).events.append(event)
+                # Close the active node — subsequent events (until the
+                # next NodeStarted) are flow-scoped.
+                current_node = None
+            elif isinstance(
+                event,
+                (
+                    TokenGenerated,
+                    ToolCallStarted,
+                    ToolCallFinished,
+                    ProgressEvent,
+                    CustomEvent,
+                ),
+            ):
+                # Node-scoped events.  Use the latched node name; fall
+                # back to the flow bucket for the edge case where the
+                # event fires outside any NodeStarted/NodeFinished pair
+                # (e.g. a misconfigured node, or a caller emitting from
+                # flow-level setup code).
+                name = current_node or _FLOW_BUCKET
+                bucket(name).events.append(event)
+            else:
+                # FlowFinished, FlowError, UserInputRequired, or any
+                # future FlowEvent subtype that isn't node-scoped.
+                bucket(_FLOW_BUCKET).events.append(event)
+
+        return cls(
+            events=list(events),
+            by_node=by_node,
+            duration_seconds=duration_seconds,
+        )
+
+
+__all__ = ["Trace", "NodeTrace"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_trace.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_trace.py
@@ -147,8 +147,7 @@ class NodeTrace:
         return [
             event
             for event in self.events
-            if isinstance(event, CustomEvent)
-            and (name is None or event.name == name)
+            if isinstance(event, CustomEvent) and (name is None or event.name == name)
         ]
 
 
@@ -220,8 +219,7 @@ class Trace:
         return [
             event
             for event in self.events
-            if isinstance(event, CustomEvent)
-            and (name is None or event.name == name)
+            if isinstance(event, CustomEvent) and (name is None or event.name == name)
         ]
 
     def as_jsonl(self) -> str:

--- a/quartermaster-sdk/src/quartermaster_sdk/telemetry.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/telemetry.py
@@ -274,7 +274,9 @@ def _finish_tool_span(event: ToolCallFinished) -> None:
     span.end()
 
 
-def _record_event_on_active_span(event: FlowEvent, name: str, attrs: dict[str, Any]) -> None:
+def _record_event_on_active_span(
+    event: FlowEvent, name: str, attrs: dict[str, Any]
+) -> None:
     """Add an OTEL event to the active node span (preferred) or flow span."""
     with _state_lock:
         node_id = getattr(event, "node_id", None)

--- a/quartermaster-sdk/src/quartermaster_sdk/telemetry.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/telemetry.py
@@ -1,0 +1,439 @@
+"""OpenTelemetry instrumentation for Quartermaster flows.
+
+Bolt-on tracing — call :func:`instrument` once at app boot and every
+:func:`quartermaster_sdk.run` / :func:`quartermaster_sdk.arun` /
+``run.stream`` will emit GenAI-conventioned OpenTelemetry spans without
+any further callsite changes.
+
+    import quartermaster_sdk as qm
+    from quartermaster_sdk import telemetry
+
+    qm.configure(provider="ollama", default_model="gemma4:26b")
+    telemetry.instrument()                     # uses global tracer provider
+    # or with explicit provider:
+    # telemetry.instrument(tracer_provider=my_provider)
+
+    result = qm.run(graph, "hi")               # spans flow to your exporter
+
+The implementation hooks into the SDK's :mod:`._listeners` registry,
+which the runners already invoke from inside their ``on_event=`` callback
+to :class:`FlowRunner`.  We never touch the engine itself.
+
+Span model
+----------
+
+* One root ``qm.flow`` span per flow_id, opened on the first event we
+  see for that flow and closed on :class:`~quartermaster_engine.FlowFinished`
+  / :class:`~quartermaster_engine.FlowError`.
+* One ``qm.node.<node_name>`` span per node, opened on
+  :class:`~quartermaster_engine.NodeStarted`, closed on
+  :class:`~quartermaster_engine.NodeFinished`.  Parented to the flow span.
+* One ``qm.tool.<tool>`` span per tool call (matched by ``iteration``),
+  opened on :class:`~quartermaster_engine.ToolCallStarted`, closed on
+  :class:`~quartermaster_engine.ToolCallFinished`.  Parented to the
+  enclosing node span.
+* :class:`~quartermaster_engine.TokenGenerated` /
+  :class:`~quartermaster_engine.ProgressEvent` /
+  :class:`~quartermaster_engine.CustomEvent` are recorded as span events
+  on the active node span — never as their own spans (would be far too
+  noisy at LLM token granularity).
+
+Attributes follow the OpenTelemetry GenAI semantic conventions:
+``gen_ai.system``, ``gen_ai.operation.name``, ``gen_ai.tool.name``,
+``gen_ai.tool.call.arguments``, ``gen_ai.usage.input_tokens``,
+``gen_ai.usage.output_tokens``.  See
+https://opentelemetry.io/docs/specs/semconv/gen-ai/ .
+
+Scope & limitations
+-------------------
+
+* Single-process only.  The active-span dict is module-level state
+  guarded by a :class:`threading.Lock`; cross-process distribution is
+  the responsibility of whatever exporter the caller wires up
+  (e.g. OTLP → Jaeger / Tempo / Honeycomb).
+* The OpenTelemetry SDK is an *optional* dependency.  Install with
+  ``pip install 'quartermaster-sdk[telemetry]'``.  Importing this module
+  works without OTEL installed; only :func:`instrument` requires it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any
+from uuid import UUID
+
+from quartermaster_engine import (
+    CustomEvent,
+    FlowError,
+    FlowEvent,
+    FlowFinished,
+    NodeFinished,
+    NodeStarted,
+    ProgressEvent,
+    TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
+)
+
+from . import _listeners
+
+logger = logging.getLogger(__name__)
+
+# ── Module-level state ───────────────────────────────────────────────
+#
+# Active spans are tracked here; we cannot rely on
+# ``opentelemetry.trace.use_span`` context-manager scoping because the
+# FlowEvent stream is delivered out-of-band from a worker thread, after
+# the event-source code has already returned.  All access goes through
+# ``_state_lock`` so concurrent flows on different threads don't trample
+# each other.
+_state_lock = threading.Lock()
+
+# Set when ``instrument()`` succeeds; tested by ``uninstrument()`` and
+# by ``instrument()`` itself to avoid double-registration.
+_listener: Any = None  # callable[[FlowEvent], None]
+_tracer: Any = None  # opentelemetry.trace.Tracer
+
+# Open spans, keyed by stable identifiers we synthesise from event fields.
+# - flow_id (UUID)            → root flow span
+# - (flow_id, node_id) (UUIDs) → per-node span
+# - (flow_id, node_id, "tool", iteration: int) → per-tool-call span
+_active_spans: dict[Any, Any] = {}
+
+# OTEL semantic-convention constants.  We hard-code rather than import
+# from ``opentelemetry.semconv`` because the GenAI SemConv module moved
+# packages a few times in the 1.2x → 1.4x window — string literals are
+# simpler and don't pin us to a specific SDK version.
+_GEN_AI_SYSTEM = "gen_ai.system"
+_GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+_GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+_GEN_AI_TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments"
+_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+
+# Quartermaster-specific attributes (custom prefix ``qm.*`` so they
+# don't collide with future SemConv reservations).
+_QM_FLOW_ID = "qm.flow.id"
+_QM_NODE_ID = "qm.node.id"
+_QM_NODE_NAME = "qm.node.name"
+_QM_NODE_TYPE = "qm.node.type"
+
+
+def _safe_json(value: Any) -> str:
+    """Serialise *value* to JSON, falling back to ``repr`` on failure.
+
+    Tool-call arguments can contain anything the LLM dreamt up — bytes,
+    custom objects, NaN floats — and ``json.dumps`` choking would leak
+    the exception into the engine thread and abort the listener.  This
+    helper keeps the listener bullet-proof while still getting the
+    common case (plain dict of primitives) right.
+    """
+    try:
+        return json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:  # pragma: no cover — defensive
+        return repr(value)
+
+
+def _flow_key(flow_id: UUID) -> UUID:
+    """Stable key for the root flow span — just the flow_id."""
+    return flow_id
+
+
+def _node_key(flow_id: UUID, node_id: UUID) -> tuple[UUID, UUID]:
+    """Stable key for a per-node span."""
+    return (flow_id, node_id)
+
+
+def _tool_key(flow_id: UUID, node_id: UUID, iteration: int) -> tuple:
+    """Stable key for a per-tool-call span (one per agent iteration)."""
+    return (flow_id, node_id, "tool", iteration)
+
+
+def _ensure_flow_span(event: FlowEvent) -> Any:
+    """Open the root ``qm.flow`` span on first sight of *event.flow_id*.
+
+    Idempotent — returns the existing span if we've already seen this
+    flow.  Caller holds ``_state_lock``.
+    """
+    key = _flow_key(event.flow_id)
+    span = _active_spans.get(key)
+    if span is not None:
+        return span
+    span = _tracer.start_span("qm.flow")
+    span.set_attribute(_GEN_AI_SYSTEM, "quartermaster")
+    span.set_attribute(_GEN_AI_OPERATION_NAME, "flow")
+    span.set_attribute(_QM_FLOW_ID, str(event.flow_id))
+    _active_spans[key] = span
+    return span
+
+
+def _start_node_span(event: NodeStarted) -> None:
+    """Open a child span for a node beginning execution."""
+    # OTEL needs explicit parent context for cross-thread parent linkage
+    # (the runner's worker thread doesn't share the OTEL context-vars
+    # with whoever called ``instrument()``).  We attach a context whose
+    # active span is the flow span so the new node span gets parented
+    # correctly even though we're outside the original flow context.
+    from opentelemetry import trace
+
+    with _state_lock:
+        flow_span = _ensure_flow_span(event)
+        ctx = trace.set_span_in_context(flow_span)
+        span = _tracer.start_span(
+            f"qm.node.{event.node_name or event.node_id}",
+            context=ctx,
+        )
+        span.set_attribute(_GEN_AI_SYSTEM, "quartermaster")
+        # The engine's NodeType is a string-enum; .value gives the
+        # serialised form integrators see in their graph definitions.
+        span.set_attribute(
+            _GEN_AI_OPERATION_NAME,
+            event.node_type.value if event.node_type is not None else "unknown",
+        )
+        span.set_attribute(_QM_NODE_NAME, event.node_name)
+        span.set_attribute(_QM_NODE_ID, str(event.node_id))
+        span.set_attribute(_QM_NODE_TYPE, event.node_type.value)
+        _active_spans[_node_key(event.flow_id, event.node_id)] = span
+
+
+def _finish_node_span(event: NodeFinished) -> None:
+    """Close the matching node span and surface usage attributes."""
+    with _state_lock:
+        span = _active_spans.pop(_node_key(event.flow_id, event.node_id), None)
+    if span is None:
+        # Missed the start (instrument() called mid-flight, or duplicate
+        # finish) — nothing to close.
+        return
+    # Pull token-usage hints from output_data when the node populated
+    # them.  Different node types report different shapes; we look for
+    # the common keys without mandating any particular schema.
+    output = event.output_data or {}
+    in_tok = (
+        output.get("input_tokens")
+        or output.get("prompt_tokens")
+        or output.get("usage", {}).get("input_tokens")
+        if isinstance(output.get("usage"), dict)
+        else None
+    )
+    out_tok = (
+        output.get("output_tokens")
+        or output.get("completion_tokens")
+        or output.get("usage", {}).get("output_tokens")
+        if isinstance(output.get("usage"), dict)
+        else None
+    )
+    if isinstance(in_tok, int):
+        span.set_attribute(_GEN_AI_USAGE_INPUT_TOKENS, in_tok)
+    if isinstance(out_tok, int):
+        span.set_attribute(_GEN_AI_USAGE_OUTPUT_TOKENS, out_tok)
+    span.end()
+
+
+def _start_tool_span(event: ToolCallStarted) -> None:
+    """Open a tool span nested under the agent-node span that issued it."""
+    from opentelemetry import trace
+
+    with _state_lock:
+        # Parent the tool span on the enclosing node span when we have
+        # one; fall back to the flow span otherwise.  Direct reach into
+        # ``_active_spans`` is fine — we're under ``_state_lock``.
+        parent = _active_spans.get(_node_key(event.flow_id, event.node_id))
+        if parent is None:
+            parent = _active_spans.get(_flow_key(event.flow_id))
+        ctx = trace.set_span_in_context(parent) if parent is not None else None
+        span = _tracer.start_span(
+            f"qm.tool.{event.tool}",
+            context=ctx,
+        )
+        span.set_attribute(_GEN_AI_SYSTEM, "quartermaster")
+        span.set_attribute(_GEN_AI_OPERATION_NAME, "execute_tool")
+        span.set_attribute(_GEN_AI_TOOL_NAME, event.tool)
+        span.set_attribute(
+            _GEN_AI_TOOL_CALL_ARGUMENTS,
+            _safe_json(dict(event.arguments or {})),
+        )
+        _active_spans[_tool_key(event.flow_id, event.node_id, event.iteration)] = span
+
+
+def _finish_tool_span(event: ToolCallFinished) -> None:
+    """Close the tool span and mark ERROR status if the tool raised."""
+    from opentelemetry.trace import Status, StatusCode
+
+    with _state_lock:
+        span = _active_spans.pop(
+            _tool_key(event.flow_id, event.node_id, event.iteration),
+            None,
+        )
+    if span is None:
+        return
+    if event.error:
+        span.set_status(Status(StatusCode.ERROR, event.error))
+        span.set_attribute("error.message", event.error)
+    span.end()
+
+
+def _record_event_on_active_span(event: FlowEvent, name: str, attrs: dict[str, Any]) -> None:
+    """Add an OTEL event to the active node span (preferred) or flow span."""
+    with _state_lock:
+        node_id = getattr(event, "node_id", None)
+        span = None
+        if node_id is not None:
+            span = _active_spans.get(_node_key(event.flow_id, node_id))
+        if span is None:
+            span = _active_spans.get(_flow_key(event.flow_id))
+    if span is None:
+        return
+    # OTEL attributes must be primitives or sequences of primitives —
+    # stringify anything dict-shaped via _safe_json.
+    safe_attrs: dict[str, Any] = {}
+    for k, v in attrs.items():
+        if isinstance(v, (str, bool, int, float)):
+            safe_attrs[k] = v
+        elif v is None:
+            continue
+        else:
+            safe_attrs[k] = _safe_json(v)
+    try:
+        span.add_event(name, attributes=safe_attrs)
+    except Exception:  # pragma: no cover — defensive
+        logger.exception("telemetry: add_event(%r) failed", name)
+
+
+def _finish_flow_span(event: FlowEvent, *, error: str | None = None) -> None:
+    """Close the root flow span (and any orphan child spans for that flow)."""
+    from opentelemetry.trace import Status, StatusCode
+
+    with _state_lock:
+        flow_span = _active_spans.pop(_flow_key(event.flow_id), None)
+        # Mop up any node / tool spans we never saw a finish for.
+        # They'd otherwise leak forever — bad for memory and for
+        # exporters that batch on span end.
+        orphans: list[Any] = []
+        for key in list(_active_spans):
+            if isinstance(key, tuple) and key and key[0] == event.flow_id:
+                orphans.append(_active_spans.pop(key))
+    for orphan in orphans:
+        try:
+            orphan.end()
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("telemetry: failed to end orphan span")
+    if flow_span is None:
+        return
+    if error:
+        flow_span.set_status(Status(StatusCode.ERROR, error))
+        flow_span.set_attribute("error.message", error)
+    flow_span.end()
+
+
+def _on_event(event: FlowEvent) -> None:
+    """The single listener registered on :mod:`_listeners`."""
+    try:
+        # Lazy: even FlowFinished should ensure a flow span exists in
+        # the pathological case of an empty flow that emits only the
+        # terminal event — without this, _finish_flow_span pops nothing
+        # and we lose the trace.
+        if not isinstance(event, (FlowFinished, FlowError)):
+            with _state_lock:
+                _ensure_flow_span(event)
+
+        if isinstance(event, NodeStarted):
+            _start_node_span(event)
+        elif isinstance(event, NodeFinished):
+            _finish_node_span(event)
+        elif isinstance(event, ToolCallStarted):
+            _start_tool_span(event)
+        elif isinstance(event, ToolCallFinished):
+            _finish_tool_span(event)
+        elif isinstance(event, TokenGenerated):
+            # Recorded as a span event on the node — one-per-token would
+            # blow out exporters at LLM throughput, so we attach the
+            # token to the active node span as an event with the token
+            # text as an attribute.  Most exporters dedupe by event name
+            # and surface counts in their UI.
+            _record_event_on_active_span(
+                event, "token", {"gen_ai.token.value": event.token}
+            )
+        elif isinstance(event, ProgressEvent):
+            _record_event_on_active_span(
+                event,
+                "progress",
+                {
+                    "message": event.message,
+                    "percent": event.percent,
+                    **(event.data or {}),
+                },
+            )
+        elif isinstance(event, CustomEvent):
+            _record_event_on_active_span(
+                event,
+                event.name or "custom",
+                dict(event.payload or {}),
+            )
+        elif isinstance(event, FlowError):
+            _finish_flow_span(event, error=event.error)
+        elif isinstance(event, FlowFinished):
+            _finish_flow_span(event)
+    except Exception:  # pragma: no cover — defensive
+        logger.exception("telemetry: listener crashed on %r", type(event).__name__)
+
+
+def instrument(
+    *,
+    tracer_provider: Any | None = None,
+    instrumenting_module_name: str = "quartermaster_sdk",
+) -> None:
+    """Register the OTEL listener; every subsequent flow emits spans.
+
+    Args:
+        tracer_provider: An :class:`opentelemetry.sdk.trace.TracerProvider`
+            (or compatible).  Defaults to the global provider returned
+            by :func:`opentelemetry.trace.get_tracer_provider`, so most
+            integrators don't need to pass anything.
+        instrumenting_module_name: Library name reported on each span;
+            shows up as ``otel.library.name`` in many exporters.
+
+    Idempotent: calling :func:`instrument` more than once is a no-op
+    until :func:`uninstrument` is called.
+    """
+    global _listener, _tracer
+
+    try:
+        from opentelemetry import trace
+    except ImportError as exc:  # pragma: no cover — depends on extras
+        raise ImportError(
+            "OpenTelemetry not installed. "
+            "Run: pip install 'quartermaster-sdk[telemetry]'"
+        ) from exc
+
+    with _state_lock:
+        if _listener is not None:
+            # Already instrumented — caller probably double-bootstrapped
+            # something.  No harm done; just bail.
+            return
+        provider = tracer_provider or trace.get_tracer_provider()
+        _tracer = provider.get_tracer(instrumenting_module_name)
+        _listener = _on_event
+
+    _listeners.register(_on_event)
+
+
+def uninstrument() -> None:
+    """Reverse of :func:`instrument` — remove the OTEL listener.
+
+    Any in-flight spans are left as they are; they'll close naturally
+    when their flow finishes.  Calling :func:`uninstrument` before
+    :func:`instrument` (or twice in a row) is a no-op.
+    """
+    global _listener, _tracer
+    with _state_lock:
+        if _listener is None:
+            return
+        listener = _listener
+        _listener = None
+        _tracer = None
+    _listeners.unregister(listener)
+
+
+__all__ = ["instrument", "uninstrument"]

--- a/quartermaster-sdk/tests/test_v020_surface.py
+++ b/quartermaster-sdk/tests/test_v020_surface.py
@@ -399,9 +399,9 @@ class TestStreamEarlyExitCancels:
 
         original_run = FlowRunner.run
 
-        def capture_run(self, input_message, flow_id=None):
+        def capture_run(self, input_message, *, images=None, flow_id=None):
             captured["flow_id_passed"] = flow_id
-            return original_run(self, input_message, flow_id=flow_id)
+            return original_run(self, input_message, images=images, flow_id=flow_id)
 
         monkeypatch.setattr(FlowRunner, "run", capture_run)
 

--- a/quartermaster-sdk/tests/test_v022_tool_streaming.py
+++ b/quartermaster-sdk/tests/test_v022_tool_streaming.py
@@ -160,10 +160,7 @@ def _graph_with_agent() -> Any:
     captured agent output so non-streaming tests can read it back via
     ``result["agent"]``."""
     return (
-        qm.Graph("chat")
-        .user()
-        .agent("Tooled", tools=["x"], capture_as="agent")
-        .build()
+        qm.Graph("chat").user().agent("Tooled", tools=["x"], capture_as="agent").build()
     )
 
 
@@ -343,9 +340,7 @@ class TestToolPrefixNormalisation:
 
         # --- Streaming surface: ToolCallChunk.tool is stripped ---
         chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
-        tool_call_chunk = next(
-            (c for c in chunks if c.type == "tool_call"), None
-        )
+        tool_call_chunk = next((c for c in chunks if c.type == "tool_call"), None)
         assert tool_call_chunk is not None, "no tool_call chunk emitted"
         assert isinstance(tool_call_chunk, qm.ToolCallChunk)
         assert tool_call_chunk.tool == "list_orders", (

--- a/quartermaster-sdk/tests/test_v030_filtered_iterators.py
+++ b/quartermaster-sdk/tests/test_v030_filtered_iterators.py
@@ -175,7 +175,9 @@ class _ProgressEmittingTool:
         ctx = qm.current_context()
         if ctx is not None:
             if self._progress_message is not None:
-                ctx.emit_progress(self._progress_message, percent=self._progress_percent)
+                ctx.emit_progress(
+                    self._progress_message, percent=self._progress_percent
+                )
             for name, payload in self._customs:
                 ctx.emit_custom(name, payload)
 
@@ -215,10 +217,7 @@ class _ToolRegistry:
 
 def _graph_with_agent() -> Any:
     return (
-        qm.Graph("chat")
-        .user()
-        .agent("Tooled", tools=["x"], capture_as="agent")
-        .build()
+        qm.Graph("chat").user().agent("Tooled", tools=["x"], capture_as="agent").build()
     )
 
 
@@ -239,13 +238,7 @@ def test_tokens_filter_yields_strings_only():
     reg, _ = _multi_token_registry(["a", "b", "c"])
     qm.configure(registry=reg)
     # Three instruction nodes — one streamed TokenResponse per node.
-    graph = (
-        qm.Graph("x")
-        .instruction("A")
-        .instruction("B")
-        .instruction("C")
-        .build()
-    )
+    graph = qm.Graph("x").instruction("A").instruction("B").instruction("C").build()
 
     stream = qm.run.stream(graph, "hi")
     tokens = list(stream.tokens())
@@ -289,9 +282,7 @@ def test_progress_filter():
     """
     reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
     qm.configure(registry=reg)
-    tool = _ProgressEmittingTool(
-        progress_message="searching", progress_percent=0.5
-    )
+    tool = _ProgressEmittingTool(progress_message="searching", progress_percent=0.5)
     tool_reg = _ToolRegistry({"x": tool})
     graph = _graph_with_agent()
 
@@ -316,9 +307,7 @@ def test_custom_filter_by_name():
     """
     reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
     qm.configure(registry=reg)
-    tool = _ProgressEmittingTool(
-        customs=[("a", {"v": 1}), ("b", {"v": 2})]
-    )
+    tool = _ProgressEmittingTool(customs=[("a", {"v": 1}), ("b", {"v": 2})])
     tool_reg = _ToolRegistry({"x": tool})
     graph = _graph_with_agent()
 
@@ -335,9 +324,7 @@ def test_custom_filter_without_name_yields_all():
     """``.custom()`` with no ``name=`` yields every custom chunk."""
     reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
     qm.configure(registry=reg)
-    tool = _ProgressEmittingTool(
-        customs=[("a", {"v": 1}), ("b", {"v": 2})]
-    )
+    tool = _ProgressEmittingTool(customs=[("a", {"v": 1}), ("b", {"v": 2})])
     tool_reg = _ToolRegistry({"x": tool})
     graph = _graph_with_agent()
 
@@ -432,13 +419,7 @@ async def test_async_tokens_filter():
     ``async for token in qm.arun.stream(...).tokens()`` yields ``str``."""
     reg, _ = _multi_token_registry(["a", "b", "c"])
     qm.configure(registry=reg)
-    graph = (
-        qm.Graph("x")
-        .instruction("A")
-        .instruction("B")
-        .instruction("C")
-        .build()
-    )
+    graph = qm.Graph("x").instruction("A").instruction("B").instruction("C").build()
 
     stream = qm.arun.stream(graph, "hi")
     tokens = [t async for t in stream.tokens()]

--- a/quartermaster-sdk/tests/test_v030_filtered_iterators.py
+++ b/quartermaster-sdk/tests/test_v030_filtered_iterators.py
@@ -1,0 +1,482 @@
+"""Tests for v0.3.0 filtered stream iterators.
+
+v0.3.0 wraps the raw ``Iterator[Chunk]`` / ``AsyncIterator[Chunk]``
+returned from ``qm.run.stream(...)`` / ``qm.arun.stream(...)`` in a
+small object exposing filter methods — ``.tokens()``, ``.tool_calls()``,
+``.progress()``, ``.custom(name=...)`` — so callers don't write the
+``if chunk.type == "token": print(chunk.content)`` boilerplate.
+
+The wrapper is still iterable / async-iterable, so every pre-0.3 code
+path that did ``for chunk in qm.run.stream(...)`` keeps working
+unchanged. This file pins both sides of the guarantee: filters yield
+the right subset, and raw iteration still yields the full stream.
+
+Single-pass contract: the wrapper owns the underlying generator. First
+consumer drains it; a second filter (or raw iter after a filter)
+raises ``RuntimeError("stream already consumed")``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse, ToolCall
+
+
+# ── Fixtures / helpers ────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Minimal mock registry — copy of the helper from test_v020_surface.py.
+
+    Token responses default to a single-chunk streamed reply and the
+    native channel is primed with the same text so either path the
+    engine picks yields a consistent string.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+def _multi_token_registry(tokens: list[str]) -> tuple[ProviderRegistry, MockProvider]:
+    """Primed mock that streams ``tokens`` as one TokenResponse per token.
+
+    ``MockProvider`` consumes its ``responses`` queue one entry per
+    streamed call, so each entry becomes one ``TokenGenerated`` event
+    which maps 1:1 to a :class:`TokenChunk`. That lets
+    ``test_tokens_filter_yields_strings_only`` assert the exact string
+    sequence produced by ``.tokens()``.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=t, stop_reason="stop") for t in tokens],
+        native_responses=[
+            NativeResponse(
+                text_content="".join(tokens),
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+# Tool-aware helpers — lifted from test_v022_tool_streaming.py so these
+# tests stay self-contained (they're the lowest-friction way to
+# provoke ToolCall / Progress / Custom chunks).
+
+
+def _tool_aware_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> tuple[ProviderRegistry, MockProvider]:
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg, mock
+
+
+class _OkTool:
+    """Plain tool that returns a structured payload. See the v0.2.2 suite."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = dict(self._data)
+        return r
+
+
+class _ProgressEmittingTool:
+    """Tool whose ``safe_run`` body emits progress + custom events.
+
+    Mirrors the documented ``@tool()`` pattern: look up the current
+    :class:`ExecutionContext` via :func:`current_context` and fire
+    ``emit_progress`` / ``emit_custom``. The agent-executor binds the
+    context before dispatching ``safe_run``, so these become real
+    :class:`ProgressChunk` / :class:`CustomChunk` entries in the stream.
+    """
+
+    def __init__(
+        self,
+        progress_message: str | None = None,
+        progress_percent: float | None = None,
+        customs: list[tuple[str, dict[str, Any]]] | None = None,
+    ):
+        self._progress_message = progress_message
+        self._progress_percent = progress_percent
+        self._customs = list(customs or [])
+
+    def safe_run(self, **kwargs: Any):
+        ctx = qm.current_context()
+        if ctx is not None:
+            if self._progress_message is not None:
+                ctx.emit_progress(self._progress_message, percent=self._progress_percent)
+            for name, payload in self._customs:
+                ctx.emit_custom(name, payload)
+
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = {"emitted": True}
+        return r
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's interface."""
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        return self._tools[name]
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+def _graph_with_agent() -> Any:
+    return (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+
+# ── 1. .tokens() yields strings ──────────────────────────────────────
+
+
+def test_tokens_filter_yields_strings_only():
+    """A stream primed with three one-token responses yields exactly
+    ``["a", "b", "c"]`` through ``.tokens()``.
+
+    Proves two things at once:
+
+    * filter returns ``str`` (not ``TokenChunk``) — the documented
+      shortcut so callers don't write ``chunk.content`` in the hot path.
+    * non-token chunks (node_start, node_finish, done) are filtered
+      out silently.
+    """
+    reg, _ = _multi_token_registry(["a", "b", "c"])
+    qm.configure(registry=reg)
+    # Three instruction nodes — one streamed TokenResponse per node.
+    graph = (
+        qm.Graph("x")
+        .instruction("A")
+        .instruction("B")
+        .instruction("C")
+        .build()
+    )
+
+    stream = qm.run.stream(graph, "hi")
+    tokens = list(stream.tokens())
+
+    assert tokens == ["a", "b", "c"], (
+        f"expected ['a', 'b', 'c'] from .tokens(), got {tokens!r}"
+    )
+
+
+# ── 2. .tool_calls() yields ToolCallChunks ───────────────────────────
+
+
+def test_tool_calls_filter_yields_tool_call_chunks():
+    """When a tool fires during the stream, ``.tool_calls()`` yields
+    the typed :class:`ToolCallChunk` — not the paired ``ToolResultChunk``,
+    not the surrounding node lifecycle events.
+    """
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hello"})
+    qm.configure(registry=reg)
+    tool_reg = _ToolRegistry({"x": _OkTool({"ok": True})})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    calls = list(stream.tool_calls())
+
+    assert len(calls) == 1, f"expected exactly 1 tool_call, got {calls}"
+    assert all(isinstance(c, qm.ToolCallChunk) for c in calls), (
+        f"all entries must be ToolCallChunk, got {[type(c) for c in calls]}"
+    )
+    assert calls[0].tool == "x"
+    assert calls[0].args == {"q": "hello"}
+
+
+# ── 3. .progress() yields ProgressChunks ─────────────────────────────
+
+
+def test_progress_filter():
+    """A tool that calls ``current_context().emit_progress(...)`` inside
+    ``safe_run`` surfaces as a :class:`ProgressChunk` on the stream —
+    ``.progress()`` pulls it out verbatim.
+    """
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+    qm.configure(registry=reg)
+    tool = _ProgressEmittingTool(
+        progress_message="searching", progress_percent=0.5
+    )
+    tool_reg = _ToolRegistry({"x": tool})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    progress_chunks = list(stream.progress())
+
+    assert len(progress_chunks) == 1, (
+        f"expected 1 progress chunk, got {progress_chunks}"
+    )
+    assert isinstance(progress_chunks[0], qm.ProgressChunk)
+    assert progress_chunks[0].message == "searching"
+    assert progress_chunks[0].percent == 0.5
+
+
+# ── 4. .custom(name=...) filters by name ─────────────────────────────
+
+
+def test_custom_filter_by_name():
+    """Two ``emit_custom`` calls ("a", "b") surface as two
+    :class:`CustomChunk` entries; ``.custom(name="a")`` yields only the
+    matching one.
+    """
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+    qm.configure(registry=reg)
+    tool = _ProgressEmittingTool(
+        customs=[("a", {"v": 1}), ("b", {"v": 2})]
+    )
+    tool_reg = _ToolRegistry({"x": tool})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    a_only = list(stream.custom(name="a"))
+
+    assert len(a_only) == 1, f"expected 1 chunk named 'a', got {a_only}"
+    assert isinstance(a_only[0], qm.CustomChunk)
+    assert a_only[0].name == "a"
+    assert a_only[0].payload == {"v": 1}
+
+
+def test_custom_filter_without_name_yields_all():
+    """``.custom()`` with no ``name=`` yields every custom chunk."""
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+    qm.configure(registry=reg)
+    tool = _ProgressEmittingTool(
+        customs=[("a", {"v": 1}), ("b", {"v": 2})]
+    )
+    tool_reg = _ToolRegistry({"x": tool})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    all_customs = list(stream.custom())
+
+    assert len(all_customs) == 2
+    names = {c.name for c in all_customs}
+    assert names == {"a", "b"}
+
+
+# ── 5. Raw iteration still works (regression guard) ──────────────────
+
+
+def test_raw_iteration_still_works():
+    """Pre-v0.3 code paths that did ``for chunk in qm.run.stream(...)``
+    must keep yielding the full chunk sequence unchanged — the wrapper
+    object is itself iterable and delegates to the underlying generator.
+    """
+    reg, _ = _mock_registry("streaming words")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    chunks = [c for c in stream]
+    types = [c.type for c in chunks]
+
+    # Same terminal guarantee as test_v020_surface — DoneChunk last,
+    # populated Result, at least one node lifecycle pair.
+    assert types[-1] == "done"
+    last = chunks[-1]
+    assert isinstance(last, qm.DoneChunk)
+    assert last.result.success
+    assert "node_start" in types
+    assert "node_finish" in types
+
+
+# ── 6. Single-pass contract ──────────────────────────────────────────
+
+
+def test_double_consumption_raises():
+    """Calling a filter twice on the same wrapper raises ``RuntimeError``
+    with the documented ``"stream already consumed"`` message — so the
+    mistake shows up immediately instead of silently yielding zero
+    chunks from a drained generator.
+    """
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    # First consumer drains the generator — we don't care what it yields.
+    list(stream.tokens())
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        list(stream.tokens())
+
+
+def test_filter_then_raw_iter_raises():
+    """Any two entry points on the same wrapper share the single-pass
+    flag — filter-then-raw-iter trips the same guard."""
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    list(stream.tokens())
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        for _ in stream:
+            pass
+
+
+def test_raw_iter_then_filter_raises():
+    """Inverse of the previous — raw iteration first, filter second."""
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    list(stream)
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        list(stream.tokens())
+
+
+# ── 7. Async equivalents ─────────────────────────────────────────────
+
+
+async def test_async_tokens_filter():
+    """Async analogue of test_tokens_filter_yields_strings_only —
+    ``async for token in qm.arun.stream(...).tokens()`` yields ``str``."""
+    reg, _ = _multi_token_registry(["a", "b", "c"])
+    qm.configure(registry=reg)
+    graph = (
+        qm.Graph("x")
+        .instruction("A")
+        .instruction("B")
+        .instruction("C")
+        .build()
+    )
+
+    stream = qm.arun.stream(graph, "hi")
+    tokens = [t async for t in stream.tokens()]
+
+    assert tokens == ["a", "b", "c"], (
+        f"expected ['a', 'b', 'c'] from async .tokens(), got {tokens!r}"
+    )
+
+
+async def test_async_raw_iteration():
+    """Regression: ``async for chunk in qm.arun.stream(...)`` continues
+    to yield the raw full chunk sequence — the async wrapper is itself
+    async-iterable and delegates to the underlying async generator.
+    """
+    reg, _ = _mock_registry("streaming async words")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.arun.stream(graph, "hi")
+    chunks = [c async for c in stream]
+    types = [c.type for c in chunks]
+
+    assert types[-1] == "done"
+    last = chunks[-1]
+    assert isinstance(last, qm.DoneChunk)
+    assert last.result.success
+    assert "node_start" in types
+    assert "node_finish" in types
+
+
+async def test_async_double_consumption_raises():
+    """The single-pass guarantee applies to the async wrapper too."""
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.arun.stream(graph, "hi")
+    _ = [t async for t in stream.tokens()]
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        _ = [t async for t in stream.tokens()]

--- a/quartermaster-sdk/tests/test_v030_telemetry.py
+++ b/quartermaster-sdk/tests/test_v030_telemetry.py
@@ -1,0 +1,334 @@
+"""Tests for the v0.3.0 OpenTelemetry instrumentation module.
+
+Covers four guarantees of :mod:`quartermaster_sdk.telemetry`:
+
+1. After :func:`telemetry.instrument`, every node executed by
+   :func:`qm.run` produces a ``qm.node.<name>`` OpenTelemetry span.
+2. Tool calls during an agent node produce a ``qm.tool.<name>`` span
+   parented to the agent's ``qm.node.<name>`` span.
+3. :func:`telemetry.uninstrument` removes the listener so subsequent
+   flows emit zero spans.
+4. ``ProgressEvent`` from inside a tool surfaces as an OTEL span event
+   with name ``progress`` on the active node span.
+
+All tests run only when the optional ``opentelemetry`` extra is
+installed — skipped cleanly otherwise so the bare-bones SDK test suite
+stays portable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import openai  # noqa: F401 — eager import; see test_ollama_chat.py for context
+
+import pytest
+
+# Skip the entire module if OTEL isn't installed — keeps the bare SDK
+# test run green for users who haven't pulled the [telemetry] extra.
+pytest.importorskip("opentelemetry")
+
+# Imported here so missed imports surface as ImportError, not skip.
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+import quartermaster_sdk as qm
+from quartermaster_engine.context.current_context import current_context
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import (
+    NativeResponse,
+    TokenResponse,
+    ToolCall,
+)
+from quartermaster_sdk import telemetry
+from quartermaster_sdk import _listeners as _listeners_mod
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def exporter() -> InMemorySpanExporter:
+    """Fresh in-memory span exporter wired to a private TracerProvider.
+
+    A private provider per test prevents cross-test span pollution and
+    avoids stomping on whatever the global provider is configured for.
+    """
+    provider = TracerProvider()
+    exp = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    yield exp, provider
+    exp.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(exporter):
+    """Reset SDK config + telemetry state between tests."""
+    qm.reset_config()
+    # Make sure a stray instrument() from a previous test doesn't leak.
+    telemetry.uninstrument()
+    _listeners_mod.clear()
+    yield
+    telemetry.uninstrument()
+    _listeners_mod.clear()
+    qm.reset_config()
+
+
+def _mock_registry(text: str = "ok") -> ProviderRegistry:
+    """Single-shot mock provider — same shape as test_v022_async_runner."""
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg
+
+
+def _agent_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> ProviderRegistry:
+    """Mock provider primed for a 2-turn agent loop (one tool call)."""
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg
+
+
+class _OkTool:
+    """Tool that always succeeds with a fixed payload."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = dict(self._data)
+        return r
+
+
+class _ProgressTool:
+    """Tool that emits a ``ProgressEvent`` while running."""
+
+    def safe_run(self, **kwargs: Any):
+        ctx = current_context()
+        if ctx is not None:
+            ctx.emit_progress("loading", percent=0.5, data={"step": "fetch"})
+
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = {"ok": True}
+        return r
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's expected interface."""
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        return self._tools[name]
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+# ── 1. Node spans ────────────────────────────────────────────────────
+
+
+def test_instrument_creates_span_per_node(exporter):
+    """Each executed node yields a ``qm.node.<name>`` OTEL span.
+
+    A two-instruction graph executes Start → Instruction → Instruction →
+    End plus the auto-injected user node, so we expect at least the
+    two named instruction spans plus a root flow span.
+    """
+    exp, provider = exporter
+    qm.configure(registry=_mock_registry("ok"))
+    telemetry.instrument(tracer_provider=provider)
+
+    graph = (
+        qm.Graph("x")
+        .instruction("first")
+        .instruction("second")
+        .build()
+    )
+    result = qm.run(graph, "hi")
+    assert result.success, result.error
+
+    spans = exp.get_finished_spans()
+    names = [s.name for s in spans]
+    # Root flow span always present once a single event fired.
+    assert "qm.flow" in names, f"missing qm.flow span; got {names}"
+    # Both named instruction nodes produced their own spans.
+    assert "qm.node.first" in names, f"missing first node span; got {names}"
+    assert "qm.node.second" in names, f"missing second node span; got {names}"
+
+    # Each node span carries the GenAI semconv attributes.
+    for span in spans:
+        if span.name.startswith("qm.node."):
+            assert span.attributes.get("gen_ai.system") == "quartermaster"
+            assert "gen_ai.operation.name" in span.attributes
+
+
+# ── 2. Tool spans nested under agent ─────────────────────────────────
+
+
+def test_instrument_creates_tool_spans_under_agent_node(exporter):
+    """Tool spans are parented to the enclosing agent node span."""
+    exp, provider = exporter
+    qm.configure(registry=_agent_registry(tool_name="x", final_text="done"))
+    telemetry.instrument(tracer_provider=provider)
+
+    tool_reg = _ToolRegistry({"x": _OkTool({"echo": "hi"})})
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    spans = exp.get_finished_spans()
+    names = [s.name for s in spans]
+
+    # Tool span exists.
+    tool_spans = [s for s in spans if s.name == "qm.tool.x"]
+    assert tool_spans, f"no qm.tool.x span; got {names}"
+    tool_span = tool_spans[0]
+
+    # Tool span carries gen_ai.tool.* attributes.
+    assert tool_span.attributes.get("gen_ai.tool.name") == "x"
+    assert "gen_ai.tool.call.arguments" in tool_span.attributes
+
+    # The agent node span exists and is the tool span's parent.
+    agent_spans = [s for s in spans if s.name == "qm.node.Tooled"]
+    assert agent_spans, f"no qm.node.Tooled span; got {names}"
+    agent_span = agent_spans[0]
+
+    assert tool_span.parent is not None, "tool span has no parent context"
+    assert tool_span.parent.span_id == agent_span.context.span_id, (
+        "tool span parent must be the agent node span; "
+        f"tool.parent.span_id={tool_span.parent.span_id} "
+        f"agent.span_id={agent_span.context.span_id}"
+    )
+
+
+# ── 3. Uninstrument removes the listener ─────────────────────────────
+
+
+def test_uninstrument_removes_listener(exporter):
+    """After uninstrument(), no spans flow to the exporter."""
+    exp, provider = exporter
+    qm.configure(registry=_mock_registry("ok"))
+
+    telemetry.instrument(tracer_provider=provider)
+    telemetry.uninstrument()
+
+    graph = qm.Graph("x").instruction("One").build()
+    result = qm.run(graph, "hi")
+    assert result.success
+
+    spans = exp.get_finished_spans()
+    assert len(spans) == 0, (
+        f"expected zero spans after uninstrument, got {[s.name for s in spans]}"
+    )
+
+
+# ── 4. Progress events become span events ────────────────────────────
+
+
+def test_progress_event_becomes_span_event(exporter):
+    """Tool-emitted ProgressEvent appears as a span event named ``progress``."""
+    exp, provider = exporter
+    qm.configure(registry=_agent_registry(tool_name="p", final_text="done"))
+    telemetry.instrument(tracer_provider=provider)
+
+    tool_reg = _ToolRegistry({"p": _ProgressTool()}, schema_name="p")
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Loader", tools=["p"], capture_as="agent")
+        .build()
+    )
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    spans = exp.get_finished_spans()
+
+    # Search every node-or-tool span for a "progress" event — it lives
+    # on whichever span was active when ``emit_progress`` fired.
+    progress_events: list[Any] = []
+    for span in spans:
+        for evt in span.events:
+            if evt.name == "progress":
+                progress_events.append((span.name, evt))
+
+    assert progress_events, (
+        f"no 'progress' span event found; spans={[(s.name, [e.name for e in s.events]) for s in spans]}"
+    )
+    # Payload made it through the OTEL boundary.
+    span_name, evt = progress_events[0]
+    assert evt.attributes.get("message") == "loading"
+    assert evt.attributes.get("percent") == 0.5

--- a/quartermaster-sdk/tests/test_v030_telemetry.py
+++ b/quartermaster-sdk/tests/test_v030_telemetry.py
@@ -206,12 +206,7 @@ def test_instrument_creates_span_per_node(exporter):
     qm.configure(registry=_mock_registry("ok"))
     telemetry.instrument(tracer_provider=provider)
 
-    graph = (
-        qm.Graph("x")
-        .instruction("first")
-        .instruction("second")
-        .build()
-    )
+    graph = qm.Graph("x").instruction("first").instruction("second").build()
     result = qm.run(graph, "hi")
     assert result.success, result.error
 
@@ -241,10 +236,7 @@ def test_instrument_creates_tool_spans_under_agent_node(exporter):
 
     tool_reg = _ToolRegistry({"x": _OkTool({"echo": "hi"})})
     graph = (
-        qm.Graph("chat")
-        .user()
-        .agent("Tooled", tools=["x"], capture_as="agent")
-        .build()
+        qm.Graph("chat").user().agent("Tooled", tools=["x"], capture_as="agent").build()
     )
 
     result = qm.run(graph, "hi", tool_registry=tool_reg)
@@ -307,10 +299,7 @@ def test_progress_event_becomes_span_event(exporter):
 
     tool_reg = _ToolRegistry({"p": _ProgressTool()}, schema_name="p")
     graph = (
-        qm.Graph("chat")
-        .user()
-        .agent("Loader", tools=["p"], capture_as="agent")
-        .build()
+        qm.Graph("chat").user().agent("Loader", tools=["p"], capture_as="agent").build()
     )
     result = qm.run(graph, "hi", tool_registry=tool_reg)
     assert result.success, result.error

--- a/quartermaster-sdk/tests/test_v030_trace.py
+++ b/quartermaster-sdk/tests/test_v030_trace.py
@@ -1,0 +1,457 @@
+"""Tests for v0.3.0 structured trace.
+
+Covers the :class:`quartermaster_sdk.Trace` / :class:`NodeTrace` surface
+that every :class:`Result` now carries:
+
+* ``result.trace.text`` — concatenated :class:`TokenGenerated` tokens
+* ``result.trace.tool_calls`` — dicts extracted from
+  :class:`ToolCallFinished` events
+* ``result.trace.by_node["name"]`` — per-node :class:`NodeTrace` buckets
+* ``result.trace.progress`` / ``result.trace.custom(name=...)`` — event
+  filter shortcuts
+* ``result.trace.as_jsonl()`` — JSONL export
+* Populated for both streaming (``DoneChunk.result``) and non-streaming
+  runs
+* ``result.trace.duration_seconds`` — wall-clock
+
+The :class:`MockProvider` / ``_OkTool`` / ``_ToolRegistry`` shim pattern
+is lifted wholesale from :mod:`tests.test_v022_tool_streaming`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse, ToolCall
+
+
+# ── Test fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Mirror of :func:`test_v020_surface._mock_registry`.
+
+    Primes both the streamed-token and the native-response channels so
+    a graph built without ``agent()`` gets the same string from either
+    path the engine might take.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+def _tool_aware_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Mirror of :func:`test_v022_tool_streaming._tool_aware_registry`."""
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg, mock
+
+
+class _OkTool:
+    """Same success-envelope tool used by v0.2.2 tests."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True, "echo": "hello"}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = dict(self._data)
+        return r
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's expected interface —
+    ``.get(name)`` plus ``.to_openai_tools()``.
+
+    Keeps the same contract as ``test_v022_tool_streaming._ToolRegistry``
+    so a tool registered under its bare public name can be invoked by
+    name from a :class:`MockProvider`-driven agent loop.
+    """
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise KeyError(name) from exc
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+# ── 1. ``trace.text`` aggregates all tokens ──────────────────────────
+
+
+def test_trace_text_aggregates_all_tokens():
+    """The mock provider streams ``"hello world"`` — the trace's
+    :attr:`Trace.text` must be exactly that string, concatenated from
+    every :class:`TokenGenerated` event regardless of which node emitted
+    it."""
+    reg, _ = _mock_registry("hello world")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    result = qm.run(graph, "hi")
+
+    assert isinstance(result.trace, qm.Trace)
+    # The mock's streamed response is a single TokenResponse — the
+    # engine delivers it as one token, so ``trace.text`` equals the
+    # whole canned reply. Using ``result.text`` as the oracle keeps
+    # this robust to how the mock is tokenised internally.
+    assert result.trace.text == result.text == "hello world"
+
+
+# ── 2. Tool-call records extracted from ToolCallFinished events ──────
+
+
+def test_trace_tool_calls_extracted_from_events():
+    """One tool call → exactly one :class:`ToolCallFinished` event →
+    exactly one dict in :attr:`Trace.tool_calls` carrying every field
+    the spec requires (``tool``, ``arguments``, ``result``, ``raw``,
+    ``error``, ``iteration``)."""
+    reg, _ = _tool_aware_registry(
+        tool_name="x", tool_args={"q": "world"}, final_text="ack"
+    )
+    qm.configure(registry=reg)
+
+    tool_reg = _ToolRegistry({"x": _OkTool({"value": 42})})
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    tool_calls = result.trace.tool_calls
+    assert isinstance(tool_calls, list), (
+        f"expected list, got {type(tool_calls)}"
+    )
+    assert len(tool_calls) == 1, f"expected exactly 1 tool call, got {tool_calls}"
+
+    entry = tool_calls[0]
+    expected_keys = {"tool", "arguments", "result", "raw", "error", "iteration"}
+    assert set(entry) == expected_keys, (
+        f"keys mismatch — missing {expected_keys - set(entry)}, "
+        f"extra {set(entry) - expected_keys}"
+    )
+    assert entry["tool"] == "x"
+    assert entry["arguments"] == {"q": "world"}
+    assert entry["error"] is None
+    assert entry["raw"] == {"value": 42}
+    assert isinstance(entry["iteration"], int)
+
+
+# ── 3. by_node buckets events by node name ──────────────────────────
+
+
+def test_trace_by_node_buckets_events_by_name():
+    """Two named instruction nodes; each :class:`NodeTrace.events` must
+    contain only the events from its own node (the ``NodeStarted`` /
+    ``NodeFinished`` pair plus any tokens scoped to it).
+
+    The :class:`MockProvider` is primed with two responses so the engine
+    can serve each instruction node independently — the test asserts
+    that the two per-node buckets in :attr:`Trace.by_node` carry
+    disjoint event lists keyed by the two node names.
+    """
+    mock = MockProvider(
+        responses=[
+            TokenResponse(content="first-out", stop_reason="stop"),
+            TokenResponse(content="second-out", stop_reason="stop"),
+        ],
+        native_responses=[
+            NativeResponse(
+                text_content="first-out",
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+            NativeResponse(
+                text_content="second-out",
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    qm.configure(registry=reg)
+
+    # The ``instruction(name, ...)`` first arg IS the node's name — no
+    # second ``name=`` kwarg. The trace buckets on that same string
+    # via :class:`NodeStarted.node_name` / :class:`NodeFinished.node_name`.
+    graph = (
+        qm.Graph("x")
+        .instruction("node_a")
+        .instruction("node_b")
+        .build()
+    )
+
+    result = qm.run(graph, "hi")
+    assert result.success, result.error
+
+    assert "node_a" in result.trace.by_node, (
+        f"node_a missing from by_node keys: {list(result.trace.by_node)}"
+    )
+    assert "node_b" in result.trace.by_node, (
+        f"node_b missing from by_node keys: {list(result.trace.by_node)}"
+    )
+
+    node_a_trace = result.trace.by_node["node_a"]
+    node_b_trace = result.trace.by_node["node_b"]
+
+    # Each per-node bucket carries at least the NodeStarted and
+    # NodeFinished events for that node plus its own tokens — we
+    # don't hard-code counts (the engine may emit other events too)
+    # but the two buckets must be disjoint by identity.
+    assert isinstance(node_a_trace, qm.NodeTrace)
+    assert node_a_trace.node_name == "node_a"
+    assert isinstance(node_b_trace, qm.NodeTrace)
+    assert node_b_trace.node_name == "node_b"
+
+    # No event in node_a's bucket may appear in node_b's bucket.
+    a_ids = {id(e) for e in node_a_trace.events}
+    b_ids = {id(e) for e in node_b_trace.events}
+    assert a_ids.isdisjoint(b_ids), (
+        "by_node buckets must be disjoint — event overlap indicates "
+        "the latch logic leaked events across nodes"
+    )
+
+    # Per-node text accessor must scope correctly.  Tokens emitted for
+    # node_a are the ones the engine generated for that node; combining
+    # them must equal that node's share of ``result.trace.text``.
+    combined = node_a_trace.text + node_b_trace.text
+    assert combined == result.trace.text, (
+        f"per-node text should concat to trace.text: "
+        f"got {combined!r} vs {result.trace.text!r}"
+    )
+
+
+# ── 4. Progress + custom filters ─────────────────────────────────────
+
+
+def test_trace_progress_and_custom_filters():
+    """A tool emits one :class:`ProgressEvent` and one
+    :class:`CustomEvent`.  After the run:
+
+    * ``result.trace.progress`` must carry the progress event
+    * ``result.trace.custom(name="x")`` must carry only the matching
+      custom event (here named ``"x"``) — zero matches for a different
+      name.
+    """
+    # Tool that emits progress + custom via the contextvar on each call.
+    class _EmittingTool:
+        """Emit progress/custom when invoked by the agent loop."""
+
+        def safe_run(self, **kwargs: Any):
+            ctx = qm.current_context()
+            # Contract: the agent executor runs inside
+            # ``bind_current_context(...)`` so ctx is non-None here.
+            assert ctx is not None, (
+                "current_context() returned None inside tool — "
+                "contextvar propagation is broken"
+            )
+            ctx.emit_progress("emitting", percent=0.5)
+            ctx.emit_custom("x", {"hello": "world"})
+
+            class _R:
+                success = True
+
+            r = _R()
+            r.data = {"ok": True}
+            return r
+
+    reg, _ = _tool_aware_registry(
+        tool_name="x", tool_args={"q": "q"}, final_text="ok"
+    )
+    qm.configure(registry=reg)
+    tool_reg = _ToolRegistry({"x": _EmittingTool()})
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    # Progress filter: one event, with the message & percent we emitted.
+    progress = result.trace.progress
+    assert len(progress) == 1, f"expected 1 progress event, got {progress}"
+    assert progress[0].message == "emitting"
+    assert progress[0].percent == 0.5
+
+    # Custom filter by name: only matching events come back.
+    custom_x = result.trace.custom(name="x")
+    assert len(custom_x) == 1, f"expected 1 custom event named 'x', got {custom_x}"
+    assert custom_x[0].name == "x"
+    assert custom_x[0].payload == {"hello": "world"}
+
+    # Different name filter → zero matches.
+    assert result.trace.custom(name="other") == [], (
+        "filter by non-matching name must return []"
+    )
+
+    # No-arg filter returns every custom event (just the one here).
+    assert len(result.trace.custom()) == 1
+
+
+# ── 5. JSONL round-trip ──────────────────────────────────────────────
+
+
+def test_trace_as_jsonl_roundtrips():
+    """:meth:`Trace.as_jsonl` produces one valid JSON object per line,
+    and the number of lines equals the number of events in the trace.
+    """
+    reg, _ = _mock_registry("abc")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    result = qm.run(graph, "hi")
+    jsonl = result.trace.as_jsonl()
+
+    # Every line must parse as JSON.
+    lines = jsonl.splitlines()
+    assert len(lines) == len(result.trace.events), (
+        f"line count {len(lines)} != event count {len(result.trace.events)}"
+    )
+    for line in lines:
+        parsed = json.loads(line)
+        assert isinstance(parsed, dict), f"line not a JSON object: {line}"
+        # ``flow_id`` is required on every FlowEvent (it's the only
+        # base-class field) — its presence is the cheapest sanity check
+        # that ``asdict`` serialised the dataclass correctly.
+        assert "flow_id" in parsed, f"line missing flow_id: {line}"
+
+
+# ── 6. Streaming run populates trace on DoneChunk.result ────────────
+
+
+def test_trace_populated_for_streaming_run():
+    """Drain :func:`run.stream` to the terminal :class:`DoneChunk` and
+    assert its :attr:`Result.trace.text` matches the streamed canned
+    reply — the streaming path installs the same collector as the
+    sync path so both surfaces expose the trace.
+    """
+    reg, _ = _mock_registry("streamed reply")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    chunks = list(qm.run.stream(graph, "hi"))
+
+    done = chunks[-1]
+    assert isinstance(done, qm.DoneChunk)
+    assert isinstance(done.result.trace, qm.Trace)
+    assert done.result.trace.text == "streamed reply"
+    # The trace must also carry events (i.e. the collector actually ran
+    # — a default-constructed Trace() has an empty event list, which
+    # would pass the .text check above trivially).
+    assert len(done.result.trace.events) > 0, (
+        "streaming path produced a Trace with zero events — "
+        "on_event collector didn't run"
+    )
+
+
+# ── 7. Duration recorded ─────────────────────────────────────────────
+
+
+def test_trace_duration_seconds_recorded():
+    """:attr:`Trace.duration_seconds` is populated to a positive value
+    after a run — either mirroring :attr:`Result.duration_seconds` or
+    falling back to the runner's wall-clock measurement.
+    """
+    reg, _ = _mock_registry("x")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    result = qm.run(graph, "hi")
+
+    assert result.trace.duration_seconds > 0, (
+        f"expected positive duration, got {result.trace.duration_seconds!r}"
+    )

--- a/quartermaster-sdk/tests/test_v030_trace.py
+++ b/quartermaster-sdk/tests/test_v030_trace.py
@@ -195,19 +195,14 @@ def test_trace_tool_calls_extracted_from_events():
 
     tool_reg = _ToolRegistry({"x": _OkTool({"value": 42})})
     graph = (
-        qm.Graph("chat")
-        .user()
-        .agent("Tooled", tools=["x"], capture_as="agent")
-        .build()
+        qm.Graph("chat").user().agent("Tooled", tools=["x"], capture_as="agent").build()
     )
 
     result = qm.run(graph, "hi", tool_registry=tool_reg)
     assert result.success, result.error
 
     tool_calls = result.trace.tool_calls
-    assert isinstance(tool_calls, list), (
-        f"expected list, got {type(tool_calls)}"
-    )
+    assert isinstance(tool_calls, list), f"expected list, got {type(tool_calls)}"
     assert len(tool_calls) == 1, f"expected exactly 1 tool call, got {tool_calls}"
 
     entry = tool_calls[0]
@@ -265,12 +260,7 @@ def test_trace_by_node_buckets_events_by_name():
     # The ``instruction(name, ...)`` first arg IS the node's name — no
     # second ``name=`` kwarg. The trace buckets on that same string
     # via :class:`NodeStarted.node_name` / :class:`NodeFinished.node_name`.
-    graph = (
-        qm.Graph("x")
-        .instruction("node_a")
-        .instruction("node_b")
-        .build()
-    )
+    graph = qm.Graph("x").instruction("node_a").instruction("node_b").build()
 
     result = qm.run(graph, "hi")
     assert result.success, result.error
@@ -324,6 +314,7 @@ def test_trace_progress_and_custom_filters():
       custom event (here named ``"x"``) — zero matches for a different
       name.
     """
+
     # Tool that emits progress + custom via the contextvar on each call.
     class _EmittingTool:
         """Emit progress/custom when invoked by the agent loop."""
@@ -346,16 +337,11 @@ def test_trace_progress_and_custom_filters():
             r.data = {"ok": True}
             return r
 
-    reg, _ = _tool_aware_registry(
-        tool_name="x", tool_args={"q": "q"}, final_text="ok"
-    )
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "q"}, final_text="ok")
     qm.configure(registry=reg)
     tool_reg = _ToolRegistry({"x": _EmittingTool()})
     graph = (
-        qm.Graph("chat")
-        .user()
-        .agent("Tooled", tools=["x"], capture_as="agent")
-        .build()
+        qm.Graph("chat").user().agent("Tooled", tools=["x"], capture_as="agent").build()
     )
 
     result = qm.run(graph, "hi", tool_registry=tool_reg)

--- a/quartermaster-sdk/tests/test_v030_vision.py
+++ b/quartermaster-sdk/tests/test_v030_vision.py
@@ -1,0 +1,294 @@
+"""Tests for the v0.3.0 vision image input surface.
+
+Covers ``qm.run(graph, user_input, image=...)`` / ``images=[...]``,
+``qm.arun(...)`` equivalents, and the :func:`qm.instruction` helper's
+image forwarding. Replaces the pre-0.3.0 ``[IMAGE_BASE64::...]`` shim
+that downstream Sorex ERP used to prepend to user input.
+
+The tests mock the provider via :class:`MockProvider` so nothing hits
+the network — each assertion reaches into ``mock.last_config.images``
+to verify that the engine forwarded the base64-encoded tuples through
+``flow_memory["__user_images__"]`` into ``LLMConfig.images`` when the
+node declared ``vision=True``, and that plain ``.instruction()`` nodes
+receive an empty list (the image kwarg is a no-op on non-vision graphs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import pathlib
+from typing import Any
+
+import openai  # noqa: F401 — eager import, matches test_v020_surface.py
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _mock_registry(text: str = "ocr-output") -> tuple[ProviderRegistry, MockProvider]:
+    """Build a ProviderRegistry with a MockProvider registered as ``ollama``.
+
+    Both text (streamed) and native-response channels are primed so the
+    vision LLMExecutor — which takes the streamed text path — sees a
+    consistent reply. Matches the helper used by ``test_v020_surface``.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+def _vision_graph() -> qm.GraphSpec:
+    """Single-node vision graph for most tests."""
+    return (
+        qm.Graph("ocr")
+        .vision(
+            "extract",
+            system_instruction="You are an OCR system.",
+        )
+        .build()
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+@pytest.fixture
+def tiny_png_bytes() -> bytes:
+    """A minimal, valid 1x1 PNG. Lets us test real bytes without fixtures on disk."""
+    # Smallest syntactically valid PNG — 67 bytes. Good enough to
+    # exercise bytes → base64 conversion without pulling a real image
+    # into the test tree.
+    return bytes.fromhex(
+        "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+        "890000000d49444154789c63f8cfc0500f0000040001212c2e4e0000000049454e44ae426082"
+    )
+
+
+@pytest.fixture
+def tiny_png_file(tmp_path: pathlib.Path, tiny_png_bytes: bytes) -> pathlib.Path:
+    """Writes the tiny PNG to a temp file so tests can exercise the Path code path."""
+    p = tmp_path / "test.png"
+    p.write_bytes(tiny_png_bytes)
+    return p
+
+
+# ── 1. qm.run accepts image= bytes ────────────────────────────────────
+
+
+class TestQmRunImageBytes:
+    def test_qm_run_accepts_image_bytes(self, tiny_png_bytes):
+        """Passing ``image=bytes`` lands a base64 tuple on ``LLMConfig.images``.
+
+        The vision node's LLMExecutor reads ``__user_images__`` from
+        flow memory; ``_build_llm_config`` forwards it to the provider
+        via ``LLMConfig.images`` only when ``vision=True`` is set on
+        the node (the builder handles that).
+        """
+        reg, mock = _mock_registry()
+        qm.configure(registry=reg)
+
+        result = qm.run(_vision_graph(), "extract the invoice", image=tiny_png_bytes)
+
+        assert result.success, f"run failed: {result.error}"
+        # The provider received the image through LLMConfig.
+        assert mock.last_config is not None
+        assert mock.last_config.vision is True
+        assert len(mock.last_config.images) == 1
+        b64, mime = mock.last_config.images[0]
+        assert b64 == base64.b64encode(tiny_png_bytes).decode("ascii")
+        # Raw bytes default to image/jpeg — we didn't give an extension.
+        assert mime == "image/jpeg"
+
+
+# ── 2. qm.run accepts pathlib.Path ────────────────────────────────────
+
+
+class TestQmRunImagePath:
+    def test_qm_run_accepts_path(self, tiny_png_file, tiny_png_bytes):
+        """Passing a ``pathlib.Path`` reads the file and detects MIME from ext."""
+        reg, mock = _mock_registry()
+        qm.configure(registry=reg)
+
+        qm.run(_vision_graph(), "extract", image=tiny_png_file)
+
+        assert mock.last_config is not None
+        assert len(mock.last_config.images) == 1
+        b64, mime = mock.last_config.images[0]
+        assert b64 == base64.b64encode(tiny_png_bytes).decode("ascii")
+        assert mime == "image/png"
+
+    def test_qm_run_accepts_str_path(self, tiny_png_file, tiny_png_bytes):
+        """A filesystem path given as ``str`` works the same as Path."""
+        reg, mock = _mock_registry()
+        qm.configure(registry=reg)
+
+        qm.run(_vision_graph(), "extract", image=str(tiny_png_file))
+
+        assert mock.last_config is not None
+        b64, mime = mock.last_config.images[0]
+        assert b64 == base64.b64encode(tiny_png_bytes).decode("ascii")
+        assert mime == "image/png"
+
+
+# ── 3. qm.run accepts images= list ────────────────────────────────────
+
+
+class TestQmRunImagesList:
+    def test_qm_run_accepts_images_list(self, tiny_png_bytes):
+        """Multiple images forward as a list of ``(b64, mime)`` tuples."""
+        reg, mock = _mock_registry()
+        qm.configure(registry=reg)
+
+        # Two copies of the same bytes is enough to exercise the list path.
+        qm.run(
+            _vision_graph(),
+            "compare these",
+            images=[tiny_png_bytes, tiny_png_bytes],
+        )
+
+        assert mock.last_config is not None
+        assert len(mock.last_config.images) == 2
+        expected_b64 = base64.b64encode(tiny_png_bytes).decode("ascii")
+        assert all(b64 == expected_b64 for b64, _ in mock.last_config.images)
+
+    def test_qm_run_rejects_both_image_and_images(self, tiny_png_bytes):
+        """Passing both at once is ambiguous — fail loudly."""
+        reg, _ = _mock_registry()
+        qm.configure(registry=reg)
+
+        with pytest.raises(ValueError, match="either image= .* or images="):
+            qm.run(
+                _vision_graph(),
+                "x",
+                image=tiny_png_bytes,
+                images=[tiny_png_bytes],
+            )
+
+
+# ── 4. qm.arun equivalent ─────────────────────────────────────────────
+
+
+class TestQmArunImage:
+    def test_qm_arun_accepts_image(self, tiny_png_bytes):
+        """``await qm.arun(..., image=bytes)`` forwards the same way qm.run does."""
+        reg, mock = _mock_registry()
+        qm.configure(registry=reg)
+
+        async def _main() -> Any:
+            return await qm.arun(_vision_graph(), "extract", image=tiny_png_bytes)
+
+        result = asyncio.run(_main())
+        assert result.success, f"arun failed: {result.error}"
+        assert mock.last_config is not None
+        assert len(mock.last_config.images) == 1
+        b64, _ = mock.last_config.images[0]
+        assert b64 == base64.b64encode(tiny_png_bytes).decode("ascii")
+
+
+# ── 5. instruction() helper ───────────────────────────────────────────
+
+
+class TestInstructionImage:
+    def test_instruction_helper_accepts_image(self, tiny_png_bytes):
+        """``qm.instruction(..., image=bytes)`` routes through a .vision() node.
+
+        The helper builds a one-node graph under the hood; passing
+        ``image=`` flips it from an instruction node to a vision node so
+        the engine actually forwards the image to the provider config.
+        """
+        reg, mock = _mock_registry(text="extracted")
+        qm.configure(registry=reg)
+
+        out = qm.instruction(
+            system="Extract",
+            user="read the image",
+            image=tiny_png_bytes,
+        )
+
+        assert out == "extracted"
+        assert mock.last_config is not None
+        assert mock.last_config.vision is True
+        assert len(mock.last_config.images) == 1
+        b64, _ = mock.last_config.images[0]
+        assert b64 == base64.b64encode(tiny_png_bytes).decode("ascii")
+
+
+# ── 6. Non-vision graph silently drops the image ──────────────────────
+
+
+class TestNoOpOnNonVisionGraph:
+    def test_image_kwarg_works_without_vision_node(self, tiny_png_bytes):
+        """Passing ``image=`` to a plain instruction graph is a no-op.
+
+        Rationale: callers shouldn't have to branch on "is this graph
+        vision-enabled?" — the image is stored in flow memory, but
+        ``_build_llm_config`` only reads it when the node declared
+        ``vision=True``. Plain instruction nodes see an empty list.
+        """
+        reg, mock = _mock_registry()
+        qm.configure(registry=reg)
+
+        # Note: plain .instruction(), not .vision()
+        graph = qm.Graph("plain").instruction("one").build()
+
+        result = qm.run(graph, "hi", image=tiny_png_bytes)
+
+        assert result.success, f"run failed: {result.error}"
+        assert mock.last_config is not None
+        # vision=False on the config — no image parts were forwarded.
+        assert mock.last_config.vision is False
+        assert mock.last_config.images == []
+
+
+# ── 7. URL / data: URI rejection ──────────────────────────────────────
+
+
+class TestUriRejection:
+    def test_data_uri_raises_clear_error(self):
+        """``data:image/...;base64,...`` URIs are out of scope."""
+        reg, _ = _mock_registry()
+        qm.configure(registry=reg)
+
+        with pytest.raises(ValueError, match="data: URIs"):
+            qm.run(
+                _vision_graph(),
+                "x",
+                image="data:image/jpeg;base64,/9j/4AAQ",
+            )
+
+    def test_http_url_raises_clear_error(self):
+        """``http://...`` URLs are out of scope — callers fetch bytes themselves."""
+        reg, _ = _mock_registry()
+        qm.configure(registry=reg)
+
+        with pytest.raises(ValueError, match="http\\(s\\) URLs"):
+            qm.run(
+                _vision_graph(),
+                "x",
+                image="https://example.com/image.jpg",
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,7 +3143,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-providers" }
 dependencies = [
     { name = "httpx" },
@@ -3197,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3254,6 +3254,10 @@ privacy = [
 providers-all = [
     { name = "quartermaster-providers", extra = ["all"] },
 ]
+telemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+]
 tools-all = [
     { name = "quartermaster-tools", extra = ["all"] },
 ]
@@ -3267,6 +3271,8 @@ web = [
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.41.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.41.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -3292,11 +3298,11 @@ requires-dist = [
     { name = "quartermaster-tools", extras = ["web"], marker = "extra == 'web'", editable = "quartermaster-tools" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
 ]
-provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "web", "browser", "database", "vector", "privacy", "observability", "tools-all", "mcp", "code-runner", "all", "dev"]
+provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "web", "browser", "database", "vector", "privacy", "observability", "tools-all", "mcp", "code-runner", "all", "dev", "telemetry"]
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3370,7 +3376,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Major ergonomics upgrade. Closes the four "still clunky" items the downstream Sorex ERP team flagged after using v0.2.2 in production.

Plan: \`~/.claude/plans/expressive-soaring-melody.md\` (read-only on disk, summarised below).

## Four workstreams

### T1 — Custom & progress events
- New engine events \`ProgressEvent(message, percent, data)\` and \`CustomEvent(name, payload)\`.
- New \`ExecutionContext.emit_progress(...)\` / \`emit_custom(...)\` methods (mirror existing \`on_token\` pattern).
- New \`quartermaster_engine/context/current_context.py\` exposes a contextvar + \`current_context()\` getter + \`bind()\` ctx-manager. \`FlowRunner._run_executor\` wraps \`executor.execute()\` in a bind block so tools inside any node call \`qm.current_context().emit_progress(...)\` from arbitrary depth.
- **Critical regression guard**: \`_run_executor\` propagates the contextvar across its \`ThreadPoolExecutor\` boundary via \`contextvars.copy_context().run(...)\`. Without this the worker thread sees \`current_context() == None\` and tools silently no-op. Pinned by a dedicated test (\`test_current_context_propagates_into_thread_pool_executor\`).
- New SDK chunks \`ProgressChunk\` / \`CustomChunk\` translated by \`_event_to_chunk\`.
- \`current_context\` re-exported at \`quartermaster_sdk\` top level.

### T2 — Filtered iterators
- \`qm.run.stream(graph, ...)\` and \`qm.arun.stream(...)\` now return a \`_Stream\` / \`_AsyncStream\` wrapper that's still iterable (\`for chunk in ...\` works unchanged) but exposes filter helpers:
  - \`.tokens()\` → \`Iterator[str]\` (yields \`chunk.content\` directly — most common case)
  - \`.tool_calls()\` → \`Iterator[ToolCallChunk]\`
  - \`.progress()\` → \`Iterator[ProgressChunk]\`
  - \`.custom(name=None)\` → \`Iterator[CustomChunk]\`, optionally filtered by name
- Single-pass semantics: calling a second filter on the same stream raises \`RuntimeError("stream already consumed")\`.
- Sync + async parity.

### T3 — Structured \`Trace\` on \`Result\`
- \`Result.trace: Trace\` populated for both streaming and non-streaming runs.
- \`trace.text\` (concatenated tokens), \`trace.tool_calls\`, \`trace.progress\`, \`trace.custom(name=None)\`, \`trace.events\` (raw FlowEvent list), \`trace.duration_seconds\`.
- \`trace.by_node["research"]\` → \`NodeTrace\` with the same accessors scoped to one node.
- Flow-level events (\`FlowFinished\`, \`FlowError\`, \`UserInputRequired\`) land in synthetic \`"_flow"\` bucket.
- \`trace.as_jsonl()\` → string of one JSON object per line; \`asdict\` + \`default=str\` for UUID/datetime coercion.

### T5 — OpenTelemetry instrumentation
- New \`quartermaster_sdk.telemetry.instrument(tracer_provider=None)\` + \`uninstrument()\`.
- Listener registry at \`quartermaster_sdk._listeners\` (thread-safe, lock-guarded). Both \`run\` and \`arun\` paths invoke \`_listeners.dispatch(event)\` from inside their existing \`on_event\` callback — single seam, zero engine changes.
- Spans use OTEL GenAI semantic conventions: \`gen_ai.system\`, \`gen_ai.operation.name\`, \`gen_ai.tool.name\`, \`gen_ai.tool.call.arguments\`, \`gen_ai.usage.input_tokens\`, \`gen_ai.usage.output_tokens\`. Quartermaster extras under \`qm.*\`.
- Tool spans nest under their owning agent node span via explicit \`trace.set_span_in_context(parent)\` (engine worker threads don't share OTEL contextvars with the caller — important to know).
- Optional dependency: \`pip install 'quartermaster-sdk[telemetry]'\` (pulls \`opentelemetry-api>=1.25\`, \`opentelemetry-sdk>=1.25\`).

## Tests

| Package | Before | After | Delta |
|---|---|---|---|
| engine | 432 | **441** | +9 (\`test_v030_events_and_context.py\`) |
| sdk | 89 | **112** | +23 (12 filtered iterators + 7 trace + 4 telemetry) |
| graph | 232 | 232 | unchanged |
| providers | 241 + 9 skip | 241 + 9 skip | unchanged |
| **Total** | 994 | **1026** | **+32** |

\`test_v022_tool_streaming.py\` and \`test_v022_async_runner.py\` pass unchanged — full back-compat with v0.2.2 surface.

## Deferred (NOT in v0.3.0)

- Hierarchical \`span_id\` / \`parent_span_id\` on every event — there's no sub-graph spawning yet, so \`node_id\` is sufficient for tree-rendering today. Will ship in v0.3.1 once sub-graphs become real.
- Listener registry as a public surface (it's internal-only for telemetry). Public \`qm.run.on_token(fn)\` deferred until users ask.
- Event replay from JSONL — events are now JSON-clean via \`as_jsonl()\`, so this is a follow-up library, not core.
- True async-native \`FlowRunner\` — current thread-bridge works; refactor invasive, defer.

## After merge

1. **Actions → Publish to PyPI → Run workflow**, \`bump=minor\` → ships **v0.3.0**.
2. Back-merge \`master\` → \`develop\`.
3. **No yanks needed** — v0.2.x stays live; v0.3.0 is purely additive. \`pip install -U quartermaster-sdk\` gets the new surface and existing code keeps working.