### PR TITLE
Bring v0.2.2 + v0.3.0 work onto develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,34 +27,64 @@ uv sync
 
 ## Quick Start
 
-The simplest possible graph — `start → user → agent → end` — running against a
-local Ollama in three lines:
+The simplest possible graph — running against a local Ollama in four lines
+(no `.start()`, no `.end()`, no `.build()`, no `FlowRunner` import):
 
 ```python
-from quartermaster_sdk import Graph, FlowRunner, register_local
+import quartermaster_sdk as qm
 
-provider_registry = register_local(
-    "ollama",
-    base_url="http://localhost:11434",   # or set $OLLAMA_HOST
-    default_model="gemma4:26b",
-)
+qm.configure(provider="ollama", base_url="http://localhost:11434", default_model="gemma4:26b")
 
-graph = Graph("chat").start().user().agent().end().build()
-runner = FlowRunner(graph=graph, provider_registry=provider_registry)
-result = runner.run("Pozdravljen, koliko je ura?")
-print(result.final_output)
+result = qm.run(qm.Graph("chat").user().agent(), "Pozdravljen, koliko je ura?")
+print(result.text)
+```
+
+`qm.run()` accepts the builder directly and finalises it internally —
+`.build()` is only needed when you want the validated `GraphSpec` for
+serialisation or inspection. For single-shot calls skip the graph entirely:
+
+```python
+reply = qm.instruction(system="Respond in Slovenian.", user="Pozdravljen!")
+# reply is a str.
+```
+
+For typed JSON extraction:
+
+```python
+from pydantic import BaseModel
+
+class Classification(BaseModel):
+    category: str
+    priority: str
+
+data = qm.instruction_form(Classification, system="Classify.", user=email_body)
+# data is a Classification instance.
 ```
 
 For richer flows you keep the explicit per-node configuration:
 
 ```python
 agent = (
-    Graph("My Agent")
-    .start()
+    qm.Graph("My Agent")
     .user("What can I help you with?")
     .instruction("Respond", model="gpt-4o", system_instruction="You are a helpful assistant.")
-    .end()
 )
+result = qm.run(agent, "...")
+```
+
+### Reading specific node outputs with `capture_as=`
+
+Attach a name to any node and read its output from `result.captures`:
+
+```python
+graph = (
+    qm.Graph("enrich")
+    .agent("Research", tools=[...], capture_as="notes")
+    .instruction_form(CustomerData, system="Extract.", capture_as="data")
+)
+result = qm.run(graph, "VT-Treyd Slovenija")
+result["notes"].output_text    # agent's free-text research
+result["data"].output_text     # form-parsed JSON
 ```
 
 ### Sync `OllamaProvider.chat()` for non-graph callers
@@ -239,7 +269,7 @@ quartermaster-code-runner   Standalone Docker code execution
 ## Key Concepts
 
 - **Graph** -- A directed graph (supports cycles via `connect()` for loops) of nodes and edges. Built with the fluent `Graph("name").start().user("Input")...end()` API.
-- **GraphSpec** -- The serializable graph model (`GraphSpec` in quartermaster-graph) returned by `Graph.build()`. `AgentGraph` remains as a deprecated backward-compat alias.
+- **GraphSpec** -- The serializable graph model (`GraphSpec` in quartermaster-graph). `qm.run(graph, ...)` finalises the builder for you; explicit `Graph.build()` only matters when you want the validated spec to serialise / inspect. `AgentGraph` remains as a deprecated backward-compat alias.
 - **User Node** -- Every graph starts with `.user()` after `.start()` to collect user input.
 - **Nodes** -- Units of work: LLM calls, decisions, user input, memory, tools, templates.
 - **Edges** -- Directed connections between nodes. Decision/IF/Switch edges carry labels.

--- a/examples/01_hello_agent.py
+++ b/examples/01_hello_agent.py
@@ -1,26 +1,46 @@
 """The simplest possible agent: user asks, LLM responds.
 
-Demonstrates the minimal Graph API -- three nodes chained together
-with the fluent builder, then executed with a real LLM.
+Canonical v0.2.0 ergonomic demo — four imports, four lines, no
+``.start()`` / ``.end()`` / ``.build()`` / ``FlowRunner`` boilerplate.
 
 Usage:
-    export ANTHROPIC_API_KEY="sk-ant-..."   # or OPENAI_API_KEY
+    # Either set an API key...
+    export ANTHROPIC_API_KEY="sk-ant-..."      # or OPENAI_API_KEY
+    uv run examples/01_hello_agent.py
+
+    # ...or run against a local Ollama:
+    ollama serve && ollama pull gemma4:26b
+    export OLLAMA_HOST=http://localhost:11434
+    export QM_DEFAULT_MODEL=gemma4:26b
     uv run examples/01_hello_agent.py
 """
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
-# The simplest agent: ask user -> LLM responds
-agent = (
-    Graph("Hello Agent")
-    .start()
-    .user("Ask me anything")
-    .instruction("Respond", model="claude-haiku-4-5-20251001", system_instruction="You are a helpful assistant. Be concise.")
-    .end()
+# Single-shot: no graph visible.  `qm.instruction(...)` builds a
+# one-node graph internally, runs it, and returns the assistant text.
+# Uses the default provider from `qm.configure(...)` or $OLLAMA_HOST /
+# $QM_DEFAULT_MODEL — no boilerplate.
+reply = qm.instruction(
+    system="You are a helpful assistant. Be concise.",
+    user="What is the capital of Slovenia?",
+    model="claude-haiku-4-5-20251001",
 )
+print("Single-shot:", reply)
 
-# Execute with a real LLM
-run_graph(agent, user_input="What is the capital of Slovenia?")
+# Full graph path: same semantics as the cloud-auto-detecting v0.1.x
+# `run_graph()`, but now without the `.start().end().build()` dance.
+# `qm.run_graph()` finalises the builder internally and prints as it
+# streams.
+agent = (
+    qm.Graph("Hello Agent")
+    .user("Ask me anything")
+    .instruction(
+        "Respond",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="You are a helpful assistant. Be concise.",
+    )
+)
+qm.run_graph(agent, user_input="What is the capital of Slovenia?")

--- a/examples/02_decision_flow.py
+++ b/examples/02_decision_flow.py
@@ -11,25 +11,38 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Sentiment Analyzer")
-    .start()
+    qm.Graph("Sentiment Analyzer")
     .user("Enter text to analyze")
-    .instruction("Analyze sentiment", model="claude-haiku-4-5-20251001", system_instruction="Classify as positive or negative")
+    .instruction(
+        "Analyze sentiment",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Classify as positive or negative",
+    )
     .decision("Sentiment?", options=["positive", "negative"])
     .on("positive")
-        .instruction("Positive response", model="claude-haiku-4-5-20251001", system_instruction="Generate an enthusiastic response")
+    .instruction(
+        "Positive response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Generate an enthusiastic response",
+    )
     .end()
     .on("negative")
-        .instruction("Negative response", model="claude-haiku-4-5-20251001", system_instruction="Generate an empathetic response")
+    .instruction(
+        "Negative response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Generate an empathetic response",
+    )
     .end()
     # No merge needed -- decision picks ONE branch, so branches converge
     # directly on the next node.
-    .instruction("Final summary", model="claude-haiku-4-5-20251001", system_instruction="Summarize the analysis")
-    .end()
+    .instruction(
+        "Final summary",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Summarize the analysis",
+    )
 )
 
-run_graph(agent, user_input="I absolutely love this product, it changed my life!")
+qm.run_graph(agent, user_input="I absolutely love this product, it changed my life!")

--- a/examples/03_multi_decision.py
+++ b/examples/03_multi_decision.py
@@ -12,47 +12,72 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Multi-Stage Classifier")
-    .start()
+    qm.Graph("Multi-Stage Classifier")
     .user("Describe your issue")
-
     # First decision: categorize the request
     .decision("Category?", options=["technical", "billing", "general"])
     .on("technical")
-        .instruction("Tech triage", model="claude-haiku-4-5-20251001", system_instruction="Assess technical severity")
+    .instruction(
+        "Tech triage",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Assess technical severity",
+    )
     .end()
     .on("billing")
-        .instruction("Billing check", model="claude-haiku-4-5-20251001", system_instruction="Look up account status")
+    .instruction(
+        "Billing check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Look up account status",
+    )
     .end()
     .on("general")
-        .instruction("General info", model="claude-haiku-4-5-20251001", system_instruction="Provide general help")
+    .instruction(
+        "General info",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide general help",
+    )
     .end()
     # No merge -- decision picks ONE branch, they converge on the next node.
-
     # Second decision: urgency check (boolean if-node)
     .if_node("Is urgent?", expression="severity == 'high'")
     .on("true")
-        .instruction("Escalate", model="claude-haiku-4-5-20251001", system_instruction="Create urgent ticket")
-        .static("Alert team", text="Urgent issue!")
+    .instruction(
+        "Escalate",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create urgent ticket",
+    )
+    .static("Alert team", text="Urgent issue!")
     .end()
     .on("false")
-        .instruction("Standard response", model="claude-haiku-4-5-20251001", system_instruction="Provide standard help")
+    .instruction(
+        "Standard response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide standard help",
+    )
     .end()
     # No merge -- IF picks ONE branch.
-
     # Third decision: user feedback (manual choice)
     .decision("Was this helpful?", options=["yes", "no"])
     .on("yes")
-        .instruction("Thank user", model="claude-haiku-4-5-20251001", system_instruction="Thank them and close")
+    .instruction(
+        "Thank user",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Thank them and close",
+    )
     .end()
     .on("no")
-        .instruction("Escalate to human", model="claude-haiku-4-5-20251001", system_instruction="Transfer to human agent")
-    .end()
+    .instruction(
+        "Escalate to human",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Transfer to human agent",
+    )
     .end()
 )
 
-run_graph(agent, user_input="My server keeps crashing with out-of-memory errors every few hours")
+qm.run_graph(
+    agent,
+    user_input="My server keeps crashing with out-of-memory errors every few hours",
+)

--- a/examples/04_sub_graphs.py
+++ b/examples/04_sub_graphs.py
@@ -12,42 +12,66 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # --- Reusable sub-graphs ---------------------------------------------------
 
 research_flow = (
-    Graph("Research")
-    .start()
-    .instruction("Search web", model="claude-haiku-4-5-20251001", system_instruction="Find relevant information")
-    .instruction("Summarize findings", model="claude-haiku-4-5-20251001", system_instruction="Create a concise summary")
-    .end()
+    qm.Graph("Research")
+    .instruction(
+        "Search web",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Find relevant information",
+    )
+    .instruction(
+        "Summarize findings",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create a concise summary",
+    )
 )
 
 code_review_flow = (
-    Graph("Code Review")
-    .start()
-    .instruction("Analyze code", model="claude-haiku-4-5-20251001", system_instruction="Review code for bugs and style")
-    .instruction("Generate suggestions", model="claude-haiku-4-5-20251001", system_instruction="Suggest improvements")
-    .end()
+    qm.Graph("Code Review")
+    .instruction(
+        "Analyze code",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Review code for bugs and style",
+    )
+    .instruction(
+        "Generate suggestions",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Suggest improvements",
+    )
 )
 
 # --- Compose into a main agent ---------------------------------------------
 
 agent = (
-    Graph("Dev Assistant")
-    .start()
+    qm.Graph("Dev Assistant")
     .user("What do you need help with?")
     .decision("Task type?", options=["research", "code_review", "chat"])
-    .on("research").use(research_flow).end()
-    .on("code_review").use(code_review_flow).end()
+    .on("research")
+    .use(research_flow)
+    .end()
+    .on("code_review")
+    .use(code_review_flow)
+    .end()
     .on("chat")
-        .instruction("Chat", model="claude-haiku-4-5-20251001", system_instruction="Have a helpful conversation")
+    .instruction(
+        "Chat",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Have a helpful conversation",
+    )
     .end()
     # No merge -- decision picks ONE branch.
-    .instruction("Deliver answer", model="claude-haiku-4-5-20251001", system_instruction="Present the final result clearly")
-    .end()
+    .instruction(
+        "Deliver answer",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Present the final result clearly",
+    )
 )
 
-run_graph(agent, user_input="Research the latest trends in WebAssembly for server-side applications")
+qm.run_graph(
+    agent,
+    user_input="Research the latest trends in WebAssembly for server-side applications",
+)

--- a/examples/05_memory_flow.py
+++ b/examples/05_memory_flow.py
@@ -18,30 +18,32 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Customer Service Agent")
-    .start()
-
+    qm.Graph("Customer Service Agent")
     # --- Step 1: Collect customer name ----------------------------------------
     .user("What is your name?")
     .var("Capture name", variable="customer_name")
     .write_memory("Remember customer", memory_name="customer_name")
-
     # --- Step 2: Personalised greeting using a text template ------------------
-    .text("Greeting", template="Hello {{customer_name}}, welcome to support! How can I help?")
-
+    .text(
+        "Greeting",
+        template="Hello {{customer_name}}, welcome to support! How can I help?",
+    )
     # --- Step 3: Collect and store the issue -----------------------------------
     .user("Describe your issue")
     .var("Capture issue", variable="issue_description")
     .write_memory(
         "Create ticket",
         memory_name="support_ticket",
-        variables=[{"name": "issue_description", "value": "status:open | issue:{{issue_description}}"}],
+        variables=[
+            {
+                "name": "issue_description",
+                "value": "status:open | issue:{{issue_description}}",
+            }
+        ],
     )
-
     # --- Step 4: Read back customer name for personalised resolution ----------
     .read_memory("Recall customer", memory_name="customer_name")
     .instruction(
@@ -52,21 +54,23 @@ agent = (
             "Their issue: {{issue_description}}. Provide a clear, empathetic resolution."
         ),
     )
-
     # --- Step 5: Update ticket and log interaction ----------------------------
     .update_memory("Close ticket", memory_name="support_ticket")
     .write_memory(
         "Log interaction",
         memory_name="interaction_log",
-        variables=[{"name": "interaction", "value": "resolved | customer:{{customer_name}} | issue:{{issue_description}}"}],
+        variables=[
+            {
+                "name": "interaction",
+                "value": "resolved | customer:{{customer_name}} | issue:{{issue_description}}",
+            }
+        ],
     )
-
     # --- Step 6: Farewell -----------------------------------------------------
     .text(
         "Farewell",
         template="Thank you {{customer_name}}! Your ticket has been resolved.",
     )
-    .end()
 )
 
-run_graph(agent, user_input="Alice")
+qm.run_graph(agent, user_input="Alice")

--- a/examples/06_tool_decorator.py
+++ b/examples/06_tool_decorator.py
@@ -72,4 +72,6 @@ print(f"\nWeather result: {result}")
 # Export as JSON Schema for LLM function calling
 print("\nJSON Schema export:")
 for schema in registry.to_json_schema():
-    print(f"  {schema['name']}: {len(schema['parameters'].get('properties', {}))} params")
+    print(
+        f"  {schema['name']}: {len(schema['parameters'].get('properties', {}))} params"
+    )

--- a/examples/07_switch_router.py
+++ b/examples/07_switch_router.py
@@ -11,23 +11,54 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # Multi-language support agent with switch-style routing
 agent = (
-    Graph("Multi-Language Agent")
-    .start()
+    qm.Graph("Multi-Language Agent")
     .user("Enter your message")
-    .instruction("Detect language", model="claude-haiku-4-5-20251001", system_instruction="Detect the language. Output: en/es/fr/de/other")
+    .instruction(
+        "Detect language",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Detect the language. Output: en/es/fr/de/other",
+    )
     .decision("Language?", options=["en", "es", "fr", "de", "other"])
-    .on("en").instruction("English handler", model="claude-haiku-4-5-20251001", system_instruction="Respond in English").end()
-    .on("es").instruction("Spanish handler", model="claude-haiku-4-5-20251001", system_instruction="Responde en espanol").end()
-    .on("fr").instruction("French handler", model="claude-haiku-4-5-20251001", system_instruction="Repondez en francais").end()
-    .on("de").instruction("German handler", model="claude-haiku-4-5-20251001", system_instruction="Antworten Sie auf Deutsch").end()
-    .on("other").instruction("Fallback", model="claude-haiku-4-5-20251001", system_instruction="Respond in English, note language").end()
-    # No merge -- decision picks one language branch, they converge on End.
+    .on("en")
+    .instruction(
+        "English handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Respond in English",
+    )
     .end()
+    .on("es")
+    .instruction(
+        "Spanish handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Responde en espanol",
+    )
+    .end()
+    .on("fr")
+    .instruction(
+        "French handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Repondez en francais",
+    )
+    .end()
+    .on("de")
+    .instruction(
+        "German handler",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Antworten Sie auf Deutsch",
+    )
+    .end()
+    .on("other")
+    .instruction(
+        "Fallback",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Respond in English, note language",
+    )
+    .end()
+    # No merge -- decision picks one language branch, they converge on the (implicit) end.
 )
 
-run_graph(agent, user_input="Bonjour, comment allez-vous aujourd'hui?")
+qm.run_graph(agent, user_input="Bonjour, comment allez-vous aujourd'hui?")

--- a/examples/08_iterative_refinement.py
+++ b/examples/08_iterative_refinement.py
@@ -18,9 +18,8 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_graph.enums import TraverseIn
-from quartermaster_engine import run_graph
 
 
 WRITER = dict(model="claude-haiku-4-5-20251001", provider="anthropic")
@@ -29,27 +28,30 @@ CRITIC = dict(model="llama-3.3-70b-versatile", provider="groq")
 MAX_ITERATIONS = 3
 
 agent = (
-    Graph("Iterative Refinement")
-    .start()
+    qm.Graph("Iterative Refinement")
     .user("What should I write about?")
     .var("Capture topic", variable="topic", show_output=False)
-
-    .text("Brief", template=(
-        "Assignment: Write a short, compelling paragraph about: {{topic}}\n"
-        "We will refine it through " + str(MAX_ITERATIONS) + " rounds of writing and critique."
-    ))
-
+    .text(
+        "Brief",
+        template=(
+            "Assignment: Write a short, compelling paragraph about: {{topic}}\n"
+            "We will refine it through "
+            + str(MAX_ITERATIONS)
+            + " rounds of writing and critique."
+        ),
+    )
     # -- Initialize iteration counter --
     .var("Init iteration", variable="iteration", expression="1", show_output=False)
-
     # -- Loop target --
-    .text("Iteration header", template=(
-        "\n──── Iteration {{iteration}} of " + str(MAX_ITERATIONS) + " ────"
-    ), traverse_in=TraverseIn.AWAIT_FIRST)
-
+    .text(
+        "Iteration header",
+        template=("\n──── Iteration {{iteration}} of " + str(MAX_ITERATIONS) + " ────"),
+        traverse_in=TraverseIn.AWAIT_FIRST,
+    )
     # -- Writer drafts/revises --
     .instruction(
-        "Writer drafts", **WRITER,
+        "Writer drafts",
+        **WRITER,
         system_instruction=(
             "You are a skilled writer. Write or revise a SHORT paragraph (3-5 sentences) "
             "about the given topic.\n\n"
@@ -59,10 +61,10 @@ agent = (
             "Output ONLY the paragraph, no meta-commentary."
         ),
     )
-
     # -- Critic reviews --
     .instruction(
-        "Critic reviews", **CRITIC,
+        "Critic reviews",
+        **CRITIC,
         system_instruction=(
             "You are a sharp editorial critic. Review the paragraph you just read.\n\n"
             "Give exactly 3 specific, actionable suggestions for improvement. "
@@ -73,45 +75,52 @@ agent = (
             "Format: numbered list, one line each. No fluff."
         ),
     )
-
     # -- Increment and check --
-    .var("Increment", variable="iteration", expression="iteration + 1", show_output=False)
-    .if_node("More iterations?", expression=f"iteration > {MAX_ITERATIONS}", show_output=False)
-
+    .var(
+        "Increment", variable="iteration", expression="iteration + 1", show_output=False
+    )
+    .if_node(
+        "More iterations?",
+        expression=f"iteration > {MAX_ITERATIONS}",
+        show_output=False,
+    )
     # TRUE: done refining
     .on("true")
-        .text("Refinement complete", template=(
+    .text(
+        "Refinement complete",
+        template=(
             "\n──── Refinement Complete ────\n"
-            "The paragraph has been refined through {0} rounds of writing and critique." + str(MAX_ITERATIONS)
-        ))
-        .instruction(
-            "Final polish", **WRITER,
-            system_instruction=(
-                "You are the writer making a FINAL polish. "
-                "Take the latest draft and apply the last critic's feedback. "
-                "Output ONLY the final, polished paragraph. Make every word count."
-            ),
-        )
+            "The paragraph has been refined through {0} rounds of writing and critique."
+            + str(MAX_ITERATIONS)
+        ),
+    )
+    .instruction(
+        "Final polish",
+        **WRITER,
+        system_instruction=(
+            "You are the writer making a FINAL polish. "
+            "Take the latest draft and apply the last critic's feedback. "
+            "Output ONLY the final, polished paragraph. Make every word count."
+        ),
+    )
     .end()
-
     # FALSE: loop back
     .on("false")
-        .text("Next iteration", template="", show_output=False)
-    .end()
-
+    .text("Next iteration", template="", show_output=False)
     .end()
 )
 
 # -- Wire the loop back-edge --
 agent.connect("Next iteration", "Iteration header", label="next_iteration")
 
-# -- Build and run --
+# -- Build and run -- .build(validate=False) kept here because we deliberately
+# form a cycle (loop-back edge) which the default validator rejects.
 graph = agent.build(validate=False)
 
 print(f"Graph: {len(graph.nodes)} nodes, {len(graph.edges)} edges")
 print()
 
-run_graph(
+qm.run_graph(
     graph,
     user_input="The feeling of writing code at 3am when everything finally clicks",
 )

--- a/examples/09_parallel_agents.py
+++ b/examples/09_parallel_agents.py
@@ -32,6 +32,7 @@ for topic in topics:
 
     def make_task(t: str):
         """Create a closure over the topic string."""
+
         def task(s):
             # Simulate research work with a small delay
             time.sleep(0.1)
@@ -39,6 +40,7 @@ for topic in topics:
                 AgentMessage(role="assistant", content=f"Researching: {t}")
             )
             return {"topic": t, "findings": f"Key findings about {t}"}
+
         return task
 
     manager.start_session(session.id, make_task(topic))

--- a/examples/10_enterprise_agent.py
+++ b/examples/10_enterprise_agent.py
@@ -17,8 +17,7 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # ---------------------------------------------------------------------------
 # Sub-graph: HR department
@@ -26,20 +25,26 @@ from quartermaster_engine import run_graph
 # Analyses HR queries and conditionally escalates for manager approval.
 
 hr_flow = (
-    Graph("HR Handler")
-    .start()
-    .instruction("HR analysis", model="claude-haiku-4-5-20251001", system_instruction="Analyse HR-related query and determine policy")
+    qm.Graph("HR Handler")
+    .instruction(
+        "HR analysis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Analyse HR-related query and determine policy",
+    )
     .if_node("Needs approval?", expression="requires_manager_approval")
     .on("true")
-        .static("Alert manager", text="HR request requires manager approval")
-        .user("Awaiting manager response")
+    .static("Alert manager", text="HR request requires manager approval")
+    .user("Awaiting manager response")
     .end()
     .on("false")
-        .instruction("Direct HR response", model="claude-haiku-4-5-20251001", system_instruction="Provide HR information from policy database")
+    .instruction(
+        "Direct HR response",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide HR information from policy database",
+    )
     .end()
     # No merge — IF picks one branch, they converge here.
     .write_memory("Log HR query", memory_name="hr_query_log")
-    .end()
 )
 
 # ---------------------------------------------------------------------------
@@ -49,22 +54,34 @@ hr_flow = (
 # before suggesting a fix.
 
 it_flow = (
-    Graph("IT Handler")
-    .start()
-    .instruction("IT diagnosis", model="claude-haiku-4-5-20251001", system_instruction="Diagnose the reported IT issue")
-
+    qm.Graph("IT Handler")
+    .instruction(
+        "IT diagnosis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Diagnose the reported IT issue",
+    )
     # Parallel: run security and performance checks concurrently
     .parallel()
     .branch()
-        .instruction("Security check", model="claude-haiku-4-5-20251001", system_instruction="Check for security implications")
+    .instruction(
+        "Security check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Check for security implications",
+    )
     .end()
     .branch()
-        .instruction("Performance check", model="claude-haiku-4-5-20251001", system_instruction="Assess performance impact")
+    .instruction(
+        "Performance check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Assess performance impact",
+    )
     .end()
     .static_merge("Combine IT checks")
-
-    .instruction("Suggest fix", model="claude-haiku-4-5-20251001", system_instruction="Provide troubleshooting steps based on diagnosis and checks")
-    .end()
+    .instruction(
+        "Suggest fix",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide troubleshooting steps based on diagnosis and checks",
+    )
 )
 
 # ---------------------------------------------------------------------------
@@ -73,20 +90,30 @@ it_flow = (
 # Handles finance queries with an IF for large amounts requiring CFO sign-off.
 
 finance_flow = (
-    Graph("Finance Handler")
-    .start()
-    .instruction("Finance analysis", model="claude-haiku-4-5-20251001", system_instruction="Analyse the finance-related request")
+    qm.Graph("Finance Handler")
+    .instruction(
+        "Finance analysis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Analyse the finance-related request",
+    )
     .if_node("Large amount?", expression="amount > 10000")
     .on("true")
-        .static("CFO alert", text="Finance request over $10k requires CFO approval")
-        .instruction("Prepare CFO brief", model="claude-haiku-4-5-20251001", system_instruction="Summarise request for CFO review")
+    .static("CFO alert", text="Finance request over $10k requires CFO approval")
+    .instruction(
+        "Prepare CFO brief",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Summarise request for CFO review",
+    )
     .end()
     .on("false")
-        .instruction("Process directly", model="claude-haiku-4-5-20251001", system_instruction="Handle finance request within standard limits")
+    .instruction(
+        "Process directly",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Handle finance request within standard limits",
+    )
     .end()
     # No merge — IF picks one branch.
     .write_memory("Log finance query", memory_name="last_finance_query")
-    .end()
 )
 
 # ---------------------------------------------------------------------------
@@ -94,46 +121,81 @@ finance_flow = (
 # ---------------------------------------------------------------------------
 
 agent = (
-    Graph("Enterprise Assistant")
-    .start()
+    qm.Graph("Enterprise Assistant")
     .user("How can I help you today?")
-    .write_memory("Log session start", memory_name="session_start", variables=[{"name": "timestamp", "value": "{{timestamp}}"}])
-    .instruction("Classify request", model="claude-haiku-4-5-20251001", system_instruction="Classify the request into: hr, it, finance, or general")
-
+    .write_memory(
+        "Log session start",
+        memory_name="session_start",
+        variables=[{"name": "timestamp", "value": "{{timestamp}}"}],
+    )
+    .instruction(
+        "Classify request",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Classify the request into: hr, it, finance, or general",
+    )
     # --- Department routing ---------------------------------------------------
     .decision("Department?", options=["hr", "it", "finance", "general"])
     .on("hr")
-        .use(hr_flow)
+    .use(hr_flow)
     .end()
     .on("it")
-        .use(it_flow)
+    .use(it_flow)
     .end()
     .on("finance")
-        .use(finance_flow)
+    .use(finance_flow)
     .end()
     .on("general")
-        .instruction("General help", model="claude-haiku-4-5-20251001", system_instruction="Provide general assistance")
+    .instruction(
+        "General help",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Provide general assistance",
+    )
     .end()
     # No merge after decision — only one department branch runs.
-
     # --- Quality gate ---------------------------------------------------------
-    .instruction("Quality check", model="claude-haiku-4-5-20251001", system_instruction="Review the response for accuracy and completeness (0-1 score)")
+    .instruction(
+        "Quality check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Review the response for accuracy and completeness (0-1 score)",
+    )
     .if_node("Quality OK?", expression="quality_score > 0.8")
     .on("true")
-        .instruction("Deliver", model="claude-haiku-4-5-20251001", system_instruction="Format and deliver the final response")
+    .instruction(
+        "Deliver",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Format and deliver the final response",
+    )
     .end()
     .on("false")
-        .instruction("Improve", model="claude-haiku-4-5-20251001", system_instruction="Rewrite the response to improve clarity and accuracy")
-        .instruction("Re-deliver", model="claude-haiku-4-5-20251001", system_instruction="Format and deliver the improved response")
+    .instruction(
+        "Improve",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Rewrite the response to improve clarity and accuracy",
+    )
+    .instruction(
+        "Re-deliver",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Format and deliver the improved response",
+    )
     .end()
     # No merge after IF — only one branch runs.
-
     # --- Audit trail ----------------------------------------------------------
-    .write_memory("Audit log", memory_name="audit_log", variables=[{"name": "audit", "value": "completed | dept:{{department}} | quality:{{quality_score}}"}])
+    .write_memory(
+        "Audit log",
+        memory_name="audit_log",
+        variables=[
+            {
+                "name": "audit",
+                "value": "completed | dept:{{department}} | quality:{{quality_score}}",
+            }
+        ],
+    )
     .static("Completion notice", text="Request handled successfully")
     .static("Audit", text="Enterprise request completed")
-    .end()
 )
 
 # Execute with a real LLM
-run_graph(agent, user_input="My laptop won't connect to the VPN and I need access to the finance portal urgently")
+qm.run_graph(
+    agent,
+    user_input="My laptop won't connect to the VPN and I need access to the finance portal urgently",
+)

--- a/examples/11_nested_control_flow.py
+++ b/examples/11_nested_control_flow.py
@@ -14,48 +14,58 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 agent = (
-    Graph("Whiteboard Agent")
-    .start()
+    qm.Graph("Whiteboard Agent")
     .user("Describe your task")
-    .instruction("Analyse input", model="claude-haiku-4-5-20251001", system_instruction="Break the task into components for parallel processing")
-
+    .instruction(
+        "Analyse input",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Break the task into components for parallel processing",
+    )
     # --- Parallel fan-out: 3 branches with nested control flow ----------------
     .parallel("Fan out")
-
     # Branch A: deep analysis pipeline
     .branch()
-        .text("Prepare context", template="Task context: {{user_input}}")
-        .instruction("Deep analysis", model="claude-haiku-4-5-20251001", system_instruction="Perform thorough analysis of the task")
+    .text("Prepare context", template="Task context: {{user_input}}")
+    .instruction(
+        "Deep analysis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Perform thorough analysis of the task",
+    )
     .end()
-
     # Branch B: independent lightweight check (pass-through)
     .branch()
-        .instruction("Quick check", model="claude-haiku-4-5-20251001", system_instruction="Perform a fast independent assessment")
+    .instruction(
+        "Quick check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Perform a fast independent assessment",
+    )
     .end()
-
     # Branch C: conditional quality gate (IF picks one path — no merge needed)
     .branch()
-        .if_node("Confidence high?", expression="confidence > 0.7")
-        .on("true")
-            .text("Accept result", template="Result meets confidence threshold -- approved")
-        .end()
-        .on("false")
-            .text("Flag for review", template="Low confidence -- manual review recommended")
-        .end()
-        # IF branches converge on this static node, which becomes the branch endpoint
-        .static("Quality gate result", text="Quality gate complete")
+    .if_node("Confidence high?", expression="confidence > 0.7")
+    .on("true")
+    .text("Accept result", template="Result meets confidence threshold -- approved")
     .end()
-
+    .on("false")
+    .text("Flag for review", template="Low confidence -- manual review recommended")
+    .end()
+    # IF branches converge on this static node, which becomes the branch endpoint
+    .static("Quality gate result", text="Quality gate complete")
+    .end()
     .static_merge("Combine all branches")
-
     # --- Final synthesis -------------------------------------------------------
-    .summarize("Final synthesis", model="claude-haiku-4-5-20251001", system_instruction="Combine all branch results into a coherent response")
-    .end()
+    .summarize(
+        "Final synthesis",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Combine all branch results into a coherent response",
+    )
 )
 
 # Execute with a real LLM
-run_graph(agent, user_input="Design a Python microservice that handles user authentication with JWT tokens and rate limiting")
+qm.run_graph(
+    agent,
+    user_input="Design a Python microservice that handles user authentication with JWT tokens and rate limiting",
+)

--- a/examples/12_full_showcase.py
+++ b/examples/12_full_showcase.py
@@ -25,20 +25,29 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # ---------------------------------------------------------------------------
 # Sub-graph: Web research pipeline
 # ---------------------------------------------------------------------------
 
 web_research = (
-    Graph("Web Research")
-    .start()
-    .instruction("Web search", model="claude-haiku-4-5-20251001", system_instruction="Search the web for recent information on the topic")
-    .instruction("Extract key facts", model="claude-haiku-4-5-20251001", system_instruction="Extract and list the key facts from search results")
-    .instruction("Assess source quality", model="claude-haiku-4-5-20251001", system_instruction="Rate the reliability of each source (1-5)")
-    .end()
+    qm.Graph("Web Research")
+    .instruction(
+        "Web search",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Search the web for recent information on the topic",
+    )
+    .instruction(
+        "Extract key facts",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Extract and list the key facts from search results",
+    )
+    .instruction(
+        "Assess source quality",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Rate the reliability of each source (1-5)",
+    )
 )
 
 # ---------------------------------------------------------------------------
@@ -46,12 +55,22 @@ web_research = (
 # ---------------------------------------------------------------------------
 
 academic_research = (
-    Graph("Academic Research")
-    .start()
-    .instruction("Search papers", model="claude-haiku-4-5-20251001", system_instruction="Search academic databases for peer-reviewed papers")
-    .instruction("Summarise papers", model="claude-haiku-4-5-20251001", system_instruction="Create structured summaries of the top papers")
-    .instruction("Identify consensus", model="claude-haiku-4-5-20251001", system_instruction="Identify areas of scientific consensus and debate")
-    .end()
+    qm.Graph("Academic Research")
+    .instruction(
+        "Search papers",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Search academic databases for peer-reviewed papers",
+    )
+    .instruction(
+        "Summarise papers",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create structured summaries of the top papers",
+    )
+    .instruction(
+        "Identify consensus",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Identify areas of scientific consensus and debate",
+    )
 )
 
 # ---------------------------------------------------------------------------
@@ -59,84 +78,111 @@ academic_research = (
 # ---------------------------------------------------------------------------
 
 agent = (
-    Graph("AI Research Assistant")
-    .start()
-
+    qm.Graph("AI Research Assistant")
     # --- Input and topic capture ----------------------------------------------
     .user("What do you want to research?")
     .var("Capture topic", variable="research_topic")
     .write_memory("Store topic", memory_name="research_topic")
     .text("Acknowledge", template="Researching: {{research_topic}}")
-
     # --- Strategy selection ----------------------------------------------------
-    .instruction("Classify research", model="claude-haiku-4-5-20251001", system_instruction="Classify the research type: academic, general, or technical")
-
+    .instruction(
+        "Classify research",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Classify the research type: academic, general, or technical",
+    )
     .decision("Research strategy?", options=["academic", "general", "technical"])
-
     .on("academic")
-        .use(academic_research)
+    .use(academic_research)
     .end()
-
     .on("general")
-        .use(web_research)
+    .use(web_research)
     .end()
-
     .on("technical")
-        .instruction("Technical deep-dive", model="claude-haiku-4-5-20251001", system_instruction="Perform in-depth technical analysis with code examples")
-        .instruction("Benchmark review", model="claude-haiku-4-5-20251001", system_instruction="Review benchmarks and performance comparisons")
+    .instruction(
+        "Technical deep-dive",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Perform in-depth technical analysis with code examples",
+    )
+    .instruction(
+        "Benchmark review",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Review benchmarks and performance comparisons",
+    )
     .end()
-
     # No merge — decision picks ONE research strategy.
-
     # --- Quality review: parallel checks with nested IF -----------------------
     .read_memory("Recall topic", memory_name="research_topic")
-
     .parallel("Quality review")
-
     # Branch 1: Fact-checking with pass/fail gate
     .branch()
-        .instruction("Fact-check", model="claude-haiku-4-5-20251001", system_instruction="Verify all factual claims against sources")
-        .if_node("Facts verified?", expression="verification_score > 0.9")
-        .on("true")
-            .text("Facts OK", template="All facts verified successfully")
-        .end()
-        .on("false")
-            .instruction("Fix errors", model="claude-haiku-4-5-20251001", system_instruction="Correct any unverified or inaccurate claims")
-        .end()
-        # IF branches converge on a result node
-        .static("Fact-check done", text="Fact-check complete")
+    .instruction(
+        "Fact-check",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Verify all factual claims against sources",
+    )
+    .if_node("Facts verified?", expression="verification_score > 0.9")
+    .on("true")
+    .text("Facts OK", template="All facts verified successfully")
     .end()
-
+    .on("false")
+    .instruction(
+        "Fix errors",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Correct any unverified or inaccurate claims",
+    )
+    .end()
+    # IF branches converge on a result node
+    .static("Fact-check done", text="Fact-check complete")
+    .end()
     # Branch 2: Bias assessment (no conditional, straight-through)
     .branch()
-        .instruction("Bias assessment", model="claude-haiku-4-5-20251001", system_instruction="Check for confirmation bias, source bias, and framing issues")
+    .instruction(
+        "Bias assessment",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Check for confirmation bias, source bias, and framing issues",
+    )
     .end()
-
     # Branch 3: Completeness check with gap detection
     .branch()
-        .if_node("Coverage gaps?", expression="has_coverage_gaps")
-        .on("true")
-            .instruction("Fill gaps", model="claude-haiku-4-5-20251001", system_instruction="Research and fill identified coverage gaps")
-        .end()
-        .on("false")
-            .text("Coverage complete", template="Research covers all key aspects of {{research_topic}}")
-        .end()
-        # IF branches converge on a result node
-        .static("Coverage done", text="Coverage check complete")
+    .if_node("Coverage gaps?", expression="has_coverage_gaps")
+    .on("true")
+    .instruction(
+        "Fill gaps",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Research and fill identified coverage gaps",
+    )
     .end()
-
+    .on("false")
+    .text(
+        "Coverage complete",
+        template="Research covers all key aspects of {{research_topic}}",
+    )
+    .end()
+    # IF branches converge on a result node
+    .static("Coverage done", text="Coverage check complete")
+    .end()
     .static_merge("Quality review complete")
-
     # --- Synthesis and delivery -----------------------------------------------
-    .instruction("Synthesise findings", model="claude-haiku-4-5-20251001", provider="anthropic", system_instruction="Synthesise all research findings into a coherent analysis")
-    .summarize("Executive summary", model="claude-haiku-4-5-20251001", system_instruction="Create a concise executive summary with key takeaways")
-
+    .instruction(
+        "Synthesise findings",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction="Synthesise all research findings into a coherent analysis",
+    )
+    .summarize(
+        "Executive summary",
+        model="claude-haiku-4-5-20251001",
+        system_instruction="Create a concise executive summary with key takeaways",
+    )
     # --- Audit trail ----------------------------------------------------------
     .update_memory("Update status", memory_name="research_status")
-    .static("Report ready", text="Research report on {{research_topic}} is ready for review")
+    .static(
+        "Report ready", text="Research report on {{research_topic}} is ready for review"
+    )
     .static("Completed", text="Research pipeline completed for: {{research_topic}}")
-    .end()
 )
 
 # Execute with a real LLM
-run_graph(agent, user_input="What are the latest advances in quantum error correction?")
+qm.run_graph(
+    agent, user_input="What are the latest advances in quantum error correction?"
+)

--- a/examples/13_orchestrator.py
+++ b/examples/13_orchestrator.py
@@ -20,14 +20,12 @@ Usage:
     uv run examples/13_orchestrator.py
 """
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 # -- Build the graph ----------------------------------------------------------
 graph = (
-    Graph("ParallelOrchestrator")
+    qm.Graph("ParallelOrchestrator")
     .allowed_agents("researcher", "writer", "reviewer")
-    .start()
     # 1. Collect the user's request
     .user("Describe the project you'd like researched, written, and reviewed.")
     # 2. Orchestrator -- an Agent node with session-management tools
@@ -62,8 +60,10 @@ graph = (
             "reviewer's feedback."
         ),
     )
-    .end()
 )
 
 # Execute with a real LLM
-run_graph(graph, user_input="Write a technical blog post about WebAssembly's role in server-side computing")
+qm.run_graph(
+    graph,
+    user_input="Write a technical blog post about WebAssembly's role in server-side computing",
+)

--- a/examples/14_user_forms.py
+++ b/examples/14_user_forms.py
@@ -20,8 +20,7 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 
 # ---------------------------------------------------------------------------
@@ -29,33 +28,59 @@ from quartermaster_engine import run_graph
 # ---------------------------------------------------------------------------
 
 agent = (
-    Graph("Event Registration")
-    .start()
-
+    qm.Graph("Event Registration")
     # --- Step 1: Greet the user -------------------------------------------------
     .text("Welcome", template="Welcome! Ready to register for TechConf 2026?")
-
     # --- Step 2: Structured form for registration data ------------------------
-    .user_form("Registration form", parameters=[
-        {"name": "full_name",    "type": "text",   "label": "Full name",     "required": "true"},
-        {"name": "email",        "type": "email",  "label": "Email address", "required": "true"},
-        {"name": "company",      "type": "text",   "label": "Company",       "required": "false"},
-        {"name": "ticket_type",  "type": "select", "label": "Ticket type",   "options": "standard,vip"},
-        {"name": "quantity",     "type": "number", "label": "Number of tickets", "default": "1"},
-    ])
-
+    .user_form(
+        "Registration form",
+        parameters=[
+            {
+                "name": "full_name",
+                "type": "text",
+                "label": "Full name",
+                "required": "true",
+            },
+            {
+                "name": "email",
+                "type": "email",
+                "label": "Email address",
+                "required": "true",
+            },
+            {
+                "name": "company",
+                "type": "text",
+                "label": "Company",
+                "required": "false",
+            },
+            {
+                "name": "ticket_type",
+                "type": "select",
+                "label": "Ticket type",
+                "options": "standard,vip",
+            },
+            {
+                "name": "quantity",
+                "type": "number",
+                "label": "Number of tickets",
+                "default": "1",
+            },
+        ],
+    )
     # --- Step 3: Compute derived value from form data -------------------------
     # ticket_type, quantity, full_name, email, company are already available
     # from the form -- no need to re-capture them with var().
-    .var("Calculate price",
-         variable="total_price",
-         expression="int(quantity) * 500 if ticket_type == 'vip' else int(quantity) * 150")
-
+    .var(
+        "Calculate price",
+        variable="total_price",
+        expression="int(quantity) * 500 if ticket_type == 'vip' else int(quantity) * 150",
+    )
     # --- Step 4: Conditional branch based on ticket type ----------------------
     .if_node("VIP ticket?", expression="ticket_type == 'vip'")
-
     .on("true")
-        .text("VIP perks", template=(
+    .text(
+        "VIP perks",
+        template=(
             "VIP Registration for {{full_name}}\n"
             "-------------------------------\n"
             "Your VIP package includes:\n"
@@ -63,42 +88,50 @@ agent = (
             "  - Speaker meet-and-greet\n"
             "  - Exclusive networking dinner\n"
             "  - Priority Q&A access"
-        ))
+        ),
+    )
     .end()
-
     .on("false")
-        .text("Standard info", template=(
+    .text(
+        "Standard info",
+        template=(
             "Standard Registration for {{full_name}}\n"
             "-----------------------------------\n"
             "Your standard package includes:\n"
             "  - General admission seating\n"
             "  - Access to all talks\n"
             "  - Conference materials"
-        ))
+        ),
+    )
     .end()
-
     # IF picks one branch -- no merge needed. Branches converge here.
-
     # --- Step 5: Confirmation summary using Jinja2 template -------------------
-    .text("Confirmation", template=(
-        "=== Registration Confirmed ===\n"
-        "\n"
-        "Name:      {{full_name}}\n"
-        "Email:     {{email}}\n"
-        "Company:   {{company}}\n"
-        "Ticket:    {{ticket_type}} x{{quantity}}\n"
-        "Total:     ${{total_price}}\n"
-        "\n"
-        "A confirmation email will be sent to {{email}}."
-    ))
-
+    .text(
+        "Confirmation",
+        template=(
+            "=== Registration Confirmed ===\n"
+            "\n"
+            "Name:      {{full_name}}\n"
+            "Email:     {{email}}\n"
+            "Company:   {{company}}\n"
+            "Ticket:    {{ticket_type}} x{{quantity}}\n"
+            "Total:     ${{total_price}}\n"
+            "\n"
+            "A confirmation email will be sent to {{email}}."
+        ),
+    )
     # --- Step 6: Persist to memory --------------------------------------------
-    .write_memory("Save registration", memory_name="registrations", variables=[
-        {"name": "registration", "value": "{{full_name}}|{{email}}|{{ticket_type}}|{{quantity}}|{{total_price}}"},
-    ])
-
+    .write_memory(
+        "Save registration",
+        memory_name="registrations",
+        variables=[
+            {
+                "name": "registration",
+                "value": "{{full_name}}|{{email}}|{{ticket_type}}|{{quantity}}|{{total_price}}",
+            },
+        ],
+    )
     .text("Thank you", template="Thank you {{full_name}}! See you at TechConf 2026.")
-    .end()
 )
 
 
@@ -107,54 +140,74 @@ agent = (
 # ---------------------------------------------------------------------------
 
 feedback = (
-    Graph("Feedback Collector")
-    .start()
-
+    qm.Graph("Feedback Collector")
     .text("Greeting", template="We'd love your feedback!")
-
-    .user_form("Feedback form", parameters=[
-        {"name": "rating",   "type": "number", "label": "Rating (1-5)",     "required": "true"},
-        {"name": "comments", "type": "text",   "label": "Comments",         "required": "false"},
-        {"name": "contact",  "type": "email",  "label": "Follow-up email",  "required": "false"},
-    ])
-
+    .user_form(
+        "Feedback form",
+        parameters=[
+            {
+                "name": "rating",
+                "type": "number",
+                "label": "Rating (1-5)",
+                "required": "true",
+            },
+            {
+                "name": "comments",
+                "type": "text",
+                "label": "Comments",
+                "required": "false",
+            },
+            {
+                "name": "contact",
+                "type": "email",
+                "label": "Follow-up email",
+                "required": "false",
+            },
+        ],
+    )
     # rating is already available from the form -- only compute derived values
     .var("Parse rating", variable="rating_num", expression="int(rating)")
-
     # Branch on rating
     .if_node("Good rating?", expression="rating_num >= 4")
-
     .on("true")
-        .text("Positive thanks", template=(
+    .text(
+        "Positive thanks",
+        template=(
             "Thank you for the great rating ({{rating}}/5)!\n"
             "We're glad you enjoyed the experience."
-        ))
+        ),
+    )
     .end()
-
     .on("false")
-        .text("Improvement note", template=(
+    .text(
+        "Improvement note",
+        template=(
             "We're sorry the experience wasn't perfect ({{rating}}/5).\n"
             "Your feedback: {{comments}}\n"
             "We'll work on improving."
-        ))
-        .instruction("Suggest improvements",
-                     model="claude-haiku-4-5-20251001",
-                     system_instruction=(
-                         "The user rated us {{rating}}/5 and said: '{{comments}}'. "
-                         "Suggest 2-3 specific improvements we could make."
-                     ))
+        ),
+    )
+    .instruction(
+        "Suggest improvements",
+        model="claude-haiku-4-5-20251001",
+        system_instruction=(
+            "The user rated us {{rating}}/5 and said: '{{comments}}'. "
+            "Suggest 2-3 specific improvements we could make."
+        ),
+    )
     .end()
-
     # IF picks one branch -- no merge needed.
-
-    .write_memory("Store feedback", memory_name="feedback_log", variables=[
-        {"name": "entry", "value": "rating:{{rating}}|comments:{{comments}}"},
-    ])
-    .end()
+    .write_memory(
+        "Store feedback",
+        memory_name="feedback_log",
+        variables=[
+            {"name": "entry", "value": "rating:{{rating}}|comments:{{comments}}"},
+        ],
+    )
 )
 
 
 # Execute both graphs
-run_graph(agent, user_input="Register me for the conference")
+qm.run_graph(agent, user_input="Register me for the conference")
 print("\n" + "=" * 60 + "\n")
-run_graph(feedback, user_input="I want to leave feedback")
+qm.run_graph(feedback, user_input="I want to leave feedback")

--- a/examples/15_courtroom_debate.py
+++ b/examples/15_courtroom_debate.py
@@ -21,16 +21,15 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_graph.enums import TraverseIn
-from quartermaster_engine import run_graph
 
 
 # -- Provider config --------------------------------------------------------
 
 PROSECUTOR = dict(model="grok-3-mini-fast", provider="xai")
-DEFENSE    = dict(model="gpt-4o", provider="openai")
-JUDGE      = dict(model="claude-haiku-4-5-20251001", provider="anthropic")
+DEFENSE = dict(model="gpt-4o", provider="openai")
+JUDGE = dict(model="claude-haiku-4-5-20251001", provider="anthropic")
 
 MAX_ROUNDS = 5
 
@@ -38,49 +37,53 @@ MAX_ROUNDS = 5
 # -- Main trial graph -------------------------------------------------------
 
 trial = (
-    Graph("The People v. Dr. Sarah Chen")
-    .start()
+    qm.Graph("The People v. Dr. Sarah Chen")
     .user("Describe the case")
     .var("Capture case", variable="case_description", show_output=False)
     .write_memory("File case", memory_name="case_file", show_output=False)
-
-    .text("Court opens", template=(
-        "═══════════════════════════════════════════\n"
-        "  SUPERIOR COURT — DEPARTMENT 7\n"
-        "  TechCorp Inc. v. Dr. Sarah Chen\n"
-        "  Charges: Trade secret theft, NDA breach\n"
-        "═══════════════════════════════════════════\n\n"
-        "BAILIFF: All rise. Court is now in session.\n"
-        f"JUDGE: We will hear {MAX_ROUNDS} rounds of argument.\n"
-    ))
-
+    .text(
+        "Court opens",
+        template=(
+            "═══════════════════════════════════════════\n"
+            "  SUPERIOR COURT — DEPARTMENT 7\n"
+            "  TechCorp Inc. v. Dr. Sarah Chen\n"
+            "  Charges: Trade secret theft, NDA breach\n"
+            "═══════════════════════════════════════════\n\n"
+            "BAILIFF: All rise. Court is now in session.\n"
+            f"JUDGE: We will hear {MAX_ROUNDS} rounds of argument.\n"
+        ),
+    )
     # -- Initialize loop counter --
     .var("Init round", variable="round_number", expression="1", show_output=False)
-
     # -- Loop target --
-    .text("Round announce", template=(
-        "\n──── Round {{round_number}} of 5 ────"
-    ), traverse_in=TraverseIn.AWAIT_FIRST)
-
+    .text(
+        "Round announce",
+        template=("\n──── Round {{round_number}} of 5 ────"),
+        traverse_in=TraverseIn.AWAIT_FIRST,
+    )
     # -- Round context injected as a text node so LLMs see it --
-    .text("Round context", template=(
-        "COURT CLERK: This is round {{round_number}} of 5.\n"
-        "{% if round_number == 1 %}"
-        "Phase: OPENING STATEMENTS. Present your theory of the case."
-        "{% elif round_number == 2 %}"
-        "Phase: EVIDENCE. Present forensic evidence, call expert witnesses, cite specific data."
-        "{% elif round_number == 3 %}"
-        "Phase: CROSS-EXAMINATION. Challenge the opposing side's evidence and witnesses directly."
-        "{% elif round_number == 4 %}"
-        "Phase: REBUTTAL. Address weaknesses in your case, introduce new counter-evidence."
-        "{% else %}"
-        "Phase: CLOSING ARGUMENTS. This is your final chance. Make it count."
-        "{% endif %}"
-    ), show_output=False)
-
+    .text(
+        "Round context",
+        template=(
+            "COURT CLERK: This is round {{round_number}} of 5.\n"
+            "{% if round_number == 1 %}"
+            "Phase: OPENING STATEMENTS. Present your theory of the case."
+            "{% elif round_number == 2 %}"
+            "Phase: EVIDENCE. Present forensic evidence, call expert witnesses, cite specific data."
+            "{% elif round_number == 3 %}"
+            "Phase: CROSS-EXAMINATION. Challenge the opposing side's evidence and witnesses directly."
+            "{% elif round_number == 4 %}"
+            "Phase: REBUTTAL. Address weaknesses in your case, introduce new counter-evidence."
+            "{% else %}"
+            "Phase: CLOSING ARGUMENTS. This is your final chance. Make it count."
+            "{% endif %}"
+        ),
+        show_output=False,
+    )
     # -- Prosecution --
     .instruction(
-        "Prosecution argues", **PROSECUTOR,
+        "Prosecution argues",
+        **PROSECUTOR,
         system_instruction=(
             "You are the lead prosecutor in TechCorp v. Dr. Sarah Chen.\n"
             "The court clerk has announced the current phase. Follow it STRICTLY:\n\n"
@@ -97,10 +100,10 @@ trial = (
             "2-3 paragraphs. Address the judge as 'Your Honor'."
         ),
     )
-
     # -- Defense --
     .instruction(
-        "Defense rebuts", **DEFENSE,
+        "Defense rebuts",
+        **DEFENSE,
         system_instruction=(
             "You are the defense attorney for Dr. Sarah Chen.\n"
             "The court clerk has announced the current phase. Follow it STRICTLY:\n\n"
@@ -121,41 +124,47 @@ trial = (
             "2-3 paragraphs. Address the judge as 'Your Honor'."
         ),
     )
-
     # -- Increment and check --
-    .var("Increment", variable="round_number", expression="round_number + 1", show_output=False)
-    .if_node("More rounds?", expression=f"round_number > {MAX_ROUNDS}", show_output=False)
-
+    .var(
+        "Increment",
+        variable="round_number",
+        expression="round_number + 1",
+        show_output=False,
+    )
+    .if_node(
+        "More rounds?", expression=f"round_number > {MAX_ROUNDS}", show_output=False
+    )
     # TRUE: verdict
     .on("true")
-        .text("Debate over", template=(
+    .text(
+        "Debate over",
+        template=(
             "\n═══════════════════════════════════════════\n"
             "  ALL ARGUMENTS HEARD — DELIVERING VERDICT\n"
             "═══════════════════════════════════════════"
-        ))
-        .instruction(
-            "Judge delivers verdict", **JUDGE,
-            system_instruction=(
-                "You are the presiding judge delivering the FINAL VERDICT.\n"
-                "You heard 5 rounds: openings, evidence, cross-examination, rebuttal, closings.\n\n"
-                "Structure your verdict:\n"
-                "1. FINDINGS OF FACT — what was established\n"
-                "2. PROSECUTION'S CASE — strongest points and weaknesses\n"
-                "3. DEFENSE'S CASE — strongest points and weaknesses\n"
-                "4. EVIDENCE EVALUATION — the 78% code similarity, access logs, expert testimony\n"
-                "5. NON-COMPETE RULING — enforceable or not, with legal reasoning\n"
-                "6. VERDICT — GUILTY, NOT GUILTY, or MISTRIAL with clear rationale\n\n"
-                "Be thorough and judicial. This is a formal ruling."
-            ),
-        )
-        .text("Adjournment", template="\n--- Court is adjourned ---")
+        ),
+    )
+    .instruction(
+        "Judge delivers verdict",
+        **JUDGE,
+        system_instruction=(
+            "You are the presiding judge delivering the FINAL VERDICT.\n"
+            "You heard 5 rounds: openings, evidence, cross-examination, rebuttal, closings.\n\n"
+            "Structure your verdict:\n"
+            "1. FINDINGS OF FACT — what was established\n"
+            "2. PROSECUTION'S CASE — strongest points and weaknesses\n"
+            "3. DEFENSE'S CASE — strongest points and weaknesses\n"
+            "4. EVIDENCE EVALUATION — the 78% code similarity, access logs, expert testimony\n"
+            "5. NON-COMPETE RULING — enforceable or not, with legal reasoning\n"
+            "6. VERDICT — GUILTY, NOT GUILTY, or MISTRIAL with clear rationale\n\n"
+            "Be thorough and judicial. This is a formal ruling."
+        ),
+    )
+    .text("Adjournment", template="\n--- Court is adjourned ---")
     .end()
-
     # FALSE: loop back
     .on("false")
-        .text("Next round", template="", show_output=False)
-    .end()
-
+    .text("Next round", template="", show_output=False)
     .end()
 )
 
@@ -163,14 +172,15 @@ trial = (
 
 trial.connect("Next round", "Round announce", label="next_round")
 
-# -- Build and run ----------------------------------------------------------
+# -- Build and run -- .build(validate=False) kept here because we deliberately
+# form a cycle (loop-back edge) which the default validator rejects.
 
 agent = trial.build(validate=False)
 
 print(f"Graph: {len(agent.nodes)} nodes, {len(agent.edges)} edges")
 print()
 
-run_graph(
+qm.run_graph(
     agent,
     user_input=(
         "Dr. Sarah Chen, a senior AI engineer, left TechCorp after 5 years "

--- a/examples/16_tool_agent.py
+++ b/examples/16_tool_agent.py
@@ -18,9 +18,8 @@ from __future__ import annotations
 
 import json
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_tools import ToolRegistry
-from quartermaster_engine import run_graph
 
 # ---------------------------------------------------------------------------
 # 1. Define custom tools with @tool()
@@ -127,8 +126,7 @@ print(f"\nAnthropic format: {len(anthropic_tools)} tools exported")
 tool_descriptions = json.dumps(schemas, indent=2)
 
 agent = (
-    Graph("Tool Agent")
-    .start()
+    qm.Graph("Tool Agent")
     .user("Ask something that needs a tool")
     .instruction(
         "Reason about tools",
@@ -154,11 +152,12 @@ agent = (
             "the direct answer. Be concise -- one or two sentences."
         ),
     )
-    .end()
 )
 
 # ---------------------------------------------------------------------------
 # 5. Run the graph
 # ---------------------------------------------------------------------------
 
-run_graph(agent, user_input="What is the capital of Japan and what's the weather there?")
+qm.run_graph(
+    agent, user_input="What is the capital of Japan and what's the weather there?"
+)

--- a/examples/18_compliance_guard.py
+++ b/examples/18_compliance_guard.py
@@ -27,10 +27,12 @@ import tempfile
 from quartermaster_tools.builtin.privacy.detect import DetectPIITool, ScanFilePIITool
 from quartermaster_tools.builtin.privacy.redact import RedactPIITool
 from quartermaster_tools.builtin.compliance.risk_classifier import RiskClassifierTool
-from quartermaster_tools.builtin.compliance.audit_log import AuditLogTool, ReadAuditLogTool
+from quartermaster_tools.builtin.compliance.audit_log import (
+    AuditLogTool,
+    ReadAuditLogTool,
+)
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 
 # ============================================================================
@@ -126,7 +128,10 @@ AuditLogTool.run(
     action="pii_redaction",
     actor="compliance_pipeline",
     system_id="complaint-analyser-v1",
-    details={"strategy": "redact", "entities_redacted": redacted_result.data.get("entities_found", 0)},
+    details={
+        "strategy": "redact",
+        "entities_redacted": redacted_result.data.get("entities_found", 0),
+    },
     log_path=audit_path,
 )
 
@@ -167,19 +172,18 @@ print()
 # -- Build the graph ---------------------------------------------------------
 
 agent = (
-    Graph("Compliance-Aware Agent")
-    .start()
-
+    qm.Graph("Compliance-Aware Agent")
     # The user input is the REDACTED text (PII already removed)
     .user("Enter the complaint text")
     .var("Capture complaint", variable="complaint_text")
     .write_memory("Store complaint", memory_name="complaint")
-
-    .text("Status", template=(
-        "--- Compliance Pipeline ---\n"
-        "PII has been removed. Processing cleaned text..."
-    ))
-
+    .text(
+        "Status",
+        template=(
+            "--- Compliance Pipeline ---\n"
+            "PII has been removed. Processing cleaned text..."
+        ),
+    )
     # Analyse the complaint (safe -- no PII in the text)
     .instruction(
         "Analyse complaint",
@@ -198,47 +202,50 @@ agent = (
         ),
     )
     .var("Capture analysis", variable="analysis", show_output=False)
-
     # Route by priority
     .if_node("High priority?", expression="priority_level <= 2")
     .on("true")
-        .text("Escalation", template=(
+    .text(
+        "Escalation",
+        template=(
             "\n*** ESCALATION ***\n"
             "High-priority complaint detected. Flagging for immediate review."
-        ))
-        .instruction(
-            "Escalation brief",
-            model="claude-haiku-4-5-20251001",
-            provider="anthropic",
-            system_instruction=(
-                "Write a brief escalation summary for a manager. Include "
-                "the core issue, why it is urgent, and recommended immediate "
-                "actions. Keep it under 100 words."
-            ),
-        )
+        ),
+    )
+    .instruction(
+        "Escalation brief",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction=(
+            "Write a brief escalation summary for a manager. Include "
+            "the core issue, why it is urgent, and recommended immediate "
+            "actions. Keep it under 100 words."
+        ),
+    )
     .end()
     .on("false")
-        .instruction(
-            "Standard response",
-            model="claude-haiku-4-5-20251001",
-            provider="anthropic",
-            system_instruction=(
-                "Draft a professional customer response acknowledging the "
-                "complaint and outlining the resolution timeline. Do NOT "
-                "include any personal data."
-            ),
-        )
+    .instruction(
+        "Standard response",
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_instruction=(
+            "Draft a professional customer response acknowledging the "
+            "complaint and outlining the resolution timeline. Do NOT "
+            "include any personal data."
+        ),
+    )
     .end()
-
     # Final summary
     .write_memory("Store resolution", memory_name="resolution")
-    .text("Complete", template=(
-        "\n--- Pipeline Complete ---\n"
-        "Complaint processed. Resolution stored in memory."
-    ))
-    .end()
+    .text(
+        "Complete",
+        template=(
+            "\n--- Pipeline Complete ---\n"
+            "Complaint processed. Resolution stored in memory."
+        ),
+    )
 )
 
 # -- Execute with the cleaned text as input ----------------------------------
 
-run_graph(agent, user_input=clean_text)
+qm.run_graph(agent, user_input=clean_text)

--- a/examples/19_mcp_client.py
+++ b/examples/19_mcp_client.py
@@ -146,6 +146,7 @@ async def demo_mcp_client() -> list[McpTool]:
 # and docstrings -- but for MCP tools the schema already exists, so we
 # build the wrapper programmatically.
 
+
 def mcp_to_quartermaster_tools(
     mcp_tools: list[McpTool],
     server_url: str = MCP_SERVER_URL,
@@ -264,7 +265,13 @@ def mcp_to_quartermaster_tools(
             wrapper.__name__ = t.name
             wrapper.__doc__ = t.description
             wrapper.__annotations__ = {
-                p.name: str if p.type == "string" else int if p.type == "integer" else float if p.type == "number" else object
+                p.name: str
+                if p.type == "string"
+                else int
+                if p.type == "integer"
+                else float
+                if p.type == "number"
+                else object
                 for p in t.parameters
             }
             wrapper.__annotations__["return"] = dict
@@ -295,6 +302,7 @@ def mcp_to_quartermaster_tools(
 # passed to an Agent or Instruction node via the ``tools=`` parameter.
 # Below we build the graph structure to show how it all fits together.
 
+
 def demo_graph_with_mcp_tools() -> None:
     """Build a graph that incorporates MCP-provided tools."""
     print("=" * 60)
@@ -303,17 +311,16 @@ def demo_graph_with_mcp_tools() -> None:
     print()
 
     try:
-        from quartermaster_graph import Graph
+        import quartermaster_sdk as qm
     except ImportError:
-        print("quartermaster-graph is not installed; skipping graph demo.")
+        print("quartermaster-sdk is not installed; skipping graph demo.")
         return
 
     # Imagine the MCP server exposes "weather_lookup" and "web_search".
     # After wrapping them (Part 2) they live in a ToolRegistry.
     # An Agent node references them by name via ``tools=[...]``.
     graph = (
-        Graph("MCP Research Agent")
-        .start()
+        qm.Graph("MCP Research Agent")
         .user("What would you like to research?")
         .agent(
             "Researcher",
@@ -338,10 +345,11 @@ def demo_graph_with_mcp_tools() -> None:
                 "concise answer for the user."
             ),
         )
-        .end()
     )
 
-    # Print the graph structure
+    # Print the graph structure — we call .build() here just to inspect the
+    # validated spec; ``qm.run_graph(graph, ...)`` would accept the builder
+    # directly in the v0.2.0 API.
     built = graph.build()
     print("Graph structure:")
     for node in built.nodes:
@@ -355,21 +363,22 @@ def demo_graph_with_mcp_tools() -> None:
         print(f"  {src} -> {tgt}{label}")
     print()
 
-    # To actually run this graph you would use the _runner helper:
+    # To actually run this graph:
     #
-    #   from quartermaster_engine import run_graph
-    #   run_graph(graph, user_input="What is the weather in Tokyo?")
+    #   import quartermaster_sdk as qm
+    #   qm.run_graph(graph, user_input="What is the weather in Tokyo?")
     #
     # The runner wires the ToolRegistry into the FlowRunner so the
     # Agent node can call tools during its reasoning loop.
     print(
         "To execute, set an API key and call:\n"
-        "  run_graph(graph, user_input='What is the weather in Tokyo?')\n"
+        "  qm.run_graph(graph, user_input='What is the weather in Tokyo?')\n"
     )
 
 
 # ── Part 4: Sync API one-liner ─────────────────────────────────────────────
 # For scripts that do not use asyncio the sync wrappers are convenient.
+
 
 def demo_sync_api() -> None:
     """Demonstrate the synchronous (non-async) MCP client API."""
@@ -402,6 +411,7 @@ def demo_sync_api() -> None:
 
 
 # ── Main ────────────────────────────────────────────────────────────────────
+
 
 async def main() -> None:
     # Part 1: connect to a live MCP server (graceful if unavailable)

--- a/examples/20_ollama_local.py
+++ b/examples/20_ollama_local.py
@@ -14,9 +14,8 @@ Usage:
 
 from __future__ import annotations
 
-from quartermaster_graph import Graph
+import quartermaster_sdk as qm
 from quartermaster_tools import ToolRegistry, tool
-from quartermaster_engine import run_graph
 
 
 MODEL = "gemma4:26b"
@@ -57,16 +56,28 @@ def search_knowledge(query: str) -> dict:
         query: Search query string.
     """
     kb = [
-        {"title": "Quartermaster", "fact": "AI agent orchestration framework by MindMade"},
-        {"title": "Gemma 4", "fact": "Google's open model with vision and tool calling"},
+        {
+            "title": "Quartermaster",
+            "fact": "AI agent orchestration framework by MindMade",
+        },
+        {
+            "title": "Gemma 4",
+            "fact": "Google's open model with vision and tool calling",
+        },
         {"title": "Slovenia", "fact": "Country in Central Europe, capital Ljubljana"},
     ]
-    results = [r for r in kb if query.lower() in r["title"].lower() or query.lower() in r["fact"].lower()]
+    results = [
+        r
+        for r in kb
+        if query.lower() in r["title"].lower() or query.lower() in r["fact"].lower()
+    ]
     return {"query": query, "results": results}
 
 
 # Build tool descriptions for the system prompt
-tool_list = "\n".join(f"- {s['name']}: {s.get('description', '')}" for s in registry.to_json_schema())
+tool_list = "\n".join(
+    f"- {s['name']}: {s.get('description', '')}" for s in registry.to_json_schema()
+)
 
 
 # ============================================================================
@@ -93,12 +104,12 @@ else:
     print("  (Sample image not found — using text description)")
 
 vision_agent = (
-    Graph("Gemma Vision")
-    .start()
+    qm.Graph("Gemma Vision")
     .user("Analyze this image")
     .vision(
         "Describe image",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction=(
             "You are an image analyst. Describe exactly what you see: "
             "the subject, colors, setting, mood, and any notable details. "
@@ -106,10 +117,9 @@ vision_agent = (
             "3-4 sentences."
         ),
     )
-    .end()
 )
 
-run_graph(vision_agent, user_input=image_prompt)
+qm.run_graph(vision_agent, user_input=image_prompt)
 
 
 # ============================================================================
@@ -119,12 +129,12 @@ run_graph(vision_agent, user_input=image_prompt)
 print("\n--- Demo 2: Tool Calling ---\n")
 
 tool_agent = (
-    Graph("Gemma Tools")
-    .start()
+    qm.Graph("Gemma Tools")
     .user("Ask anything")
     .instruction(
         "Think and call tools",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction=(
             "You are a helpful assistant with tools. When you need data, "
             "describe which tool you would call and why.\n\n"
@@ -132,13 +142,11 @@ tool_agent = (
             "Reason step-by-step about which tools to use, then answer."
         ),
     )
-    .end()
 )
 
-run_graph(
+qm.run_graph(
     tool_agent,
     user_input="What's the weather in Ljubljana and what do you know about Slovenia?",
-
 )
 
 
@@ -149,29 +157,28 @@ run_graph(
 print("\n--- Demo 3: Multi-step Pipeline ---\n")
 
 pipeline = (
-    Graph("Gemma Pipeline")
-    .start()
+    qm.Graph("Gemma Pipeline")
     .user("Topic")
     .instruction(
         "Research",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction="Write 3 key facts about the given topic. Be concise and specific.",
     )
     .instruction(
         "Summarize",
-        model=MODEL, provider=PROVIDER,
+        model=MODEL,
+        provider=PROVIDER,
         system_instruction=(
             "Take the research above and write a single compelling paragraph "
             "for a non-expert. Under 100 words."
         ),
     )
-    .end()
 )
 
-run_graph(
+qm.run_graph(
     pipeline,
     user_input="The history of artificial intelligence",
-
 )
 
 

--- a/examples/run_interactive.py
+++ b/examples/run_interactive.py
@@ -18,19 +18,23 @@ from __future__ import annotations
 
 import argparse
 
-from quartermaster_graph import Graph
-from quartermaster_engine import run_graph
+import quartermaster_sdk as qm
 
 
 def main():
     parser = argparse.ArgumentParser(description="Interactive Quartermaster agent")
-    parser.add_argument("--model", default="claude-haiku-4-5-20251001", help="Model to use")
-    parser.add_argument("--provider", default="anthropic", help="Provider (anthropic, openai, groq, xai, ollama)")
+    parser.add_argument(
+        "--model", default="claude-haiku-4-5-20251001", help="Model to use"
+    )
+    parser.add_argument(
+        "--provider",
+        default="anthropic",
+        help="Provider (anthropic, openai, groq, xai, ollama)",
+    )
     args = parser.parse_args()
 
     agent = (
-        Graph("Interactive Assistant")
-        .start()
+        qm.Graph("Interactive Assistant")
         .user("You")
         .instruction(
             "Respond",
@@ -41,7 +45,6 @@ def main():
                 "Respond in the same language the user writes in."
             ),
         )
-        .end()
     )
 
     print(f"Interactive Assistant ({args.model} via {args.provider})")
@@ -49,7 +52,7 @@ def main():
 
     while True:
         try:
-            result = run_graph(agent)
+            result = qm.run_graph(agent)
             if result is None:
                 break
         except (KeyboardInterrupt, EOFError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.2.0"
+version = "0.2.1"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quartermaster-workspace"
-version = "0.1.6"
+version = "0.2.0"
 description = "Quartermaster monorepo workspace"
 requires-python = ">=3.11"
 dependencies = [

--- a/quartermaster-code-runner/pyproject.toml
+++ b/quartermaster-code-runner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-code-runner"
-version = "0.2.0"
+version = "0.2.1"
 description = "Secure sandboxed code execution service supporting Python, Node.js, Go, Rust, Deno, and Bun via Docker containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-code-runner/pyproject.toml
+++ b/quartermaster-code-runner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-code-runner"
-version = "0.1.6"
+version = "0.2.0"
 description = "Secure sandboxed code execution service supporting Python, Node.js, Go, Rust, Deno, and Bun via Docker containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"

--- a/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
+++ b/quartermaster-code-runner/src/quartermaster_code_runner/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "TimeoutError",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/quartermaster-engine/pyproject.toml
+++ b/quartermaster-engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-engine"
-version = "0.1.6"
+version = "0.2.0"
 description = "Execution engine for AI agent graphs — traversal, branching, merging, memory, message passing, and error handling"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,13 +25,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "quartermaster-graph>=0.1.6",
-    "quartermaster-providers>=0.1.6",
+    "quartermaster-graph>=0.2.0",
+    "quartermaster-providers>=0.2.0",
     # ``quartermaster-nodes`` ships ``safe_eval`` (a simpleeval sandbox)
     # which the example runner uses for ``Var``/``If``/``Switch`` node
     # expression evaluation.  Pre-0.1.2 this was an implicit workspace
     # dep — it would ImportError when installed standalone.
-    "quartermaster-nodes>=0.1.6",
+    "quartermaster-nodes>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/quartermaster-engine/pyproject.toml
+++ b/quartermaster-engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-engine"
-version = "0.2.0"
+version = "0.2.1"
 description = "Execution engine for AI agent graphs — traversal, branching, merging, memory, message passing, and error handling"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,13 +25,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "quartermaster-graph>=0.2.0",
-    "quartermaster-providers>=0.2.0",
+    "quartermaster-graph>=0.2.1",
+    "quartermaster-providers>=0.2.1",
     # ``quartermaster-nodes`` ships ``safe_eval`` (a simpleeval sandbox)
     # which the example runner uses for ``Var``/``If``/``Switch`` node
     # expression evaluation.  Pre-0.1.2 this was an implicit workspace
     # dep — it would ImportError when installed standalone.
-    "quartermaster-nodes>=0.2.0",
+    "quartermaster-nodes>=0.2.1",
 ]
 
 [project.optional-dependencies]

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -9,6 +9,8 @@ from quartermaster_engine.events import (
     NodeFinished,
     NodeStarted,
     TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
     UserInputRequired,
 )
 from quartermaster_engine.example_runner import (
@@ -67,6 +69,8 @@ __all__ = [
     "FlowFinished",
     "UserInputRequired",
     "FlowError",
+    "ToolCallStarted",
+    "ToolCallFinished",
     # Stores
     "ExecutionStore",
     "InMemoryStore",

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -3,11 +3,13 @@
 from quartermaster_engine.context.execution_context import ExecutionContext
 from quartermaster_engine.context.node_execution import NodeExecution, NodeStatus
 from quartermaster_engine.events import (
+    CustomEvent,
     FlowError,
     FlowEvent,
     FlowFinished,
     NodeFinished,
     NodeStarted,
+    ProgressEvent,
     TokenGenerated,
     ToolCallFinished,
     ToolCallStarted,
@@ -71,6 +73,8 @@ __all__ = [
     "FlowError",
     "ToolCallStarted",
     "ToolCallFinished",
+    "ProgressEvent",
+    "CustomEvent",
     # Stores
     "ExecutionStore",
     "InMemoryStore",

--- a/quartermaster-engine/src/quartermaster_engine/__init__.py
+++ b/quartermaster-engine/src/quartermaster_engine/__init__.py
@@ -92,4 +92,4 @@ __all__ = [
     "AgentExecutor",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"

--- a/quartermaster-engine/src/quartermaster_engine/context/current_context.py
+++ b/quartermaster-engine/src/quartermaster_engine/context/current_context.py
@@ -1,0 +1,92 @@
+"""Per-flow ``ExecutionContext`` reachable from inside tool calls.
+
+This module exposes the ``qm.current_context()`` helper that application
+code — typically ``@tool()``-decorated functions — uses to emit
+progress / custom events back onto the stream::
+
+    from quartermaster_tools import tool
+    from quartermaster_sdk import current_context
+
+    @tool()
+    def slow_search(query: str) -> dict:
+        ctx = current_context()
+        if ctx is not None:
+            ctx.emit_progress(f"searching '{query}'", percent=0.25)
+        # ... do real work ...
+        if ctx is not None:
+            ctx.emit_progress("parsing results", percent=0.75)
+        return {"results": [...]}
+
+The contextvar is bound by :class:`FlowRunner._run_executor` around the
+call to ``executor.execute(context)``; it stays ``None`` when no flow
+is active, so tools remain safe to call from unit tests without a
+runner.
+
+Threading note
+--------------
+``FlowRunner._run_executor`` wraps ``executor.execute(context)`` in a
+``ThreadPoolExecutor.submit(...)`` when the caller is inside a running
+asyncio event loop. Python's ``contextvars.ContextVar`` values do NOT
+automatically propagate into pool-worker threads — you must invoke
+``contextvars.copy_context().run(...)`` from the worker. The runner
+does this for us; the :func:`bind` helper here just sets the var in
+the current context, trusting the runner to copy it across.
+
+The contextvar lives in the engine (not the SDK) so the runner can
+bind it without the engine importing from the SDK (which would flip
+the dependency direction).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from quartermaster_engine.context.execution_context import ExecutionContext
+
+
+# Module-level contextvar. ``None`` outside any flow — read via
+# :func:`current_context` which returns ``None`` cleanly for unit tests
+# and other out-of-flow callers.
+_current_ctx: contextvars.ContextVar["ExecutionContext | None"] = contextvars.ContextVar(
+    "quartermaster_current_context",
+    default=None,
+)
+
+
+def current_context() -> "ExecutionContext | None":
+    """Return the currently-executing flow's :class:`ExecutionContext`.
+
+    Returns ``None`` when called outside of an active flow, including
+    from unit tests and any code path that hasn't gone through
+    :class:`FlowRunner`. Tools that emit progress should always
+    null-check the return — the no-runner case is fully supported.
+    """
+    return _current_ctx.get()
+
+
+@contextlib.contextmanager
+def bind(context: "ExecutionContext") -> Iterator["ExecutionContext"]:
+    """Bind *context* as the current contextvar for the duration of the
+    ``with``-block.
+
+    Called by :meth:`FlowRunner._run_executor` around
+    ``executor.execute(context)``. The contextvar reset in the
+    ``finally`` clause guarantees nested or concurrent flow runs don't
+    leak state across each other — each flow sees the context bound by
+    its own runner frame, regardless of thread hopping in-between.
+
+    Yields the same context so callers can do
+    ``with bind(ctx) as c: ...`` if they find the binding symmetric.
+    """
+    token = _current_ctx.set(context)
+    try:
+        yield context
+    finally:
+        _current_ctx.reset(token)
+
+
+__all__ = ["current_context", "bind"]

--- a/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
+++ b/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
@@ -36,6 +36,14 @@ class ExecutionContext:
     on_message: Callable[[str], None] | None = None
     on_status_change: Callable[[NodeStatus], None] | None = None
     on_token: Callable[[str], None] | None = None
+    # Tool-call streaming — fires once per agent tool invocation so
+    # downstream chat UIs can render live "calling tool X..." cards
+    # instead of waiting for the full NodeResult. Payload shape matches
+    # ``events.ToolCallStarted`` / ``ToolCallFinished``.
+    on_tool_start: Callable[[str, dict, int], None] | None = None
+    on_tool_finish: (
+        Callable[[str, dict, str, Any, str | None, int], None] | None
+    ) = None
 
     def get_meta(self, key: str, default: Any = None) -> Any:
         """Get a value from the node's metadata, falling back to graph metadata."""
@@ -51,6 +59,26 @@ class ExecutionContext:
         """Emit a streaming token if a callback is registered."""
         if self.on_token:
             self.on_token(token)
+
+    def emit_tool_start(
+        self, tool: str, arguments: dict[str, Any], iteration: int
+    ) -> None:
+        """Fire ``on_tool_start`` for the agent-executor tool loop, if wired."""
+        if self.on_tool_start:
+            self.on_tool_start(tool, arguments, iteration)
+
+    def emit_tool_finish(
+        self,
+        tool: str,
+        arguments: dict[str, Any],
+        result: str,
+        raw: Any,
+        error: str | None,
+        iteration: int,
+    ) -> None:
+        """Fire ``on_tool_finish`` for the agent-executor tool loop, if wired."""
+        if self.on_tool_finish:
+            self.on_tool_finish(tool, arguments, result, raw, error, iteration)
 
     def emit_message(self, content: str) -> None:
         """Emit a complete message if a callback is registered."""

--- a/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
+++ b/quartermaster-engine/src/quartermaster_engine/context/execution_context.py
@@ -44,6 +44,13 @@ class ExecutionContext:
     on_tool_finish: (
         Callable[[str, dict, str, Any, str | None, int], None] | None
     ) = None
+    # Application-emitted event hooks — populated by the runner so
+    # user code calling ``emit_progress`` / ``emit_custom`` from
+    # inside a tool interleaves with engine-emitted tokens on the
+    # consumer's side. Both stay None when no streaming consumer is
+    # attached (e.g. a unit test invoking a tool directly).
+    on_progress: Callable[[str, float | None, dict], None] | None = None
+    on_custom: Callable[[str, dict], None] | None = None
 
     def get_meta(self, key: str, default: Any = None) -> Any:
         """Get a value from the node's metadata, falling back to graph metadata."""
@@ -79,6 +86,55 @@ class ExecutionContext:
         """Fire ``on_tool_finish`` for the agent-executor tool loop, if wired."""
         if self.on_tool_finish:
             self.on_tool_finish(tool, arguments, result, raw, error, iteration)
+
+    def emit_progress(
+        self,
+        message: str,
+        percent: float | None = None,
+        **data: Any,
+    ) -> None:
+        """Emit a user-facing progress signal.
+
+        Called by application code — typically from a long-running
+        tool — to report progress to the stream alongside model tokens.
+        Safe to call when no runner is attached (``on_progress`` is
+        ``None`` outside a flow): becomes a silent no-op so tools stay
+        unit-testable.
+
+        Args:
+            message: Short human-readable status line. Rendered in UIs.
+            percent: 0.0–1.0 for determinate progress, ``None`` (the
+                default) for indeterminate / spinner-style. Values are
+                passed through verbatim — clamp in the caller if needed.
+            **data: Free-form structured fields (query strings, step
+                indices, …) packed into a dict for the consumer.
+        """
+        if self.on_progress:
+            self.on_progress(message, percent, dict(data))
+
+    def emit_custom(
+        self,
+        name: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit an application-defined structured event.
+
+        Prefer this over :meth:`emit_progress` when the event marks a
+        discrete milestone (document retrieved, quota updated, cache
+        hit, …) rather than a percent-along-a-task signal. Consumers
+        filter on ``name`` via ``stream.custom(name=...)``.
+
+        No-op when no runner is attached.
+
+        Args:
+            name: Caller-chosen discriminator ("retrieved_docs",
+                "quota_warning", …). Used by stream consumers for
+                filtering.
+            payload: Free-form dict carried with the event. Defaults
+                to an empty dict when ``None``.
+        """
+        if self.on_custom:
+            self.on_custom(name, dict(payload or {}))
 
     def emit_message(self, content: str) -> None:
         """Emit a complete message if a callback is registered."""

--- a/quartermaster-engine/src/quartermaster_engine/events.py
+++ b/quartermaster-engine/src/quartermaster_engine/events.py
@@ -66,3 +66,41 @@ class FlowError(FlowEvent):
     node_id: UUID = field(default_factory=lambda: UUID(int=0))
     error: str = ""
     recoverable: bool = False
+
+
+@dataclass
+class ToolCallStarted(FlowEvent):
+    """Emitted when an agent node is about to invoke a tool.
+
+    Downstream SSE handlers translate this into a
+    ``ToolCallChunk`` so chat UIs can render "calling tool X..."
+    cards as they happen, rather than batching them at the end of
+    the turn.  The ``iteration`` field corresponds to the agent's
+    tool-loop round the call belongs to.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    tool: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    iteration: int = 0
+
+
+@dataclass
+class ToolCallFinished(FlowEvent):
+    """Emitted after a tool call resolves (success or error).
+
+    ``result`` is the string surface the LLM sees next turn; the
+    original structured payload — if any — lives under ``raw``.
+    ``error`` is populated for tool-registry lookups that fail or
+    for tools that raised during execution; in both cases ``result``
+    also carries an ``[ERROR: ...]`` sentinel string so the model
+    can react to the failure and retry or apologise.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    tool: str = ""
+    arguments: dict[str, Any] = field(default_factory=dict)
+    result: str = ""
+    raw: Any = None
+    error: str | None = None
+    iteration: int = 0

--- a/quartermaster-engine/src/quartermaster_engine/events.py
+++ b/quartermaster-engine/src/quartermaster_engine/events.py
@@ -104,3 +104,43 @@ class ToolCallFinished(FlowEvent):
     raw: Any = None
     error: str | None = None
     iteration: int = 0
+
+
+@dataclass
+class ProgressEvent(FlowEvent):
+    """User-emitted progress signal from inside a node or tool.
+
+    Fires when application code calls
+    ``ExecutionContext.emit_progress(...)`` — typically from a long-
+    running tool that wants to report status to the stream (e.g. a web
+    search saying "query 3 of 5") without interrupting the LLM token
+    channel. ``percent`` is optional: set to a 0.0–1.0 float for
+    determinate progress bars, leave as ``None`` for spinner-style
+    indeterminate progress. ``data`` is a free-form dict for payload
+    fields the consumer wants to render (search query, step index,
+    etc.) without bloating the message string.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    message: str = ""
+    percent: float | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CustomEvent(FlowEvent):
+    """Application-defined structured event.
+
+    Fires when application code calls
+    ``ExecutionContext.emit_custom(name, payload)``. The ``name``
+    field is a caller-chosen discriminator that downstream consumers
+    filter on (``stream.custom(name="retrieved_docs")``); ``payload``
+    carries the structured data. Use this instead of
+    :class:`ProgressEvent` when the event is a discrete milestone
+    (document retrieved, quota updated, cache hit/miss, …) rather
+    than a percent-along-a-task signal.
+    """
+
+    node_id: UUID = field(default_factory=lambda: UUID(int=0))
+    name: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -412,6 +412,28 @@ def _tool_definitions(tool_registry: Any) -> list[dict[str, Any]] | None:
     return None
 
 
+#: Provider-specific tool-namespace prefixes that should be stripped before
+#: looking the tool up in the registry.  Gemma-family models go through
+#: Ollama's OpenAI-compat proxy and emit ``default_api:list_orders``; the
+#: OpenAI native wire format uses ``functions:list_orders``; the MCP bridge
+#: emits ``mcp:foo``.  All three resolve to the same registered tool name.
+_TOOL_NAME_PREFIXES: tuple[str, ...] = (
+    "default_api:",
+    "default_api.",
+    "functions:",
+    "functions.",
+    "mcp:",
+)
+
+
+def _normalise_tool_name(tool_name: str) -> str:
+    """Strip provider-specific namespace prefixes from a tool call's name."""
+    for prefix in _TOOL_NAME_PREFIXES:
+        if tool_name.startswith(prefix):
+            return tool_name[len(prefix) :]
+    return tool_name
+
+
 def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> str:
     """Run one tool from the registry and serialise its result for the LLM.
 
@@ -423,26 +445,31 @@ def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> 
     """
     if tool_registry is None:
         return f"[ERROR: no tool registry available to execute '{tool_name}']"
+    # Strip ``default_api:`` / ``functions:`` / ``mcp:`` prefixes that
+    # different providers attach to the function name.  Without this the
+    # registry lookup would miss a tool that's registered under the bare
+    # name — a recurring integrator complaint before v0.2.0.
+    normalised = _normalise_tool_name(tool_name)
     try:
-        tool = tool_registry.get(tool_name)
+        tool = tool_registry.get(normalised)
     except Exception as exc:
-        logger.warning("Tool lookup failed for %r: %s", tool_name, exc)
-        return f"[ERROR: tool '{tool_name}' not found]"
+        logger.warning("Tool lookup failed for %r: %s", normalised, exc)
+        return f"[ERROR: tool '{normalised}' not found]"
     safe_run = getattr(tool, "safe_run", None) or getattr(tool, "run", None)
     if safe_run is None:
-        return f"[ERROR: tool '{tool_name}' has no run() method]"
+        return f"[ERROR: tool '{normalised}' has no run() method]"
     try:
         result = safe_run(**parameters)
     except Exception as exc:
-        logger.warning("Tool %r raised during execution: %s", tool_name, exc)
-        return f"[ERROR: tool '{tool_name}' execution failed]"
+        logger.warning("Tool %r raised during execution: %s", normalised, exc)
+        return f"[ERROR: tool '{normalised}' execution failed]"
     # ToolResult duck-typing: prefer .data, fall back to str().
     if hasattr(result, "success") and not result.success:
         # Tool itself returned a structured failure — these errors come from
         # the tool's own validation/business logic and are safe to surface,
         # but log them too for ops visibility.
         err = getattr(result, "error", "tool failed")
-        logger.info("Tool %r returned error result: %s", tool_name, err)
+        logger.info("Tool %r returned error result: %s", normalised, err)
         return f"[ERROR: {err}]"
     if hasattr(result, "data"):
         return str(result.data)

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pathlib
 import sys
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -434,17 +435,41 @@ def _normalise_tool_name(tool_name: str) -> str:
     return tool_name
 
 
-def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> str:
-    """Run one tool from the registry and serialise its result for the LLM.
+@dataclass
+class _ToolInvocation:
+    """Result of invoking one tool from the registry.
 
-    The returned string is fed back into the next LLM prompt, so exception
-    detail is intentionally generic — the full traceback goes to the
-    module logger instead, where ops can inspect it without exposing
-    internal paths/identifiers to the model (or, by extension, to any
-    user who can read the model's reasoning).
+    ``prompt_text`` is what gets baked into the next LLM prompt
+    (string, safe for the model to read); ``raw`` is the original
+    structured payload — a dict for most ``@tool()``-decorated
+    callables, ``None`` when the tool errored or returned nothing
+    structured. ``error`` is set when the lookup failed or the tool
+    raised; downstream ``ToolCallFinished`` event handlers surface
+    it to chat UIs so the user sees a red tool card.
+    """
+
+    prompt_text: str
+    raw: Any
+    error: str | None
+
+
+def _execute_tool_call(
+    tool_registry: Any, tool_name: str, parameters: dict
+) -> _ToolInvocation:
+    """Run one tool from the registry and return both the LLM-facing
+    string and the structured payload for live streaming.
+
+    The ``prompt_text`` surface is fed back into the next LLM prompt, so
+    exception detail is intentionally generic — the full traceback goes
+    to the module logger instead, where ops can inspect it without
+    exposing internal paths/identifiers to the model (or, by extension,
+    to any user who can read the model's reasoning). The structured
+    ``raw`` + ``error`` fields are only observed by the agent loop and
+    the ``ToolCallFinished`` event downstream, never fed back to the LLM.
     """
     if tool_registry is None:
-        return f"[ERROR: no tool registry available to execute '{tool_name}']"
+        msg = f"[ERROR: no tool registry available to execute '{tool_name}']"
+        return _ToolInvocation(prompt_text=msg, raw=None, error="no tool registry")
     # Strip ``default_api:`` / ``functions:`` / ``mcp:`` prefixes that
     # different providers attach to the function name.  Without this the
     # registry lookup would miss a tool that's registered under the bare
@@ -454,15 +479,18 @@ def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> 
         tool = tool_registry.get(normalised)
     except Exception as exc:
         logger.warning("Tool lookup failed for %r: %s", normalised, exc)
-        return f"[ERROR: tool '{normalised}' not found]"
+        msg = f"[ERROR: tool '{normalised}' not found]"
+        return _ToolInvocation(prompt_text=msg, raw=None, error=f"not found: {exc}")
     safe_run = getattr(tool, "safe_run", None) or getattr(tool, "run", None)
     if safe_run is None:
-        return f"[ERROR: tool '{normalised}' has no run() method]"
+        msg = f"[ERROR: tool '{normalised}' has no run() method]"
+        return _ToolInvocation(prompt_text=msg, raw=None, error="no run() method")
     try:
         result = safe_run(**parameters)
     except Exception as exc:
         logger.warning("Tool %r raised during execution: %s", normalised, exc)
-        return f"[ERROR: tool '{normalised}' execution failed]"
+        msg = f"[ERROR: tool '{normalised}' execution failed]"
+        return _ToolInvocation(prompt_text=msg, raw=None, error=str(exc))
     # ToolResult duck-typing: prefer .data, fall back to str().
     if hasattr(result, "success") and not result.success:
         # Tool itself returned a structured failure — these errors come from
@@ -470,10 +498,14 @@ def _execute_tool_call(tool_registry: Any, tool_name: str, parameters: dict) -> 
         # but log them too for ops visibility.
         err = getattr(result, "error", "tool failed")
         logger.info("Tool %r returned error result: %s", normalised, err)
-        return f"[ERROR: {err}]"
+        return _ToolInvocation(
+            prompt_text=f"[ERROR: {err}]",
+            raw=getattr(result, "data", None),
+            error=str(err),
+        )
     if hasattr(result, "data"):
-        return str(result.data)
-    return str(result)
+        return _ToolInvocation(prompt_text=str(result.data), raw=result.data, error=None)
+    return _ToolInvocation(prompt_text=str(result), raw=result, error=None)
 
 
 class AgentExecutor(NodeExecutor):
@@ -553,6 +585,13 @@ class AgentExecutor(NodeExecutor):
         prompt = base_prompt
         final_text = ""
         accumulated_tool_log: list[str] = []
+        # Structured record of every tool invocation this node made.
+        # Surfaces on ``NodeResult.data["tool_calls"]`` so downstream
+        # ``Result.captures["name"].data["tool_calls"]`` works for both
+        # the blocking (``qm.run``) and streaming (``qm.run.stream``)
+        # paths.  Each entry: {tool, arguments, result, raw, error,
+        # iteration}.
+        tool_call_log: list[dict[str, Any]] = []
         iteration = 0
         requires_another_call = True
         hit_iteration_cap = False
@@ -634,7 +673,40 @@ class AgentExecutor(NodeExecutor):
                     params = getattr(call, "parameters", None)
                     if params is None:
                         params = getattr(call, "arguments", {}) or {}
-                result = _execute_tool_call(per_node_tools, tool_name, params)
+
+                # Normalise the tool name BEFORE emitting the "started"
+                # event so downstream UIs see the same name the registry
+                # looks up (strips ``default_api:`` / ``functions:`` /
+                # ``mcp:`` prefixes).  Without this the chat card would
+                # say ``default_api:list_orders`` while the tool call log
+                # says ``list_orders`` — confusing.
+                public_name = _normalise_tool_name(tool_name)
+                context.emit_tool_start(public_name, dict(params), iteration)
+
+                invocation = _execute_tool_call(per_node_tools, tool_name, params)
+
+                context.emit_tool_finish(
+                    public_name,
+                    dict(params),
+                    invocation.prompt_text,
+                    invocation.raw,
+                    invocation.error,
+                    iteration,
+                )
+
+                # Structured record for NodeResult.data["tool_calls"] so
+                # ``qm.run(...)`` callers (non-streaming) can read exactly
+                # the same shape the streaming ToolCallFinished event
+                # carries.  Both surfaces stay in sync by construction.
+                tool_call_log.append({
+                    "tool": public_name,
+                    "arguments": dict(params),
+                    "result": invocation.prompt_text,
+                    "raw": invocation.raw,
+                    "error": invocation.error,
+                    "iteration": iteration,
+                })
+
                 # Wrap each tool result in an explicit untrusted-data block.
                 # Tool output frequently includes external content (web
                 # pages, file contents, DB rows), which can carry indirect
@@ -643,8 +715,8 @@ class AgentExecutor(NodeExecutor):
                 # instructions, blunts that attack class.
                 accumulated_tool_log.append(
                     "<tool_result"
-                    f' tool="{tool_name}" iteration="{iteration}"'
-                    f" args={params!r}>\n{result}\n</tool_result>"
+                    f' tool="{public_name}" iteration="{iteration}"'
+                    f" args={params!r}>\n{invocation.prompt_text}\n</tool_result>"
                 )
 
             tool_history = "\n".join(accumulated_tool_log)
@@ -677,7 +749,15 @@ class AgentExecutor(NodeExecutor):
         _append_to_conversation(conversation, node_name, final_text, round_num)
         return NodeResult(
             success=True,
-            data={"memory_updates": {"__conversation__": conversation}},
+            data={
+                "memory_updates": {"__conversation__": conversation},
+                # Surface the structured tool-call log on NodeResult.data
+                # so the SDK's Result.captures["x"].data["tool_calls"]
+                # read matches what streaming ToolCallChunk / ToolResultChunk
+                # events carry.  Empty list when the agent didn't call tools.
+                "tool_calls": tool_call_log,
+                "iterations": iteration,
+            },
             output_text=final_text,
         )
 

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -60,7 +60,14 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class FlowResult:
-    """The final result of a flow execution."""
+    """The final result of a flow execution.
+
+    The UUID-keyed ``node_results`` is the authoritative per-node record
+    and is mostly useful for debugging tooling (visualisers, trace
+    dumps).  The name-keyed ``captures`` dict (v0.2.0+) is what
+    application code should reach for — populated from the
+    ``capture_as="..."`` kwarg users pass on node builder methods.
+    """
 
     flow_id: UUID
     success: bool
@@ -68,7 +75,34 @@ class FlowResult:
     output_data: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
     node_results: dict[UUID, NodeResult] = field(default_factory=dict)
+    #: Name → NodeResult mapping for nodes that set ``capture_as="..."``.
+    #: Lets callers write ``result.captures["research"].output_text`` instead
+    #: of fishing through ``node_results`` with UUID keys and node-type
+    #: pattern matching.
+    captures: dict[str, NodeResult] = field(default_factory=dict)
     duration_seconds: float = 0.0
+
+    def __getitem__(self, name: str) -> NodeResult:
+        """Syntactic sugar: ``result["research"]`` → the captured node result.
+
+        Raises ``KeyError`` with a helpful message listing available
+        capture names when *name* is unknown.  The SDK's ``Result`` type
+        uses the same message format (see ``quartermaster_sdk._result.
+        format_missing_capture_error``) so switching between the two is
+        seamless.
+        """
+        try:
+            return self.captures[name]
+        except KeyError:
+            raise KeyError(_format_missing_capture(name, self.captures)) from None
+
+
+def _format_missing_capture(name: str, captures: dict[str, NodeResult]) -> str:
+    """Shared format for "no capture named X" errors — matches the SDK's
+    ``format_missing_capture_error``.  Kept as a module-private helper here
+    so the engine doesn't depend on the SDK package."""
+    available = ", ".join(sorted(captures)) or "(no captures registered)"
+    return f"No capture named {name!r}. Available captures: {available}"
 
 
 class FlowRunner:
@@ -551,6 +585,7 @@ class FlowRunner:
         """Collect the final result after all nodes have completed."""
         executions = self.store.get_all_node_executions(flow_id)
         node_results: dict[UUID, NodeResult] = {}
+        captures: dict[str, NodeResult] = {}
         final_output = ""
         all_success = True
         errors: list[str] = []
@@ -564,12 +599,21 @@ class FlowRunner:
                     errors.append(execution.error)
 
             if execution.result:
-                node_results[nid] = NodeResult(
+                nr = NodeResult(
                     success=execution.status == NodeStatus.FINISHED,
                     data=execution.output_data,
                     output_text=execution.result,
                     error=execution.error,
                 )
+                node_results[nid] = nr
+                # Populate name-keyed captures if the builder set
+                # ``capture_as="..."`` on this node.  We look up via the
+                # shared constant from ``quartermaster_graph`` so rename
+                # drift is caught at import time.
+                if node is not None:
+                    capture_name = node.metadata.get("capture_as")
+                    if isinstance(capture_name, str) and capture_name:
+                        captures[capture_name] = nr
 
             # The final output comes from End nodes
             if node and node.type == NodeType.END and execution.result:
@@ -589,6 +633,7 @@ class FlowRunner:
             success=all_success,
             final_output=final_output,
             node_results=node_results,
+            captures=captures,
             error="; ".join(errors) if errors else None,
         )
 

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -19,6 +19,7 @@ The execution loop:
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 import time
 from collections.abc import AsyncIterator, Callable
@@ -26,15 +27,18 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
 
+from quartermaster_engine.context.current_context import bind as bind_current_context
 from quartermaster_engine.context.execution_context import ExecutionContext
 from quartermaster_engine.context.node_execution import NodeExecution, NodeStatus
 from quartermaster_engine.dispatchers.sync_dispatcher import SyncDispatcher
 from quartermaster_engine.events import (
+    CustomEvent,
     FlowError,
     FlowEvent,
     FlowFinished,
     NodeFinished,
     NodeStarted,
+    ProgressEvent,
     TokenGenerated,
     ToolCallFinished,
     ToolCallStarted,
@@ -491,6 +495,23 @@ class FlowRunner:
                     iteration=it,
                 )
             ),
+            on_progress=lambda msg, percent, data: self._emit(
+                ProgressEvent(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    message=msg,
+                    percent=percent,
+                    data=data,
+                )
+            ),
+            on_custom=lambda name, payload: self._emit(
+                CustomEvent(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    name=name,
+                    payload=payload,
+                )
+            ),
         )
 
         # Execute with error handling
@@ -517,6 +538,20 @@ class FlowRunner:
     ) -> NodeResult:
         """Run a node executor, handling sync/async transparently.
 
+        Wraps the executor invocation in ``current_context.bind(context)``
+        so application code inside the executor (most importantly
+        ``@tool()`` callables) can reach the live :class:`ExecutionContext`
+        via :func:`quartermaster_sdk.current_context` and emit progress
+        or custom events back onto the stream.
+
+        Threading: when we're inside a running asyncio event loop we
+        dispatch to a ``ThreadPoolExecutor``. Python's ``contextvars``
+        do NOT propagate into pool workers automatically, so we submit
+        ``contextvars.copy_context().run(target)`` — the worker thread
+        inherits a snapshot of the caller's contextvars (including the
+        freshly-bound ``_current_ctx``) and tools running inside the
+        coroutine see ``current_context()`` return a non-None value.
+
         If the node has a ``timeout`` set (in seconds), execution is wrapped
         in ``asyncio.wait_for`` so that a ``TimeoutError`` is raised when the
         node exceeds its time budget.
@@ -532,14 +567,25 @@ class FlowRunner:
         except RuntimeError:
             loop = None
 
-        if loop and loop.is_running():
-            # We're inside an async context — create a new thread to run the coroutine
-            import concurrent.futures
+        # Bind the contextvar for the duration of this executor call so
+        # tools invoked during execution can emit progress/custom events.
+        # The ``with`` scope unwinds the var after the executor returns.
+        with bind_current_context(context):
+            if loop and loop.is_running():
+                # Inside an async context — spawn a worker thread for the
+                # coroutine. ``copy_context().run(...)`` carries the
+                # freshly-bound contextvar into the worker's stack so
+                # ``current_context()`` resolves correctly there too.
+                import concurrent.futures
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                future = pool.submit(asyncio.run, coro)
-                return future.result(timeout=node.timeout)
-        else:
+                ctx_snapshot = contextvars.copy_context()
+
+                def _worker() -> NodeResult:
+                    return asyncio.run(coro)
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(ctx_snapshot.run, _worker)
+                    return future.result(timeout=node.timeout)
             return asyncio.run(coro)
 
     def _handle_node_error(

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -36,6 +36,8 @@ from quartermaster_engine.events import (
     NodeFinished,
     NodeStarted,
     TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
     UserInputRequired,
 )
 from quartermaster_engine.messaging.context_manager import ContextManager
@@ -467,6 +469,27 @@ class FlowRunner:
             metadata=dict(node.metadata),
             on_token=lambda t: self._emit(
                 TokenGenerated(flow_id=flow_id, node_id=node.id, token=t)
+            ),
+            on_tool_start=lambda tool, args, it: self._emit(
+                ToolCallStarted(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    tool=tool,
+                    arguments=args,
+                    iteration=it,
+                )
+            ),
+            on_tool_finish=lambda tool, args, result, raw, err, it: self._emit(
+                ToolCallFinished(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    tool=tool,
+                    arguments=args,
+                    result=result,
+                    raw=raw,
+                    error=err,
+                    iteration=it,
+                )
             ),
         )
 

--- a/quartermaster-engine/tests/test_v030_events_and_context.py
+++ b/quartermaster-engine/tests/test_v030_events_and_context.py
@@ -1,0 +1,461 @@
+"""Regression tests for v0.3.0 ``ProgressEvent`` / ``CustomEvent`` and
+the ``current_context()`` contextvar plumbing.
+
+Surface under test (engine-side):
+
+* ``quartermaster_engine.events.ProgressEvent`` /
+  ``quartermaster_engine.events.CustomEvent`` — the two new typed
+  flow events fired when application code calls
+  ``ExecutionContext.emit_progress(...)`` / ``.emit_custom(...)``.
+* ``ExecutionContext.emit_progress`` / ``.emit_custom`` —
+  including the no-callback no-op contract that lets tools stay
+  unit-testable without a runner.
+* ``quartermaster_engine.context.current_context.current_context()``
+  / ``bind(...)`` — the contextvar that tools reach for to grab the
+  live :class:`ExecutionContext`.
+* ``FlowRunner._run_executor`` plumbing — both the synchronous path
+  and the ``ThreadPoolExecutor`` path used when the runner is
+  invoked from inside a running asyncio event loop. The latter is
+  the **regression guard** for the
+  ``contextvars.copy_context().run(...)`` snapshot — without it
+  ``current_context()`` would resolve to ``None`` in the worker
+  thread.
+* End-to-end via the public SDK surface: a ``@tool()``-decorated
+  function calling ``qm.current_context().emit_progress(...)``
+  surfaces a ``ProgressChunk`` from ``qm.run.stream(...)`` interleaved
+  between ``ToolCallChunk`` and ``ToolResultChunk``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from quartermaster_engine.context.current_context import current_context
+from quartermaster_engine.context.execution_context import ExecutionContext
+from quartermaster_engine.events import (
+    CustomEvent,
+    FlowEvent,
+    ProgressEvent,
+)
+from quartermaster_engine.nodes import NodeResult, SimpleNodeRegistry
+from quartermaster_engine.runner.flow_runner import FlowRunner
+from quartermaster_engine.types import (
+    GraphSpec,
+    GraphNode,
+    NodeType,
+    TraverseOut,
+)
+
+from tests.conftest import make_edge, make_graph, make_node
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _build_one_node_graph(
+    executor: Any,
+) -> tuple[GraphSpec, GraphNode, SimpleNodeRegistry]:
+    """Build a tiny ``Start → Inst → End`` graph wired to *executor*.
+
+    Returns the graph spec, the instruction node (so tests can assert
+    on its ``id``), and the registry.
+    """
+    start = make_node(NodeType.START, name="Start")
+    inst = make_node(NodeType.INSTRUCTION, name="Worker")
+    end = make_node(NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_NONE)
+
+    graph = make_graph(
+        [start, inst, end],
+        [make_edge(start, inst), make_edge(inst, end)],
+        start,
+    )
+
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, executor)
+    return graph, inst, registry
+
+
+# ── 1. ProgressEvent ─────────────────────────────────────────────────
+
+
+class TestProgressEvent:
+    """``ExecutionContext.emit_progress`` fires a ``ProgressEvent``
+    on the runner's ``on_event`` hook with the right shape, and is a
+    safe no-op when no callback is wired."""
+
+    def test_progress_event_emitted_when_node_emits(self):
+        """One ``emit_progress`` call → exactly one ``ProgressEvent`` with
+        matching message / percent / data / node_id."""
+
+        class _ProgressExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                context.emit_progress("loading", percent=0.5, query="hello")
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, inst, registry = _build_one_node_graph(_ProgressExecutor())
+
+        events: list[FlowEvent] = []
+        runner = FlowRunner(
+            graph=graph, node_registry=registry, on_event=events.append
+        )
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        progress = [e for e in events if isinstance(e, ProgressEvent)]
+        assert len(progress) == 1, f"expected exactly 1 ProgressEvent, got {progress}"
+
+        ev = progress[0]
+        assert ev.message == "loading"
+        assert ev.percent == 0.5
+        assert ev.data == {"query": "hello"}
+        assert ev.node_id == inst.id
+
+    def test_progress_event_no_op_when_no_callback(self):
+        """Calling ``emit_progress`` on a freshly-built ``ExecutionContext``
+        with ``on_progress=None`` must not raise and must not produce any
+        observable side effect — tools stay unit-testable without a runner."""
+        node = make_node(NodeType.INSTRUCTION, name="Standalone")
+        graph = make_graph([node], [], node)
+        ctx = ExecutionContext(
+            flow_id=uuid4(),
+            node_id=node.id,
+            graph=graph,
+            current_node=node,
+        )
+        assert ctx.on_progress is None
+
+        # Must not raise — and the callback is None so there's nothing
+        # to invoke.  Verify by re-asserting the callback is still None
+        # afterwards (no mutation as a side effect).
+        ctx.emit_progress("x")
+        ctx.emit_progress("y", percent=0.25, foo="bar")
+        assert ctx.on_progress is None
+
+
+# ── 2. CustomEvent ───────────────────────────────────────────────────
+
+
+class TestCustomEvent:
+    """``ExecutionContext.emit_custom`` fires a ``CustomEvent`` with the
+    caller-supplied name and payload; payload defaults to an empty dict."""
+
+    def test_custom_event_emitted_when_node_emits(self):
+        class _CustomExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                context.emit_custom("retrieved_docs", {"count": 3})
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, inst, registry = _build_one_node_graph(_CustomExecutor())
+
+        events: list[FlowEvent] = []
+        runner = FlowRunner(
+            graph=graph, node_registry=registry, on_event=events.append
+        )
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        customs = [e for e in events if isinstance(e, CustomEvent)]
+        assert len(customs) == 1, f"expected exactly 1 CustomEvent, got {customs}"
+
+        ev = customs[0]
+        assert ev.name == "retrieved_docs"
+        assert ev.payload == {"count": 3}
+        assert ev.node_id == inst.id
+
+    def test_custom_event_payload_defaults_to_empty_dict(self):
+        """``emit_custom("ping")`` (no payload arg) → ``CustomEvent`` with
+        ``payload={}``, not ``None``."""
+
+        class _PingExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                context.emit_custom("ping")
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(_PingExecutor())
+
+        events: list[FlowEvent] = []
+        runner = FlowRunner(
+            graph=graph, node_registry=registry, on_event=events.append
+        )
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        customs = [e for e in events if isinstance(e, CustomEvent)]
+        assert len(customs) == 1
+        assert customs[0].name == "ping"
+        assert customs[0].payload == {}
+
+
+# ── 3. current_context contextvar ────────────────────────────────────
+
+
+class TestCurrentContext:
+    """The ``_current_ctx`` contextvar is bound by ``FlowRunner._run_executor``
+    around ``executor.execute(context)`` and reset on the way out — so
+    out-of-flow callers see ``None`` and in-flow tools see the live context.
+
+    The ``test_current_context_propagates_into_thread_pool_executor`` case
+    is the regression guard for the
+    ``contextvars.copy_context().run(...)`` snapshot used when the runner
+    dispatches into a worker thread from inside a running asyncio loop;
+    without it the contextvar wouldn't propagate and tools would see
+    ``None`` mid-flow.
+    """
+
+    def test_current_context_is_none_outside_flow(self):
+        """No runner active → ``current_context()`` returns ``None``."""
+        assert current_context() is None
+
+    def test_current_context_is_set_inside_executor(self):
+        """Inside the executor body, ``current_context()`` returns the
+        same ``ExecutionContext`` instance the runner passed in."""
+        captured: list[Any] = []
+        seen_context: list[Any] = []
+
+        class _CapturingExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                seen_context.append(context)
+                captured.append(current_context())
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(_CapturingExecutor())
+
+        runner = FlowRunner(graph=graph, node_registry=registry)
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        assert len(captured) == 1
+        assert captured[0] is not None, "current_context() returned None inside flow"
+        # Identity check — must be the very same object the runner passed.
+        assert captured[0] is seen_context[0]
+
+    def test_current_context_unset_after_run_completes(self):
+        """After the run finishes, ``current_context()`` is back to ``None``
+        at the top level — the contextvar was reset by ``bind``'s
+        ``finally`` clause."""
+
+        class _NoopExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                # Just confirm we have a context in-flight.
+                assert current_context() is context
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(_NoopExecutor())
+
+        runner = FlowRunner(graph=graph, node_registry=registry)
+        result = runner.run("kickoff")
+        assert result.success, result.error
+
+        # Top-level contextvar state must be clean.
+        assert current_context() is None
+
+    def test_current_context_propagates_into_thread_pool_executor(self):
+        """REGRESSION GUARD: when the runner dispatches via the
+        ``ThreadPoolExecutor`` path (running asyncio loop active), the
+        worker thread must see the bound contextvar via
+        ``contextvars.copy_context().run(...)`` — otherwise
+        ``current_context()`` would return ``None`` inside the executor.
+
+        We force the thread-pool path by running the runner from inside
+        a coroutine: ``asyncio.get_running_loop()`` succeeds and
+        ``loop.is_running()`` is ``True``, so ``_run_executor`` takes
+        the worker-thread branch.
+        """
+        captured: dict[str, Any] = {}
+
+        class _ThreadPoolCapturingExecutor:
+            async def execute(self, context: ExecutionContext) -> NodeResult:
+                # This runs inside the worker thread spawned by
+                # _run_executor's asyncio.run(coro) — without
+                # contextvars.copy_context().run(...) the contextvar
+                # would be unset here and current_context() would be
+                # None.
+                seen = current_context()
+                captured["seen"] = seen
+                captured["is_same"] = seen is context
+                return NodeResult(success=True, data={}, output_text="ok")
+
+        graph, _inst, registry = _build_one_node_graph(
+            _ThreadPoolCapturingExecutor()
+        )
+        runner = FlowRunner(graph=graph, node_registry=registry)
+
+        async def _make_runner_call_from_async() -> Any:
+            # Calling runner.run from inside a coroutine forces
+            # _run_executor to take the ThreadPoolExecutor branch
+            # because ``asyncio.get_running_loop()`` resolves and
+            # ``loop.is_running()`` is True.
+            return runner.run("kickoff")
+
+        result = asyncio.run(_make_runner_call_from_async())
+        assert result.success, result.error
+
+        assert captured.get("seen") is not None, (
+            "current_context() returned None in the ThreadPoolExecutor "
+            "worker — contextvars.copy_context().run(...) plumbing in "
+            "FlowRunner._run_executor regressed."
+        )
+        assert captured["is_same"] is True, (
+            "current_context() in the worker did not match the "
+            "ExecutionContext the runner passed in."
+        )
+
+        # And cleanup still holds at the top level.
+        assert current_context() is None
+
+
+# ── 4. End-to-end via the public SDK surface ─────────────────────────
+
+
+class TestEmitFromTool:
+    """End-to-end: a ``@tool()`` function calling
+    ``qm.current_context().emit_progress(...)`` from inside an agent's
+    tool loop surfaces a ``ProgressChunk`` on ``qm.run.stream(...)``,
+    interleaved between the matching ``ToolCallChunk`` and
+    ``ToolResultChunk``.
+
+    Lifts the ``MockProvider`` / ``_OkTool`` / ``_ToolRegistry`` shim
+    pattern from ``quartermaster-sdk/tests/test_v022_tool_streaming.py``
+    so the agent loop terminates cleanly after one tool call.
+    """
+
+    def test_tool_inside_agent_can_emit_progress(self):
+        # Imported here so the rest of this engine-side test module
+        # stays importable even if the SDK happens to be missing in some
+        # downstream environment. With the workspace layout in this
+        # repo, both packages are always present.
+        import quartermaster_sdk as qm
+        from quartermaster_providers import ProviderRegistry
+        from quartermaster_providers.testing import MockProvider
+        from quartermaster_providers.types import (
+            NativeResponse,
+            TokenResponse,
+            ToolCall,
+        )
+        from quartermaster_tools import tool
+
+        # ── Define a tool that emits a progress event mid-execution.
+        # The decorator builds a ``FunctionTool``; the agent executor
+        # will call ``.safe_run(**args)`` which delegates to ``run``
+        # which calls our wrapped function.  Inside the function the
+        # contextvar is set (the agent executor runs inside the runner's
+        # ``bind_current_context(...)`` scope).
+        @tool()
+        def slow_search(q: str) -> dict:
+            """Pretend to do a slow search and emit a progress signal."""
+            ctx = qm.current_context()
+            assert ctx is not None, (
+                "current_context() returned None inside the @tool body — "
+                "the contextvar was not propagated into the tool call."
+            )
+            ctx.emit_progress("searching", percent=0.5)
+            return {"ok": True, "q": q}
+
+        # ── Mock provider: turn 1 returns a tool call, turn 2 ends.
+        mock = MockProvider(
+            responses=[TokenResponse(content="Done.", stop_reason="stop")],
+            native_responses=[
+                NativeResponse(
+                    text_content="",
+                    thinking=[],
+                    tool_calls=[
+                        ToolCall(
+                            tool_name="slow_search",
+                            tool_id="call_1",
+                            parameters={"q": "hello"},
+                        )
+                    ],
+                    stop_reason="tool_calls",
+                ),
+                NativeResponse(
+                    text_content="Done.",
+                    thinking=[],
+                    tool_calls=[],
+                    stop_reason="stop",
+                ),
+            ],
+        )
+        provider_reg = ProviderRegistry(auto_configure=False)
+        provider_reg.register_instance("mock", mock)
+        provider_reg.set_default_provider("mock")
+        provider_reg.set_default_model("mock", "test-model")
+
+        # ── ToolRegistry shim matching the agent executor's interface
+        # (``.get(name)`` + ``.to_openai_tools()``). We bypass
+        # ``quartermaster_tools.ToolRegistry`` to keep the test focused
+        # on the contextvar + event plumbing — the registry shape mirrors
+        # the one in test_v022_tool_streaming.py.
+        class _ToolRegistry:
+            def __init__(self, t: Any):
+                self._t = t
+
+            def get(self, name: str) -> Any:
+                if name != "slow_search":
+                    raise KeyError(name)
+                return self._t
+
+            def to_openai_tools(self) -> list[dict]:
+                return [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "slow_search",
+                            "description": "stub",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "q": {"type": "string"}
+                                },
+                            },
+                        },
+                    }
+                ]
+
+        # The agent executor calls ``.safe_run(**args)`` on the tool —
+        # ``FunctionTool`` inherits this from ``AbstractTool``. The
+        # tool's body runs synchronously inside the agent's tool loop,
+        # which itself runs inside ``bind_current_context(...)``, so
+        # ``current_context()`` resolves correctly.
+        tool_reg = _ToolRegistry(slow_search)
+
+        qm.reset_config()
+        try:
+            qm.configure(registry=provider_reg)
+
+            graph = (
+                qm.Graph("chat")
+                .user()
+                .agent("Tooled", tools=["slow_search"], capture_as="agent")
+                .build()
+            )
+
+            chunks = list(
+                qm.run.stream(graph, "hi", tool_registry=tool_reg)
+            )
+        finally:
+            qm.reset_config()
+
+        types_seq = [c.type for c in chunks]
+
+        # The progress chunk must arrive AND must sit between the
+        # matching tool_call and tool_result chunks — that's the whole
+        # point of the contextvar plumbing: live status from inside
+        # tools, interleaved with the agent loop.
+        assert "tool_call" in types_seq, f"no tool_call in {types_seq}"
+        assert "tool_result" in types_seq, f"no tool_result in {types_seq}"
+        assert "progress" in types_seq, f"no progress chunk in {types_seq}"
+
+        tool_call_idx = types_seq.index("tool_call")
+        progress_idx = types_seq.index("progress")
+        tool_result_idx = types_seq.index("tool_result")
+        assert tool_call_idx < progress_idx < tool_result_idx, (
+            f"progress chunk must sit between tool_call and tool_result; "
+            f"got order {types_seq}"
+        )
+
+        progress_chunk = next(c for c in chunks if c.type == "progress")
+        assert isinstance(progress_chunk, qm.ProgressChunk)
+        assert progress_chunk.message == "searching"
+        assert progress_chunk.percent == 0.5

--- a/quartermaster-graph/pyproject.toml
+++ b/quartermaster-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-graph"
-version = "0.2.0"
+version = "0.2.1"
 description = "Framework-agnostic agent graph schema for AI agent workflows as directed acyclic graphs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-graph/pyproject.toml
+++ b/quartermaster-graph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-graph"
-version = "0.1.6"
+version = "0.2.0"
 description = "Framework-agnostic agent graph schema for AI agent workflows as directed acyclic graphs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Enums

--- a/quartermaster-graph/src/quartermaster_graph/__init__.py
+++ b/quartermaster-graph/src/quartermaster_graph/__init__.py
@@ -62,7 +62,7 @@ from quartermaster_graph.traversal import (
 )
 from quartermaster_graph.validation import ValidationError, validate_graph
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 __all__ = [
     # Enums

--- a/quartermaster-graph/src/quartermaster_graph/builder.py
+++ b/quartermaster-graph/src/quartermaster_graph/builder.py
@@ -27,8 +27,16 @@ _FLOW_CONFIG_KEYS = {
     "error_handling",
 }
 
-# Metadata-level config keys (stored in node.metadata, not as node attributes)
-_META_CONFIG_KEYS = {"show_output"}
+# Metadata-level config keys (stored in node.metadata, not as node attributes).
+# ``capture_as`` (v0.2.0) lets callers name a node's output so
+# ``Result.captures["name"]`` can retrieve it post-run without fishing through
+# UUID-keyed ``node_results``.
+_META_CONFIG_KEYS = {"show_output", "capture_as"}
+
+# Node-metadata key under which ``capture_as`` is stored.  Kept as a named
+# constant so the engine side can import it rather than hard-coding the
+# string (see ``quartermaster_engine.runner.flow_runner``).
+CAPTURE_AS_METADATA_KEY = "capture_as"
 
 # Combined set for extraction from kwargs
 _ALL_CONFIG_KEYS = _FLOW_CONFIG_KEYS | _META_CONFIG_KEYS
@@ -41,7 +49,9 @@ def _apply_flow_config(node: GraphNode, kwargs: dict[str, Any]) -> None:
             setattr(node, key, kwargs.pop(key))
     for key in _META_CONFIG_KEYS:
         if key in kwargs:
-            node.metadata[key] = kwargs.pop(key)
+            value = kwargs.pop(key)
+            if value is not None:
+                node.metadata[key] = value
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -1062,7 +1072,18 @@ class GraphBuilder:
         )
     """
 
-    def __init__(self, name: str, description: str = "") -> None:
+    def __init__(self, name: str, description: str = "", *, auto_start: bool = True) -> None:
+        """Build a new graph.
+
+        Args:
+            name: Human-readable graph name.
+            description: Optional description stored on the spec.
+            auto_start: When ``True`` (the default, v0.2.0+) a ``Start``
+                node is added automatically so chains can open with
+                ``Graph("x").user()...`` instead of ``.start().user()...``.
+                Set to ``False`` only if you want to construct the start
+                yourself (rare — legacy compatibility path).
+        """
         self._name = name
         self._description = description
         self._nodes: list[GraphNode] = []
@@ -1075,6 +1096,24 @@ class GraphBuilder:
         self._position_x = 0
         self._position_y = 0
         self._allowed_agents: list[str] = []
+        if auto_start:
+            self._create_start_node()
+
+    def _create_start_node(self) -> None:
+        """Append the graph's ``Start`` node and mark it as the entry point.
+
+        Internal helper used by ``__init__`` (via ``auto_start=True``) and
+        by the now-idempotent :meth:`start` method so explicit callers
+        don't accidentally create two Start nodes.
+        """
+        node = GraphNode(
+            type=NodeType.START,
+            name="Start",
+            thought_type=ThoughtType.SKIP,
+            message_type=MessageType.VARIABLE,
+        )
+        self._start_node_id = node.id
+        self._add_node(node)
 
     # ------------------------------------------------------------------
     # Agent control
@@ -1199,15 +1238,20 @@ class GraphBuilder:
     # ------------------------------------------------------------------
 
     def start(self) -> GraphBuilder:
-        """Add a Start node."""
-        node = GraphNode(
-            type=NodeType.START,
-            name="Start",
-            thought_type=ThoughtType.SKIP,
-            message_type=MessageType.VARIABLE,
-        )
-        self._start_node_id = node.id
-        return self._add_node(node)
+        """Add a Start node (idempotent since v0.2.0).
+
+        ``Graph(name)`` auto-creates the Start node, so chained calls to
+        ``.start()`` are no-ops — the method is kept only for readability
+        of legacy snippets.  Explicitly creating a second Start via
+        ``auto_start=False`` + a manual ``.start()`` call is still
+        supported.
+        """
+        if self._start_node_id is not None:
+            # Auto-start already happened (or the caller previously
+            # called .start()) — don't create a duplicate.
+            return self
+        self._create_start_node()
+        return self
 
     def end(self) -> GraphBuilder:
         """Add an End node.

--- a/quartermaster-graph/src/quartermaster_graph/validation.py
+++ b/quartermaster-graph/src/quartermaster_graph/validation.py
@@ -57,15 +57,12 @@ def validate_graph(version: GraphSpec) -> list[ValidationError]:  # type: ignore
                 )
             )
 
-    # --- End node ---
-    end_nodes = [n for n in version.nodes if n.type == NodeType.END]
-    if len(end_nodes) == 0:
-        errors.append(
-            ValidationError(
-                code="no_end",
-                message="Graph must have at least one End node",
-            )
-        )
+    # --- End node (optional since v0.2.0) ---
+    # Pre-0.2.0 a graph without an explicit End node was rejected here.
+    # The runner has always been fine with "no End" — it falls back to the
+    # last finished node's output in ``FlowResult``.  Making ``.end()``
+    # optional means single-node flows (``Graph("x").instruction(...).build()``)
+    # don't need a trailing ``.end()`` boilerplate line.
 
     # --- Start node ID valid ---
     if version.start_node_id not in node_map:
@@ -214,5 +211,44 @@ def validate_graph(version: GraphSpec) -> list[ValidationError]:  # type: ignore
                         node_id=node.id,
                     )
                 )
+
+    # --- capture_as collisions with reserved node metadata keys ---
+    # v0.2.0 lets callers name a node's output via ``capture_as="x"``.
+    # A YAML-loaded graph could set ``capture_as: llm_model`` — that's
+    # not a correctness bug (captures are a separate namespace from
+    # node metadata), but the resulting ``result.captures["llm_model"]``
+    # is confusing to debug because it shadows a well-known concept.
+    # Warn so the operator sees it in logs.
+    _reserved_capture_names = frozenset(
+        {
+            "llm_model",
+            "llm_provider",
+            "llm_temperature",
+            "llm_system_instruction",
+            "llm_max_output_tokens",
+            "llm_max_input_tokens",
+            "llm_stream",
+            "llm_vision",
+            "llm_thinking_level",
+            "show_output",
+            "capture_as",
+        }
+    )
+    for node in version.nodes:
+        capture_name = node.metadata.get("capture_as")
+        if isinstance(capture_name, str) and capture_name in _reserved_capture_names:
+            errors.append(
+                ValidationError(
+                    code="capture_as_shadows_reserved_key",
+                    message=(
+                        f"Node '{node.name}' has capture_as={capture_name!r} which "
+                        f"collides with a reserved node-metadata key. Captures "
+                        f"live in a separate namespace so this still works, but "
+                        f"rename to something unambiguous for readability."
+                    ),
+                    node_id=node.id,
+                    severity="warning",
+                )
+            )
 
     return errors

--- a/quartermaster-graph/tests/test_builder.py
+++ b/quartermaster-graph/tests/test_builder.py
@@ -28,18 +28,29 @@ class TestBasicBuilder:
         assert len(version.nodes) == 5
         assert len(version.edges) == 4
 
-    def test_no_start_raises(self):
-        with pytest.raises(ValueError, match="start node"):
-            GraphBuilder("Test").instruction("X").end().build()
+    def test_auto_start_creates_start_node(self):
+        """v0.2.0+ — ``Graph(name)`` auto-creates a Start node."""
+        version = GraphBuilder("Test").instruction("X").end().build()
+        starts = [n for n in version.nodes if n.type.value.startswith("Start")]
+        assert len(starts) == 1, "exactly one Start node should exist"
 
-    def test_validation_on_build(self):
-        # No end node should produce validation warnings/errors (but build still returns)
-        version = GraphBuilder("Test").start().instruction("X").build()
+    def test_auto_start_opt_out(self):
+        """``auto_start=False`` reverts to manual .start() call (legacy path)."""
+        with pytest.raises(ValueError, match="start node"):
+            # No auto-start AND no manual .start() → no start node → .build() rejects.
+            GraphBuilder("Test", auto_start=False).instruction("X").end().build()
+
+    def test_no_end_is_now_allowed(self):
+        """v0.2.0+ — graphs without an explicit End node are valid."""
+        version = GraphBuilder("Test").instruction("X").build()
         from quartermaster_graph.validation import validate_graph
 
         errors = validate_graph(version)
         real_errors = [e for e in errors if e.severity == "error"]
-        assert len(real_errors) > 0
+        assert real_errors == [], (
+            "No-End-node is intentional post-v0.2.0; runner falls back to the "
+            f"last finished node's output.  Got errors: {real_errors}"
+        )
 
     def test_skip_validation(self):
         version = GraphBuilder("Test").start().instruction("X").build(validate=False)

--- a/quartermaster-graph/tests/test_builder_advanced.py
+++ b/quartermaster-graph/tests/test_builder_advanced.py
@@ -504,7 +504,10 @@ class TestGraphWithoutBuild:
         assert start.type == NodeType.START
 
     def test_start_node_id_raises_without_start(self):
-        graph = GraphBuilder("Empty")
+        # v0.2.0+: the Graph constructor auto-creates a Start node by
+        # default.  To hit the "no start node" path we have to opt out
+        # with ``auto_start=False``.
+        graph = GraphBuilder("Empty", auto_start=False)
         with pytest.raises(ValueError, match="No start node"):
             _ = graph.start_node_id
 

--- a/quartermaster-graph/tests/test_validation.py
+++ b/quartermaster-graph/tests/test_validation.py
@@ -86,7 +86,16 @@ class TestStartNodeValidation:
 
 
 class TestEndNodeValidation:
-    def test_no_end_node(self, agent):
+    def test_no_end_node_is_now_allowed(self, agent):
+        """v0.2.0+ — graphs without an explicit End node validate clean.
+
+        Pre-0.2.0 the validator emitted a ``no_end`` error.  That check
+        was removed because the runner has always been fine with no End
+        (it falls back to the last finished node's output in
+        ``FlowResult``).  Single-node flows like
+        ``Graph("x").instruction("y").build()`` no longer need the
+        trailing ``.end()`` boilerplate.
+        """
         start = GraphNode(type=NodeType.START, name="Start")
         inst = GraphNode(type=NodeType.INSTRUCTION, name="Inst")
         edge = GraphEdge(source_id=start.id, target_id=inst.id)
@@ -98,7 +107,7 @@ class TestEndNodeValidation:
         )
         errors = validate_graph(version)
         codes = [e.code for e in errors]
-        assert "no_end" in codes
+        assert "no_end" not in codes
 
 
 class TestEdgeValidation:

--- a/quartermaster-graph/tests/test_validation_integration.py
+++ b/quartermaster-graph/tests/test_validation_integration.py
@@ -24,11 +24,17 @@ def agent() -> Agent:
 
 
 class TestMissingStartNode:
-    """Validation must reject graphs without a Start node."""
+    """Validation must reject graphs without a Start node.
+
+    Post-v0.2.0 this is only reachable when the caller opts out of the
+    auto-start convenience via ``auto_start=False`` and then forgets to
+    call ``.start()`` themselves — still a valid error path, just a
+    harder one to hit by accident.
+    """
 
     def test_builder_requires_start(self) -> None:
-        """GraphBuilder.build() raises if .start() was never called."""
-        builder = GraphBuilder("No Start")
+        """GraphBuilder(auto_start=False).build() raises if .start() was never called."""
+        builder = GraphBuilder("No Start", auto_start=False)
         builder._nodes.append(GraphNode(type=NodeType.END, name="End"))
         with pytest.raises(ValueError, match="start node"):
             builder.build()
@@ -80,10 +86,12 @@ class TestMissingStartNode:
 
 
 class TestMissingEndNode:
-    """Validation must reject graphs without an End node."""
+    """Graphs without an End node are allowed since v0.2.0."""
 
-    def test_no_end_node(self, agent: Agent) -> None:
-        """Graph with Start and Instruction but no End produces no_end error."""
+    def test_no_end_node_validates_clean(self, agent: Agent) -> None:
+        """Pre-0.2.0 the validator emitted ``no_end``.  Now it's legal —
+        the runner falls back to the last finished node's output so
+        single-node flows don't need trailing ``.end()`` boilerplate."""
         start = GraphNode(type=NodeType.START, name="Start")
         inst = GraphNode(type=NodeType.INSTRUCTION, name="Process")
         edge = GraphEdge(source_id=start.id, target_id=inst.id)
@@ -95,7 +103,7 @@ class TestMissingEndNode:
         )
         errors = validate_graph(version)
         codes = {e.code for e in errors if e.severity == "error"}
-        assert "no_end" in codes
+        assert "no_end" not in codes
 
 
 class TestOrphanNodes:
@@ -327,7 +335,12 @@ class TestMultipleValidationErrors:
     """Validation returns all errors at once, not just the first."""
 
     def test_multiple_errors_reported(self, agent: Agent) -> None:
-        """A graph with multiple issues reports all of them."""
+        """A graph with multiple issues reports all of them.
+
+        Note: ``no_end`` was removed from the validator in v0.2.0 (End
+        nodes are optional now), so only ``no_start`` and
+        ``invalid_edge_target`` survive in this fixture.
+        """
         # No start node, no end node, invalid edge
         inst = GraphNode(type=NodeType.INSTRUCTION, name="Lonely")
         bad_edge = GraphEdge(source_id=inst.id, target_id=uuid4())
@@ -340,7 +353,6 @@ class TestMultipleValidationErrors:
         errors = validate_graph(version)
         codes = {e.code for e in errors}
         assert "no_start" in codes
-        assert "no_end" in codes
         assert "invalid_edge_target" in codes
 
 
@@ -348,12 +360,12 @@ class TestBuilderValidation:
     """The builder's validate=True flag rejects invalid graphs."""
 
     def test_builder_rejects_invalid_graph(self) -> None:
-        """Builder returns version but validation finds errors (no end node)."""
-        builder = GraphBuilder("Invalid")
-        builder.start()
+        """Builder still surfaces genuinely invalid graphs (dangling edge target)."""
+        builder = GraphBuilder("Invalid")  # auto-start creates a Start node
         builder.instruction("Process")
-        # No .end() call -- build still returns but validation finds errors
-        version = builder.build(validate=True)
+        # Dangling edge to a uuid that doesn't resolve — still an error.
+        builder._edges.append(GraphEdge(source_id=uuid4(), target_id=uuid4()))
+        version = builder.build(validate=False)  # bypass builder-side raise
         errors = validate_graph(version)
         real_errors = [e for e in errors if e.severity == "error"]
         assert len(real_errors) > 0

--- a/quartermaster-mcp-client/pyproject.toml
+++ b/quartermaster-mcp-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-mcp-client"
-version = "0.1.6"
+version = "0.2.0"
 description = "Lightweight MCP (Model Context Protocol) client with async/sync support, SSE and Streamable HTTP transports"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-mcp-client/pyproject.toml
+++ b/quartermaster-mcp-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-mcp-client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Lightweight MCP (Model Context Protocol) client with async/sync support, SSE and Streamable HTTP transports"
 readme = "README.md"
 license = "Apache-2.0"

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"

--- a/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
+++ b/quartermaster-mcp-client/src/quartermaster_mcp_client/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "parse_tool_parameters",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/quartermaster-nodes/pyproject.toml
+++ b/quartermaster-nodes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-nodes"
-version = "0.1.6"
+version = "0.2.0"
 description = "Library of composable node types for building AI agent graphs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1",
-    "quartermaster-graph>=0.1.6",
-    "quartermaster-providers>=0.1.6",
+    "quartermaster-graph>=0.2.0",
+    "quartermaster-providers>=0.2.0",
     "simpleeval>=1.0.5",
 ]
 

--- a/quartermaster-nodes/pyproject.toml
+++ b/quartermaster-nodes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-nodes"
-version = "0.2.0"
+version = "0.2.1"
 description = "Library of composable node types for building AI agent graphs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1",
-    "quartermaster-graph>=0.2.0",
-    "quartermaster-providers>=0.2.0",
+    "quartermaster-graph>=0.2.1",
+    "quartermaster-providers>=0.2.1",
     "simpleeval>=1.0.5",
 ]
 

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 __all__ = [
     # Enums

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -14,7 +14,7 @@ from quartermaster_nodes.base import AbstractAssistantNode, AbstractLLMAssistant
 from quartermaster_nodes.chain import Chain, Handler
 from quartermaster_nodes.registry import NodeCatalog, NodeRegistry, register_node
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Enums

--- a/quartermaster-providers/pyproject.toml
+++ b/quartermaster-providers/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-providers"
-version = "0.2.0"
+version = "0.2.1"
 description = "Unified multi-LLM provider abstraction supporting OpenAI, Anthropic, Google, Groq, xAI and more"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/quartermaster-providers/pyproject.toml
+++ b/quartermaster-providers/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-providers"
-version = "0.1.6"
+version = "0.2.0"
 description = "Unified multi-LLM provider abstraction supporting OpenAI, Anthropic, Google, Groq, xAI and more"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -48,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 __author__ = "MindMade"
 
 __all__ = [

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -48,7 +48,7 @@ from quartermaster_providers.types import (
     ToolDefinition,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "MindMade"
 
 __all__ = [

--- a/quartermaster-sdk/README.md
+++ b/quartermaster-sdk/README.md
@@ -24,32 +24,67 @@ ollama pull gemma4:26b      # or any model you've pulled
 ```
 
 ```python
-from quartermaster_sdk import Graph, FlowRunner, register_local
+import quartermaster_sdk as qm
 
-provider_registry = register_local(
-    "ollama",
+qm.configure(
+    provider="ollama",
     base_url="http://localhost:11434",   # or set $OLLAMA_HOST
     default_model="gemma4:26b",
 )
 
-graph = Graph("chat").start().user().agent().end().build()
-runner = FlowRunner(graph=graph, provider_registry=provider_registry)
-result = runner.run("Pozdravljen, koliko je ura?")
-print(result.final_output)
+# Graph() auto-creates Start; .end() / .build() are both optional when running via qm.run().
+result = qm.run(qm.Graph("chat").user().agent(), "Pozdravljen, koliko je ura?")
+print(result.text)
+```
+
+## Single-shot helpers (no graph visible)
+
+```python
+# prompt → str
+reply = qm.instruction(system="Respond in Slovenian.", user="Pozdravljen!")
+
+# prompt → Pydantic model (typed JSON extraction)
+from pydantic import BaseModel
+
+class Classification(BaseModel):
+    category: str
+    priority: str
+
+data = qm.instruction_form(Classification, system="Classify.", user=email_body)
+```
+
+## Reading specific node outputs with `capture_as=`
+
+```python
+graph = (
+    qm.Graph("enrich")
+    .agent("Research", tools=[...], capture_as="notes")
+    .instruction_form(CustomerData, system="Extract.", capture_as="data")
+)
+result = qm.run(graph, "VT-Treyd Slovenija")
+result["notes"].output_text    # agent's free-text research
+result["data"].output_text     # extracted JSON
+```
+
+## Streaming
+
+```python
+for chunk in qm.run.stream(qm.Graph("chat").user().agent(), "Tell me a story"):
+    if chunk.type == "token":
+        print(chunk.content, end="", flush=True)
+    elif chunk.type == "done":
+        final = chunk.result    # qm.Result
 ```
 
 ## Quick Start (cloud provider)
 
 ```python
-from quartermaster_sdk import Graph
-
 agent = (
-    Graph("My Agent")
-    .start()
+    qm.Graph("My Agent")
     .user("What can I help you with?")
     .instruction("Respond", model="gpt-4o", system_instruction="You are a helpful assistant.")
-    .end()
 )
+result = qm.run(agent, "How does photosynthesis work?")
 ```
 
 ## Sync chat shim (no graph needed)

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-sdk"
-version = "0.1.6"
+version = "0.2.0"
 description = "Quartermaster — modular AI agent orchestration framework. Install this to get all packages."
 readme = "README.md"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "quartermaster-graph>=0.1.6",
-    "quartermaster-providers>=0.1.6",
-    "quartermaster-tools>=0.1.6",
-    "quartermaster-nodes>=0.1.6",
-    "quartermaster-engine>=0.1.6",
+    "quartermaster-graph>=0.2.0",
+    "quartermaster-providers>=0.2.0",
+    "quartermaster-tools>=0.2.0",
+    "quartermaster-nodes>=0.2.0",
+    "quartermaster-engine>=0.2.0",
 ]
 
 [project.optional-dependencies]
@@ -54,8 +54,8 @@ observability = ["quartermaster-tools[observability]"]
 tools-all = ["quartermaster-tools[all]"]
 
 # Standalone packages (not included by default)
-mcp = ["quartermaster-mcp-client>=0.1.6"]
-code-runner = ["quartermaster-code-runner>=0.1.6"]
+mcp = ["quartermaster-mcp-client>=0.2.0"]
+code-runner = ["quartermaster-code-runner>=0.2.0"]
 
 # Everything
 all = [

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Quartermaster — modular AI agent orchestration framework. Install this to get all packages."
 readme = "README.md"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "quartermaster-graph>=0.2.0",
-    "quartermaster-providers>=0.2.0",
-    "quartermaster-tools>=0.2.0",
-    "quartermaster-nodes>=0.2.0",
-    "quartermaster-engine>=0.2.0",
+    "quartermaster-graph>=0.2.1",
+    "quartermaster-providers>=0.2.1",
+    "quartermaster-tools>=0.2.1",
+    "quartermaster-nodes>=0.2.1",
+    "quartermaster-engine>=0.2.1",
 ]
 
 [project.optional-dependencies]
@@ -54,8 +54,8 @@ observability = ["quartermaster-tools[observability]"]
 tools-all = ["quartermaster-tools[all]"]
 
 # Standalone packages (not included by default)
-mcp = ["quartermaster-mcp-client>=0.2.0"]
-code-runner = ["quartermaster-code-runner>=0.2.0"]
+mcp = ["quartermaster-mcp-client>=0.2.1"]
+code-runner = ["quartermaster-code-runner>=0.2.1"]
 
 # Everything
 all = [

--- a/quartermaster-sdk/pyproject.toml
+++ b/quartermaster-sdk/pyproject.toml
@@ -57,9 +57,15 @@ tools-all = ["quartermaster-tools[all]"]
 mcp = ["quartermaster-mcp-client>=0.2.1"]
 code-runner = ["quartermaster-code-runner>=0.2.1"]
 
+# OpenTelemetry instrumentation (qm.telemetry.instrument())
+telemetry = [
+    "opentelemetry-api>=1.25",
+    "opentelemetry-sdk>=1.25",
+]
+
 # Everything
 all = [
-    "quartermaster-sdk[providers-all,tools-all,mcp,code-runner]",
+    "quartermaster-sdk[providers-all,tools-all,mcp,code-runner,telemetry]",
 ]
 
 # Development

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -18,7 +18,7 @@ Optional extras:
 - pip install quartermaster-sdk[all]           — Everything
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # ── v0.2.0 primary API ────────────────────────────────────────────────
 #

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -18,7 +18,7 @@ Optional extras:
 - pip install quartermaster-sdk[all]           — Everything
 """
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 # Re-export the most common entry points for convenience.  Pre-0.1.4 the SDK
 # re-exported only the graph-builder surface, forcing downstream callers to

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -46,6 +46,9 @@ from quartermaster_engine import (  # noqa: F401
     build_default_registry,
     run_graph,
 )
+from quartermaster_engine.context.current_context import (  # noqa: F401
+    current_context,
+)
 from quartermaster_graph import (  # noqa: F401
     AgentGraph,  # deprecated alias for GraphSpec — kept for backward compat
     Graph,
@@ -63,10 +66,12 @@ from quartermaster_providers import (  # noqa: F401
 from ._chunks import (  # noqa: F401
     AwaitInputChunk,
     Chunk,
+    CustomChunk,
     DoneChunk,
     ErrorChunk,
     NodeFinishChunk,
     NodeStartChunk,
+    ProgressChunk,
     TokenChunk,
     ToolCallChunk,
     ToolResultChunk,
@@ -81,6 +86,7 @@ from ._async_runner import arun  # noqa: F401
 from ._helpers import instruction, instruction_form  # noqa: F401
 from ._result import Result  # noqa: F401
 from ._runner import run  # noqa: F401
+from ._trace import NodeTrace, Trace  # noqa: F401
 
 
 __all__ = [
@@ -93,6 +99,9 @@ __all__ = [
     "instruction",
     "instruction_form",
     "Result",
+    # Structured post-mortem trace — v0.3.0
+    "Trace",
+    "NodeTrace",
     # Typed streaming chunks
     "Chunk",
     "TokenChunk",
@@ -101,8 +110,12 @@ __all__ = [
     "ToolCallChunk",
     "ToolResultChunk",
     "AwaitInputChunk",
+    "ProgressChunk",
+    "CustomChunk",
     "DoneChunk",
     "ErrorChunk",
+    # Context reach — tools call current_context() to emit progress
+    "current_context",
     # Graph builder + spec
     "Graph",
     "GraphBuilder",

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -77,6 +77,7 @@ from ._config import (  # noqa: F401
     get_default_registry,
     reset_config,
 )
+from ._async_runner import arun  # noqa: F401
 from ._helpers import instruction, instruction_form  # noqa: F401
 from ._result import Result  # noqa: F401
 from ._runner import run  # noqa: F401
@@ -88,6 +89,7 @@ __all__ = [
     # ── v0.2.0 primary surface ──
     "configure",
     "run",
+    "arun",
     "instruction",
     "instruction_form",
     "Result",

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -20,12 +20,20 @@ Optional extras:
 
 __version__ = "0.2.0"
 
-# Re-export the most common entry points for convenience.  Pre-0.1.4 the SDK
-# re-exported only the graph-builder surface, forcing downstream callers to
-# `from quartermaster_engine import FlowRunner` and `from quartermaster_providers
-# import register_local` separately even though the SDK is the recommended
-# install.  These re-exports cover the v0.1.4 release-notes snippet so a single
-# `from quartermaster_sdk import …` line is enough to wire up the simplest graph.
+# ── v0.2.0 primary API ────────────────────────────────────────────────
+#
+# The recommended path is a four-import line for 90% of callsites:
+#
+#     from quartermaster_sdk import Graph, run, configure, instruction
+#
+# * ``Graph("x").user().agent().build()`` — auto-Start, optional End
+# * ``run(graph, user_input)`` / ``run.stream(...)`` — no ``FlowRunner``
+# * ``configure(provider="ollama", default_model=...)`` — boot once
+# * ``instruction(system=..., user=...)`` — single-shot prompt → text
+# * ``instruction_form(schema, system=..., user=...)`` — prompt → typed JSON
+#
+# Legacy v0.1.x exports (``FlowRunner``, ``build_default_registry``, …)
+# remain available for integrators who need the low-level surface.
 from quartermaster_engine import (  # noqa: F401
     AgentExecutor,
     FlowResult,
@@ -52,17 +60,54 @@ from quartermaster_providers import (  # noqa: F401
     register_local,
 )
 
+from ._chunks import (  # noqa: F401
+    AwaitInputChunk,
+    Chunk,
+    DoneChunk,
+    ErrorChunk,
+    NodeFinishChunk,
+    NodeStartChunk,
+    TokenChunk,
+    ToolCallChunk,
+    ToolResultChunk,
+)
+from ._config import (  # noqa: F401
+    configure,
+    get_default_model,
+    get_default_registry,
+    reset_config,
+)
+from ._helpers import instruction, instruction_form  # noqa: F401
+from ._result import Result  # noqa: F401
+from ._runner import run  # noqa: F401
+
 
 __all__ = [
     # Version
     "__version__",
+    # ── v0.2.0 primary surface ──
+    "configure",
+    "run",
+    "instruction",
+    "instruction_form",
+    "Result",
+    # Typed streaming chunks
+    "Chunk",
+    "TokenChunk",
+    "NodeStartChunk",
+    "NodeFinishChunk",
+    "ToolCallChunk",
+    "ToolResultChunk",
+    "AwaitInputChunk",
+    "DoneChunk",
+    "ErrorChunk",
     # Graph builder + spec
     "Graph",
     "GraphBuilder",
     "GraphSpec",
     "AgentGraph",  # deprecated
     "NodeType",
-    # Engine — runner + node-registry surface
+    # Engine — runner + node-registry surface (low-level)
     "FlowRunner",
     "FlowResult",
     "NodeRegistry",
@@ -78,4 +123,7 @@ __all__ = [
     "ChatResult",
     "ProviderRegistry",
     "register_local",
+    "get_default_registry",
+    "get_default_model",
+    "reset_config",
 ]

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -85,6 +85,19 @@ class _ARunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+
+        # v0.3.0 trace: accumulate every FlowEvent on the worker
+        # thread so we can build a ``Trace`` and attach it to the
+        # returned ``Result``. The list is populated from inside the
+        # engine's worker thread and only READ after ``await
+        # asyncio.to_thread`` resolves, so no cross-thread sync is
+        # required.
+        trace_events: list[FlowEvent] = []
+
+        def _collect(event: FlowEvent) -> None:
+            trace_events.append(event)
+            _listeners.dispatch(event)
+
         runner = FlowRunner(
             graph=spec,
             provider_registry=registry,
@@ -93,12 +106,13 @@ class _ARunCallable:
             # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
             # observes the same FlowEvent stream the streaming runner
             # gets — even though there's no consumer queue here.
-            on_event=_listeners.dispatch,
+            on_event=_collect,
         )
         # Pre-generate so the async cancel handler has something to stop,
         # even if the to_thread() call hasn't entered ``runner.run`` yet.
         flow_id = uuid4()
 
+        started = time.perf_counter()
         try:
             fr = await asyncio.to_thread(runner.run, user_input, flow_id=flow_id)
         except asyncio.CancelledError:
@@ -114,8 +128,14 @@ class _ARunCallable:
             except Exception:  # pragma: no cover — defensive
                 logger.exception("arun: runner.stop(%s) raised", flow_id)
             raise
+        elapsed = time.perf_counter() - started
 
-        return Result.from_flow_result(fr)
+        result = Result.from_flow_result(fr)
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        return result
 
     def stream(
         self,
@@ -181,11 +201,18 @@ class _ARunCallable:
         holder: dict[str, Any] = {}
         flow_id = uuid4()
 
+        # v0.3.0 trace: accumulate events as they fire (on the engine
+        # worker thread) so we can build a ``Trace`` before yielding
+        # the terminal ``DoneChunk``. Append-only from the engine
+        # thread, read-only once ``run_task`` has finished.
+        trace_events: list[FlowEvent] = []
+
         def on_event(event: FlowEvent) -> None:
             # Fan out to bolt-on instrumentation (telemetry, custom
             # listeners, etc.) on the engine's worker thread BEFORE
             # marshalling the event back to the consumer's loop.
             _listeners.dispatch(event)
+            trace_events.append(event)
             # Called from the engine's worker threads.  Hop back to the
             # consumer's loop so Queue.put() touches only loop-owned
             # state — ``asyncio.Queue`` is not thread-safe.
@@ -210,6 +237,7 @@ class _ARunCallable:
                 # Sentinel — unblocks the async iterator even on crash.
                 loop.call_soon_threadsafe(q.put_nowait, None)
 
+        started = time.perf_counter()
         run_task = asyncio.create_task(
             asyncio.to_thread(_run_sync), name="qm-arun-stream"
         )
@@ -267,7 +295,18 @@ class _ARunCallable:
             yield ErrorChunk(error="arun.stream: runner produced no result")
             return
 
-        yield DoneChunk(result=Result.from_flow_result(fr))
+        elapsed = time.perf_counter() - started
+        result = Result.from_flow_result(fr)
+        # v0.3.0: populate the structured trace from every FlowEvent
+        # the engine dispatched. The ``on_event`` hook on the engine
+        # thread appended each event as it fired; we build the
+        # bucketed view once the run has finished and hand it to the
+        # caller as part of the DoneChunk's Result.
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        yield DoneChunk(result=result)
 
 
 #: Publicly exported async runner.  ``await qm.arun(graph, input)`` runs

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -1,0 +1,239 @@
+"""Async variant of the v0.2.0 graph runner.
+
+Mirror of :mod:`quartermaster_sdk._runner` for ``async def`` call sites.
+Django views, FastAPI endpoints, and other asyncio codebases can drop
+``asgiref.sync.sync_to_async(qm.run)(...)`` in favour of the first-class
+coroutine form:
+
+    result = await qm.arun(graph, "Hello!")
+    async for chunk in qm.arun.stream(graph, "Hello!"):
+        if chunk.type == "token":
+            print(chunk.content, end="")
+
+No engine logic is duplicated — under the hood this is a thin adapter
+over :class:`FlowRunner` that dispatches the synchronous execution onto
+a worker thread (via :func:`asyncio.to_thread`) while the event loop
+keeps servicing other tasks.
+
+**Cancellation:** when the consumer's :class:`asyncio.Task` is cancelled,
+``arun`` and ``arun.stream`` both reach into the still-running
+:class:`FlowRunner` and call :meth:`FlowRunner.stop` with the pre-
+generated ``flow_id``.  The engine checks ``flow_id in self._stopped``
+in ``_execute_node`` before dispatching further work, so nodes already
+mid-LLM-call finish their current request (no hard kill) but no new
+nodes are scheduled — long agent loops unwind within a bounded time
+instead of leaking API costs after the HTTP client disconnects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, AsyncIterator
+from uuid import uuid4
+
+from quartermaster_engine import FlowEvent, FlowRunner
+
+from ._chunks import Chunk, DoneChunk, ErrorChunk
+from ._config import get_default_registry
+from ._result import Result
+from ._runner import _event_to_chunk, _resolve_graph
+
+if TYPE_CHECKING:
+    from quartermaster_graph import GraphBuilder, GraphSpec
+    from quartermaster_providers import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class _ARunCallable:
+    """Callable + ``.stream`` method exposed as ``qm.arun``.
+
+    Async analogue of :class:`_RunCallable` — same signature, same
+    semantics, but every public method is a coroutine (or async
+    iterator).  Shares :func:`_resolve_graph` and :func:`_event_to_chunk`
+    with the sync path so event mapping stays in one place.
+    """
+
+    async def __call__(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Result:
+        """Execute *graph* against *user_input* and return a :class:`Result`.
+
+        Args:
+            graph: Either a :class:`GraphBuilder` (auto-finalised) or
+                a pre-built :class:`GraphSpec`.
+            user_input: Primary user message injected into the graph.
+            provider_registry: Override the configured default registry.
+            tool_registry: Optional :class:`quartermaster_tools.ToolRegistry`
+                made available to ``agent()``-type nodes that specify
+                ``tools=[...]``.
+
+        **Cancellation:** if the awaiting task is cancelled, the running
+        flow is stopped via :meth:`FlowRunner.stop` before the
+        ``CancelledError`` propagates — nodes already dispatched finish
+        their current LLM/tool call but no new work is scheduled.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+        )
+        # Pre-generate so the async cancel handler has something to stop,
+        # even if the to_thread() call hasn't entered ``runner.run`` yet.
+        flow_id = uuid4()
+
+        try:
+            fr = await asyncio.to_thread(runner.run, user_input, flow_id=flow_id)
+        except asyncio.CancelledError:
+            # ``asyncio.to_thread`` can't actually interrupt the worker
+            # thread — the thread keeps executing until it voluntarily
+            # returns — but calling ``runner.stop(flow_id)`` flips the
+            # engine's ``_stopped`` gate so it won't dispatch any more
+            # nodes.  The current node completes, the flow wraps up,
+            # and the CancelledError re-raises to the caller.  Net
+            # effect: bounded unwind instead of runaway API calls.
+            try:
+                runner.stop(flow_id)
+            except Exception:  # pragma: no cover — defensive
+                logger.exception("arun: runner.stop(%s) raised", flow_id)
+            raise
+
+        return Result.from_flow_result(fr)
+
+    async def stream(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> AsyncIterator[Chunk]:
+        """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Terminates with a :class:`DoneChunk` (on success) or
+        :class:`ErrorChunk` (on unrecoverable failure).  The graph
+        executes on a background thread; events flow back through an
+        :class:`asyncio.Queue` so the event loop keeps servicing other
+        tasks between chunks — no blocking ``next()`` inside the coro.
+
+        **Cancellation:** if the async iterator is abandoned early
+        (``break`` out of ``async for``, enclosing task cancelled, etc.)
+        :meth:`FlowRunner.stop` is called on the pre-generated
+        ``flow_id``.  The engine short-circuits on its next
+        ``_execute_node`` dispatch — nodes mid-LLM-call finish their
+        current request but no new work is scheduled, so long agent
+        loops unwind within a bounded time instead of leaking API costs
+        after the consumer goes away.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+
+        # Capture the consumer's loop so the thread can marshal events
+        # back to it via ``call_soon_threadsafe``.  ``run_coroutine_threadsafe``
+        # would also work, but we want fire-and-forget ``put`` without
+        # blocking the engine thread on asyncio internals.
+        loop = asyncio.get_running_loop()
+        q: asyncio.Queue[FlowEvent | None] = asyncio.Queue()
+        holder: dict[str, Any] = {}
+        flow_id = uuid4()
+
+        def on_event(event: FlowEvent) -> None:
+            # Called from the engine's worker threads.  Hop back to the
+            # consumer's loop so Queue.put() touches only loop-owned
+            # state — ``asyncio.Queue`` is not thread-safe.
+            loop.call_soon_threadsafe(q.put_nowait, event)
+
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+            on_event=on_event,
+        )
+
+        def _run_sync() -> None:
+            """Runs on the ``to_thread`` worker — synchronous engine loop."""
+            try:
+                fr = runner.run(user_input, flow_id=flow_id)
+                holder["result"] = fr
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.exception("arun.stream: runner.run raised")
+                holder["exception"] = exc
+            finally:
+                # Sentinel — unblocks the async iterator even on crash.
+                loop.call_soon_threadsafe(q.put_nowait, None)
+
+        run_task = asyncio.create_task(
+            asyncio.to_thread(_run_sync), name="qm-arun-stream"
+        )
+
+        try:
+            while True:
+                event = await q.get()
+                if event is None:
+                    break
+                chunk = _event_to_chunk(event)
+                if chunk is not None:
+                    yield chunk
+        finally:
+            # Either the stream completed naturally, the caller
+            # ``break``-ed early, or our task was cancelled.  In the
+            # latter two cases the engine is still running — tell it to
+            # stop so nodes stop getting dispatched.  ``run_task`` may
+            # take up to one node's worth of runtime to actually finish,
+            # which is the same bound the sync variant documents.
+            if not run_task.done():
+                try:
+                    runner.stop(flow_id)
+                except Exception:  # pragma: no cover — defensive
+                    logger.exception(
+                        "arun.stream: runner.stop(%s) raised", flow_id
+                    )
+                # Wait (bounded) for the worker thread to observe the
+                # ``_stopped`` flag and return.  If it overshoots we let
+                # the task leak rather than blocking the event loop
+                # indefinitely — matches the 5s join() on the sync side.
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(run_task), timeout=5.0
+                    )
+                except asyncio.TimeoutError:  # pragma: no cover — defensive
+                    logger.warning(
+                        "arun.stream: runner thread did not exit within 5s"
+                    )
+                except asyncio.CancelledError:
+                    # Expected when the outer task was cancelled — let
+                    # the shielded run_task keep going in the background
+                    # (it will notice ``_stopped`` and bail on its next
+                    # node).  Re-raise so the cancellation semantics
+                    # propagate to the caller.
+                    raise
+
+        exception = holder.get("exception")
+        fr = holder.get("result")
+
+        if exception is not None:
+            yield ErrorChunk(error=str(exception))
+            return
+
+        if fr is None:
+            yield ErrorChunk(error="arun.stream: runner produced no result")
+            return
+
+        yield DoneChunk(result=Result.from_flow_result(fr))
+
+
+#: Publicly exported async runner.  ``await qm.arun(graph, input)`` runs
+#: the flow on a worker thread and awaits its result; ``async for
+#: chunk in qm.arun.stream(graph, input)`` yields typed Chunk objects.
+arun = _ARunCallable()
+
+
+__all__ = ["arun"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -29,15 +29,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING, Any, AsyncIterator
 from uuid import uuid4
 
 from quartermaster_engine import FlowEvent, FlowRunner
 
+from . import _listeners
 from ._chunks import Chunk, DoneChunk, ErrorChunk
 from ._config import get_default_registry
 from ._result import Result
 from ._runner import _event_to_chunk, _resolve_graph
+from ._stream_filters import _AsyncStream
+from ._trace import Trace
 
 if TYPE_CHECKING:
     from quartermaster_graph import GraphBuilder, GraphSpec
@@ -85,6 +89,11 @@ class _ARunCallable:
             graph=spec,
             provider_registry=registry,
             tool_registry=tool_registry,
+            # Forward every event to the global listener registry so
+            # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
+            # observes the same FlowEvent stream the streaming runner
+            # gets — even though there's no consumer queue here.
+            on_event=_listeners.dispatch,
         )
         # Pre-generate so the async cancel handler has something to stop,
         # even if the to_thread() call hasn't entered ``runner.run`` yet.
@@ -108,15 +117,22 @@ class _ARunCallable:
 
         return Result.from_flow_result(fr)
 
-    async def stream(
+    def stream(
         self,
         graph: GraphBuilder | GraphSpec,
         user_input: str = "",
         *,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
-    ) -> AsyncIterator[Chunk]:
+    ) -> _AsyncStream:
         """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Returns an :class:`_AsyncStream` wrapper that is itself
+        async-iterable (so existing ``async for chunk in
+        qm.arun.stream(...)`` loops work unchanged) and exposes filter
+        helpers — ``.tokens()``, ``.tool_calls()``, ``.progress()``,
+        ``.custom(name=...)`` — for the common "pluck one chunk type
+        out of the stream" patterns.
 
         Terminates with a :class:`DoneChunk` (on success) or
         :class:`ErrorChunk` (on unrecoverable failure).  The graph
@@ -133,6 +149,26 @@ class _ARunCallable:
         loops unwind within a bounded time instead of leaking API costs
         after the consumer goes away.
         """
+        return _AsyncStream(self._aiter_chunks(
+            graph=graph,
+            user_input=user_input,
+            provider_registry=provider_registry,
+            tool_registry=tool_registry,
+        ))
+
+    async def _aiter_chunks(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> AsyncIterator[Chunk]:
+        """Inner async generator that powers :meth:`stream`.
+
+        Kept private: callers always go through ``stream()`` which
+        wraps the result in :class:`_AsyncStream` for filter support.
+        """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
 
@@ -146,6 +182,10 @@ class _ARunCallable:
         flow_id = uuid4()
 
         def on_event(event: FlowEvent) -> None:
+            # Fan out to bolt-on instrumentation (telemetry, custom
+            # listeners, etc.) on the engine's worker thread BEFORE
+            # marshalling the event back to the consumer's loop.
+            _listeners.dispatch(event)
             # Called from the engine's worker threads.  Hop back to the
             # consumer's loop so Queue.put() touches only loop-owned
             # state — ``asyncio.Queue`` is not thread-safe.

--- a/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
@@ -1,0 +1,137 @@
+"""Typed stream-chunk classes for :func:`quartermaster_sdk.run.stream`.
+
+v0.2.0 wraps :class:`quartermaster_engine.FlowEvent` into a small typed
+discriminated union so callers can pattern-match on ``chunk.type`` without
+needing to know about the underlying engine event hierarchy.  The mapping:
+
+``FlowEvent``                           → ``Chunk``
+``TokenGenerated``                      → :class:`TokenChunk`
+``NodeStarted``                         → :class:`NodeStartChunk`
+``NodeFinished``                        → :class:`NodeFinishChunk`
+``FlowFinished``                        → :class:`DoneChunk`
+``FlowError``                           → :class:`ErrorChunk`
+``UserInputRequired``                   → :class:`AwaitInputChunk`
+tool-call inside an ``AgentExecutor``   → :class:`ToolCallChunk` + :class:`ToolResultChunk`
+                                          (future; currently surface via
+                                          ``NodeFinishChunk.node_name``.)
+
+The classes are intentionally flat dataclasses — callers can compare
+``chunk.type`` against literal strings (``"token"``, ``"done"``, etc.) or do
+``isinstance(chunk, TokenChunk)``; both styles work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, Union
+
+if TYPE_CHECKING:
+    from ._result import Result
+
+
+@dataclass
+class TokenChunk:
+    """Streaming text token from an LLM node."""
+
+    content: str
+    node_name: str | None = None
+    type: Literal["token"] = "token"
+
+
+@dataclass
+class NodeStartChunk:
+    """A node has begun executing."""
+
+    node_name: str
+    node_type: str
+    type: Literal["node_start"] = "node_start"
+
+
+@dataclass
+class NodeFinishChunk:
+    """A node has finished executing.
+
+    ``output`` is the string output of the node (may be empty).  For
+    LLM nodes this is the full assembled text; for tool or decision
+    nodes it's whatever the executor wrote to ``NodeResult.output_text``.
+    """
+
+    node_name: str
+    output: str = ""
+    type: Literal["node_finish"] = "node_finish"
+
+
+@dataclass
+class ToolCallChunk:
+    """The agent executor requested a tool call."""
+
+    tool: str
+    args: dict[str, Any] = field(default_factory=dict)
+    type: Literal["tool_call"] = "tool_call"
+
+
+@dataclass
+class ToolResultChunk:
+    """A tool call completed with a result (or an error payload)."""
+
+    tool: str
+    result: Any = None
+    error: str | None = None
+    type: Literal["tool_result"] = "tool_result"
+
+
+@dataclass
+class AwaitInputChunk:
+    """A ``User`` node is waiting for a ``runner.resume`` call."""
+
+    prompt: str
+    options: list[str] = field(default_factory=list)
+    type: Literal["await_input"] = "await_input"
+
+
+@dataclass
+class DoneChunk:
+    """The flow finished — carries the final :class:`Result`."""
+
+    result: Result
+    type: Literal["done"] = "done"
+
+
+@dataclass
+class ErrorChunk:
+    """The flow failed with an unrecoverable error."""
+
+    error: str
+    node_name: str | None = None
+    type: Literal["error"] = "error"
+
+
+Chunk = Union[
+    TokenChunk,
+    NodeStartChunk,
+    NodeFinishChunk,
+    ToolCallChunk,
+    ToolResultChunk,
+    AwaitInputChunk,
+    DoneChunk,
+    ErrorChunk,
+]
+"""Discriminated union of every chunk a stream can yield.
+
+Callers usually pattern-match on ``chunk.type`` — the literal strings are
+``"token"``, ``"node_start"``, ``"node_finish"``, ``"tool_call"``,
+``"tool_result"``, ``"await_input"``, ``"done"``, ``"error"``.
+"""
+
+
+__all__ = [
+    "Chunk",
+    "TokenChunk",
+    "NodeStartChunk",
+    "NodeFinishChunk",
+    "ToolCallChunk",
+    "ToolResultChunk",
+    "AwaitInputChunk",
+    "DoneChunk",
+    "ErrorChunk",
+]

--- a/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_chunks.py
@@ -90,6 +90,42 @@ class AwaitInputChunk:
 
 
 @dataclass
+class ProgressChunk:
+    """Application-emitted progress signal.
+
+    Fires whenever code inside a node or tool called
+    :meth:`ExecutionContext.emit_progress` — typically a long-running
+    tool (``web_search``, OCR, multi-step lookup) reporting status to
+    the UI alongside model tokens. ``percent`` is ``None`` for
+    indeterminate / spinner-style progress or a 0.0–1.0 float for a
+    determinate progress bar. ``data`` is a free-form dict for
+    structured payload fields.
+    """
+
+    message: str
+    percent: float | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+    type: Literal["progress"] = "progress"
+
+
+@dataclass
+class CustomChunk:
+    """Application-defined structured event.
+
+    Fires when node/tool code calls
+    :meth:`ExecutionContext.emit_custom`. Use this over
+    :class:`ProgressChunk` when the signal is a discrete milestone
+    ("retrieved_docs", "cache_hit", "quota_warning") rather than a
+    percent-along-a-task signal. Consumers filter on ``name`` via
+    ``stream.custom(name=...)``.
+    """
+
+    name: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    type: Literal["custom"] = "custom"
+
+
+@dataclass
 class DoneChunk:
     """The flow finished — carries the final :class:`Result`."""
 
@@ -113,6 +149,8 @@ Chunk = Union[
     ToolCallChunk,
     ToolResultChunk,
     AwaitInputChunk,
+    ProgressChunk,
+    CustomChunk,
     DoneChunk,
     ErrorChunk,
 ]
@@ -132,6 +170,8 @@ __all__ = [
     "ToolCallChunk",
     "ToolResultChunk",
     "AwaitInputChunk",
+    "ProgressChunk",
+    "CustomChunk",
     "DoneChunk",
     "ErrorChunk",
 ]

--- a/quartermaster-sdk/src/quartermaster_sdk/_config.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_config.py
@@ -1,0 +1,158 @@
+"""Module-level configuration for the v0.2.0 ergonomic API.
+
+Callers set up their provider once at app boot:
+
+    import quartermaster_sdk as qm
+    qm.configure(
+        provider="ollama",
+        base_url="http://localhost:11434",    # or $OLLAMA_HOST
+        default_model="gemma4:26b",           # or $QM_DEFAULT_MODEL
+    )
+
+Every subsequent ``qm.run(...)``, ``qm.instruction(...)``,
+``qm.instruction_form(...)`` call picks this up automatically.  Per-call
+overrides (``model="other"``, ``provider="anthropic"``) still work and
+take precedence.
+
+The design mirrors how ``openai.OpenAI()`` and ``anthropic.Anthropic()``
+clients are typically used in real codebases — one construct at boot,
+reused everywhere else.
+
+**Deployment note:** the configured registry lives in module-level
+globals.  Under pre-fork ASGI servers (``gunicorn -w 4``, Uvicorn with
+``--workers``) each worker has its own copy — calling :func:`configure`
+in the parent process before ``fork`` is visible to the children, but
+calling it after fork only affects that worker.  Best practice: call
+:func:`configure` inside your ASGI lifespan startup hook rather than at
+module import time.  Single-process servers (``uvicorn app:api``) and
+Celery workers are unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from quartermaster_providers import ProviderRegistry, register_local
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton state.  Threading note: writes from ``configure()``
+# are not serialised — call it once at startup, not from worker threads.
+_default_registry: ProviderRegistry | None = None
+_default_model: str | None = None
+
+
+def configure(
+    *,
+    provider: str = "ollama",
+    base_url: str | None = None,
+    api_key: str | None = None,
+    default_model: str | None = None,
+    registry: ProviderRegistry | None = None,
+) -> ProviderRegistry:
+    """Bind a default provider registry for subsequent ``qm.*`` calls.
+
+    Args:
+        provider: ``"ollama"``, ``"vllm"``, ``"lm-studio"``, ``"tgi"``,
+            ``"localai"``, ``"llama-cpp"``, or ``"custom"``.  For
+            cloud-hosted providers (openai / anthropic / groq / xai)
+            register them via :class:`ProviderRegistry` directly and
+            pass the result as *registry*.
+        base_url: Endpoint URL.  Falls back to ``$OLLAMA_HOST`` when
+            provider is ``"ollama"`` and no value is passed.
+        api_key: Auth token for providers that need one.
+        default_model: Model to use when a call doesn't pass ``model=``.
+            Falls back to ``$QM_DEFAULT_MODEL``.
+        registry: Hand in a fully-built registry instead of having
+            ``configure`` build one.  Mutually exclusive with
+            ``base_url`` / ``api_key``.
+
+    Returns:
+        The bound :class:`ProviderRegistry` — useful for tests that
+        want to introspect it.
+    """
+    global _default_registry, _default_model
+
+    resolved_default_model = default_model or os.environ.get("QM_DEFAULT_MODEL")
+
+    if registry is not None:
+        if base_url is not None or api_key is not None:
+            raise ValueError(
+                "configure(): pass either registry= OR base_url/api_key, not both."
+            )
+        _default_registry = registry
+    else:
+        # Let OllamaProvider pick up $OLLAMA_HOST when base_url is unset —
+        # that's already the provider's documented behaviour.
+        _default_registry = register_local(
+            provider,
+            base_url=base_url,
+            api_key=api_key,
+            default_model=resolved_default_model,
+        )
+
+    _default_model = resolved_default_model
+    logger.info(
+        "quartermaster_sdk configured: provider=%s default_model=%s",
+        provider,
+        resolved_default_model,
+    )
+    return _default_registry
+
+
+def get_default_registry() -> ProviderRegistry:
+    """Return the module-level default registry or raise a helpful error."""
+    if _default_registry is None:
+        raise RuntimeError(
+            "No default provider registry configured. Call "
+            "quartermaster_sdk.configure(provider='ollama', default_model=...) "
+            "once at app boot, or pass provider_registry= explicitly to run()."
+        )
+    return _default_registry
+
+
+def get_default_model() -> str | None:
+    """Return the module-level default model name, if set.
+
+    Resolution order:
+
+    1. The explicit ``default_model=`` passed to :func:`configure`, or
+       ``$QM_DEFAULT_MODEL`` env var it picked up.
+    2. The default model registered on the provider registry itself
+       (e.g. via ``register_local("ollama", default_model=...)`` or
+       ``registry.set_default_model("ollama", "gemma4:26b")``).
+    3. ``None`` — callers then have to pass ``model=`` per call.
+    """
+    if _default_model is not None:
+        return _default_model
+    if _default_registry is not None:
+        # ``ProviderRegistry.get_default_model()`` returns the fallback
+        # provider's default model.  We narrow the catch so real bugs
+        # (e.g. a registry that overrides the method with the wrong
+        # signature) surface instead of being silently swallowed as
+        # "no default".
+        try:
+            return _default_registry.get_default_model()
+        except (AttributeError, TypeError) as exc:
+            logger.warning(
+                "Configured registry does not expose a usable get_default_model(): %s",
+                exc,
+            )
+            return None
+    return None
+
+
+def reset_config() -> None:
+    """Clear the configured registry — used by tests to start fresh."""
+    global _default_registry, _default_model
+    _default_registry = None
+    _default_model = None
+
+
+__all__ = [
+    "configure",
+    "get_default_registry",
+    "get_default_model",
+    "reset_config",
+]

--- a/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
@@ -1,0 +1,226 @@
+"""Top-level single-shot helpers: :func:`instruction`, :func:`instruction_form`.
+
+These wrap a single-node graph so callers never touch ``Graph``,
+``FlowRunner``, or ``register_local`` for the 90% of use-cases that are
+just ``prompt → text`` or ``prompt → typed JSON``.
+
+The docs / Sorex feedback called this "the thing we'd actually write";
+v0.2.0 ships it as the primary recommended API for non-agentic calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, TypeVar
+
+from quartermaster_graph import Graph
+
+from ._config import get_default_model
+from ._runner import run
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+    from quartermaster_providers import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+T = TypeVar("T", bound="BaseModel")
+
+
+# Match an opening ```lang\n (or ``` alone) at the start of a response and
+# a closing ``` at the end, leaving any triple-backtick-looking characters
+# INSIDE the JSON alone.  ``str.strip("`")`` would eat backticks out of
+# string values (e.g. SQL or regex examples quoted in the JSON body);
+# this regex pair targets only the fence itself.
+_MD_FENCE_OPEN_RE = re.compile(r"\A\s*```[A-Za-z0-9_-]*\s*\n?")
+_MD_FENCE_CLOSE_RE = re.compile(r"\n?\s*```\s*\Z")
+
+
+def _strip_markdown_fence(raw: str) -> str:
+    """Remove a leading ``` fence (with optional language tag) and a trailing ``` fence.
+
+    Preserves every backtick that appears inside the fenced content —
+    ``re.sub(r'^```[lang]\\n?', '')`` + ``re.sub(r'\\n?```$', '')`` rather
+    than the pre-0.2.0 naive ``str.strip("`")`` which corrupted JSON
+    strings containing literal backticks.
+    """
+    text = _MD_FENCE_OPEN_RE.sub("", raw)
+    text = _MD_FENCE_CLOSE_RE.sub("", text)
+    return text.strip()
+
+
+def instruction(
+    *,
+    user: str,
+    system: str = "",
+    model: str | None = None,
+    provider: str = "",
+    temperature: float = 0.7,
+    max_output_tokens: int | None = None,
+    thinking_level: str = "off",
+    provider_registry: ProviderRegistry | None = None,
+) -> str:
+    """Single-shot prompt → text.
+
+    Builds a one-node ``Instruction`` graph under the hood, runs it,
+    and returns the final assistant text.  The ``user`` kwarg is the
+    primary user message — no ``.user()`` node boilerplate.
+
+    Args:
+        user: The user message / prompt.  **Required.**
+        system: System instruction steering the model.
+        model: Model identifier.  Falls back to the ``default_model`` set
+            via :func:`configure` or ``$QM_DEFAULT_MODEL``.
+        provider: Optional explicit provider name.  Leave blank for
+            auto-resolution from the registry.
+        temperature: Sampling temperature.
+        max_output_tokens: Hard cap on output tokens.
+        thinking_level: ``off``/``low``/``medium``/``high`` — forwarded
+            to reasoning-capable models.
+        provider_registry: Override the module-level default registry.
+
+    Returns:
+        The assistant's reply as a plain ``str``.  Raises
+        ``RuntimeError`` when the underlying flow fails.
+    """
+    resolved_model = model or get_default_model()
+    if not resolved_model:
+        raise ValueError(
+            "instruction(): no model resolved. Pass model=... or call "
+            "quartermaster_sdk.configure(default_model=...) at app boot."
+        )
+
+    graph = (
+        Graph("instruction")
+        .instruction(
+            "Instruction",
+            model=resolved_model,
+            provider=provider,
+            temperature=temperature,
+            system_instruction=system,
+            max_output_tokens=max_output_tokens,
+            thinking_level=thinking_level,
+        )
+        .build()
+    )
+
+    result = run(graph, user, provider_registry=provider_registry)
+    if not result.success:
+        raise RuntimeError(f"instruction() failed: {result.error}")
+    return result.text
+
+
+def instruction_form(
+    schema: type[T],
+    *,
+    user: str,
+    system: str = "",
+    model: str | None = None,
+    provider: str = "",
+    temperature: float = 0.1,
+    max_output_tokens: int | None = None,
+    provider_registry: ProviderRegistry | None = None,
+) -> T:
+    """Single-shot prompt → Pydantic model.
+
+    Runs the prompt through a one-node instruction graph, then parses
+    the LLM's JSON output into *schema* via ``model_validate_json``.
+    Default temperature is 0.1 — structured extraction benefits from
+    the more-deterministic end of the range.
+
+    The helper injects the schema into the system prompt so the LLM
+    knows what JSON shape to return; callers don't need to describe
+    the format themselves.
+
+    Args:
+        schema: A Pydantic v2 ``BaseModel`` subclass describing the
+            output shape.  **Required.**
+        user: The user message / prompt.  **Required.**
+        system: Instruction steering the extraction (e.g. "Classify
+            this email...").  The schema description is appended
+            automatically.
+        model: Model identifier (falls back to the configured default).
+        temperature: Sampling temperature — default 0.1 for
+            determinism.
+
+    Returns:
+        An instance of *schema* populated from the LLM's output.
+
+    Raises:
+        ValueError: ``schema`` isn't a Pydantic ``BaseModel`` subclass.
+        RuntimeError: the underlying flow failed, or the model's output
+            couldn't be parsed into *schema* (raises a
+            ``ValidationError``-wrapping ``RuntimeError`` with the raw
+            text attached for debugging).
+
+    .. warning::
+        The schema's JSON representation is injected **verbatim** into
+        the system prompt so the LLM knows the target shape.  That
+        includes every field's ``description=`` and ``default=``
+        metadata.  If your Pydantic model derives descriptions from
+        external / attacker-influenced sources (rare but not unheard of
+        in code-generation pipelines), an attacker could use them as an
+        indirect-prompt-injection channel.  Keep ``Field(description=)``
+        values static / developer-controlled.
+    """
+    try:
+        from pydantic import BaseModel, ValidationError
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover — pydantic is a hard dep of many ecosystems
+        raise ImportError(
+            "instruction_form() requires pydantic. Install with `pip install pydantic`."
+        ) from exc
+
+    if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
+        raise ValueError(
+            f"instruction_form(schema=...) must be a pydantic.BaseModel "
+            f"subclass; got {type(schema).__name__}"
+        )
+
+    # Inject a JSON-schema hint into the system prompt so the model
+    # knows what fields are expected.  Keep this short — bloating the
+    # system prompt with a giant schema eats context.
+    try:
+        schema_json = json.dumps(schema.model_json_schema(), separators=(",", ":"))
+    except Exception:
+        schema_json = str(schema.__name__)
+
+    full_system = (
+        f"{system}\n\n"
+        "Respond with a single JSON object matching this schema. "
+        "Do not wrap the JSON in markdown code fences. Do not emit any "
+        "text outside the JSON object.\n\n"
+        f"Schema: {schema_json}"
+    ).strip()
+
+    raw = instruction(
+        user=user,
+        system=full_system,
+        model=model,
+        provider=provider,
+        temperature=temperature,
+        max_output_tokens=max_output_tokens,
+        thinking_level="off",
+        provider_registry=provider_registry,
+    )
+
+    # Strip fences in case the model insists on markdown despite instructions.
+    # Uses a regex-anchored pattern — the pre-0.2.0 ``str.strip("`")`` ate
+    # backticks out of string values (code snippets, regex examples) and
+    # corrupted the JSON before parsing could see it.
+    cleaned = _strip_markdown_fence(raw)
+
+    try:
+        return schema.model_validate_json(cleaned)
+    except ValidationError as exc:
+        raise RuntimeError(
+            f"instruction_form(): model output did not match schema "
+            f"{schema.__name__}. Raw output:\n{raw}\n\nValidation errors:\n{exc}"
+        ) from exc
+
+
+__all__ = ["instruction", "instruction_form"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_listeners.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_listeners.py
@@ -1,0 +1,83 @@
+"""Process-global ``FlowEvent`` listener registry.
+
+Lets the SDK fan out a single :class:`FlowEvent` to many subscribers
+without each subscriber needing to thread its own ``on_event=`` callback
+through every ``run`` / ``arun`` / ``run.stream`` call site.
+
+This is the seam :mod:`quartermaster_sdk.telemetry` (and any other
+bolt-on instrumentation) hooks into via :func:`register` / :func:`unregister`.
+The two SDK runners (:mod:`._runner` and :mod:`._async_runner`) call
+:func:`dispatch` from inside the existing ``on_event`` callback they
+already pass to :class:`FlowRunner`, so we never have to reach into the
+engine itself to install a global handler.
+
+**Scope:** single-process. The list lives in module-level state guarded
+by a :class:`threading.Lock`; cross-process fan-out (e.g. distributed
+tracing across worker pools) is the responsibility of whatever exporter
+the listener wires up to.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable
+
+from quartermaster_engine import FlowEvent
+
+logger = logging.getLogger(__name__)
+
+#: Registered listeners. Mutated under :data:`_lock`; read under the
+#: lock too, then iterated outside the critical section so a slow
+#: handler can't stall a concurrent ``register`` / ``unregister`` call.
+_global_listeners: list[Callable[[FlowEvent], None]] = []
+_lock = threading.Lock()
+
+
+def register(fn: Callable[[FlowEvent], None]) -> None:
+    """Add *fn* to the process-global listener list.
+
+    Idempotent: registering the same callable twice is a no-op so
+    callers don't accidentally double-subscribe (which would emit
+    duplicate spans on every event).
+    """
+    with _lock:
+        if fn not in _global_listeners:
+            _global_listeners.append(fn)
+
+
+def unregister(fn: Callable[[FlowEvent], None]) -> None:
+    """Remove *fn* from the listener list. Silent if not registered."""
+    with _lock:
+        try:
+            _global_listeners.remove(fn)
+        except ValueError:
+            pass
+
+
+def dispatch(event: FlowEvent) -> None:
+    """Fan out *event* to every registered listener.
+
+    Exceptions raised by a listener are logged and swallowed — one
+    misbehaving subscriber must not break the SDK runner or starve
+    other subscribers of the same event.
+    """
+    # Snapshot under the lock so we never iterate a list someone is
+    # mutating; emit outside the lock so a slow listener can't block
+    # ``register`` / ``unregister`` from the instrumenting code.
+    with _lock:
+        listeners = list(_global_listeners)
+    for fn in listeners:
+        try:
+            fn(event)
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("Listener %r raised on %r", fn, type(event).__name__)
+
+
+def clear() -> None:
+    """Drop every listener. Test-only helper; not part of the public API."""
+    with _lock:
+        _global_listeners.clear()
+
+
+__all__ = ["register", "unregister", "dispatch", "clear"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_result.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_result.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from ._trace import Trace
+
 if TYPE_CHECKING:
     from quartermaster_engine import FlowResult
     from quartermaster_engine.nodes import NodeResult
@@ -49,6 +51,14 @@ class Result:
         error: Concatenated error messages from any failed node, or
             ``None`` on success.
         duration_seconds: Wall-clock time the flow took to execute.
+        trace: Structured :class:`Trace` carrying every
+            :class:`FlowEvent` emitted during the run — tokens, tool
+            calls, progress, custom events, per-node buckets, and a
+            JSONL exporter.  Populated by the runner (both sync and
+            streaming paths install an ``on_event`` collector); defaults
+            to an empty :class:`Trace` when a :class:`Result` is built
+            from just a :class:`FlowResult` without runner-captured
+            events.
         raw: The underlying :class:`FlowResult` — escape hatch when you
             need UUID-keyed ``node_results`` or the full ``output_data``
             maps.
@@ -59,6 +69,7 @@ class Result:
     success: bool = True
     error: str | None = None
     duration_seconds: float = 0.0
+    trace: Trace = field(default_factory=Trace)
     raw: FlowResult | None = None
 
     def __getitem__(self, name: str) -> NodeResult:

--- a/quartermaster-sdk/src/quartermaster_sdk/_result.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_result.py
@@ -1,0 +1,91 @@
+"""The v0.2.0 integrator-facing :class:`Result` type.
+
+Wraps :class:`quartermaster_engine.FlowResult` with a nicer public
+surface.  ``FlowResult.node_results`` is UUID-keyed (good for debugging
+tooling); the :class:`Result` here puts name-keyed ``captures`` front-
+and-centre so callers can write ``result["research"].output_text``
+instead of iterating ``for uuid, r in flow_result.node_results.items():
+if r.node_type == NodeType.INSTRUCTION_FORM: ...``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from quartermaster_engine import FlowResult
+    from quartermaster_engine.nodes import NodeResult
+
+
+def format_missing_capture_error(name: str, captures: dict[str, "NodeResult"]) -> str:
+    """Shared error-message formatter for missing capture keys.
+
+    Used by both :class:`Result.__getitem__` here and
+    :class:`FlowResult.__getitem__` in the engine — kept in this module
+    because the engine imports *from* the SDK only via public API, and
+    duplicating the string was flagged by the v0.2.0 reviewer as a
+    maintenance footgun (changing wording in one spot would leave the
+    other silently out of date).
+    """
+    available = ", ".join(sorted(captures)) or "(no captures registered)"
+    return f"No capture named {name!r}. Available captures: {available}"
+
+
+@dataclass
+class Result:
+    """Run result — what :func:`run` returns.
+
+    Attributes:
+        text: Final text output of the flow.  Equivalent to
+            ``FlowResult.final_output``.  For graphs without an End
+            node, this is the output of the last finished node.
+        captures: Dict of ``capture_as="name"`` → :class:`NodeResult`
+            for every node the graph-builder tagged.  Access via
+            ``result.captures["notes"].output_text`` or the shorthand
+            ``result["notes"]``.
+        success: ``True`` when every node finished without a ``STOP``
+            strategy error bubbling up.
+        error: Concatenated error messages from any failed node, or
+            ``None`` on success.
+        duration_seconds: Wall-clock time the flow took to execute.
+        raw: The underlying :class:`FlowResult` — escape hatch when you
+            need UUID-keyed ``node_results`` or the full ``output_data``
+            maps.
+    """
+
+    text: str
+    captures: dict[str, NodeResult] = field(default_factory=dict)
+    success: bool = True
+    error: str | None = None
+    duration_seconds: float = 0.0
+    raw: FlowResult | None = None
+
+    def __getitem__(self, name: str) -> NodeResult:
+        """``result["notes"]`` → the captured NodeResult.
+
+        Raises ``KeyError`` with a list of known capture names on miss
+        so the caller can see immediately which key they meant.
+        """
+        try:
+            return self.captures[name]
+        except KeyError:
+            raise KeyError(format_missing_capture_error(name, self.captures)) from None
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.captures
+
+    @classmethod
+    def from_flow_result(cls, fr: FlowResult) -> Result:
+        """Build a :class:`Result` from the underlying :class:`FlowResult`."""
+        return cls(
+            text=fr.final_output,
+            captures=dict(fr.captures),
+            success=fr.success,
+            error=fr.error,
+            duration_seconds=fr.duration_seconds,
+            raw=fr,
+        )
+
+
+__all__ = ["Result", "format_missing_capture_error"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -22,35 +22,43 @@ from __future__ import annotations
 import logging
 import queue
 import threading
+import time
 from typing import TYPE_CHECKING, Any, Iterator
 from uuid import uuid4
 
 from quartermaster_engine import (
+    CustomEvent,
     FlowError,
     FlowEvent,
     FlowFinished,
     FlowRunner,
     NodeFinished,
     NodeStarted,
+    ProgressEvent,
     TokenGenerated,
     ToolCallFinished,
     ToolCallStarted,
     UserInputRequired,
 )
 
+from . import _listeners
 from ._chunks import (
     AwaitInputChunk,
     Chunk,
+    CustomChunk,
     DoneChunk,
     ErrorChunk,
     NodeFinishChunk,
     NodeStartChunk,
+    ProgressChunk,
     TokenChunk,
     ToolCallChunk,
     ToolResultChunk,
 )
 from ._config import get_default_registry
 from ._result import Result
+from ._stream_filters import _Stream
+from ._trace import Trace
 
 if TYPE_CHECKING:
     from quartermaster_graph import GraphBuilder, GraphSpec
@@ -94,13 +102,40 @@ class _RunCallable:
         """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
+
+        # v0.3.0 trace: accumulate every FlowEvent into a local list
+        # so we can build a ``Trace`` and attach it to the returned
+        # ``Result``. Fires alongside the global listener dispatch so
+        # bolt-on instrumentation still sees the same stream.
+        trace_events: list[FlowEvent] = []
+
+        def _collect(event: FlowEvent) -> None:
+            trace_events.append(event)
+            _listeners.dispatch(event)
+
         runner = FlowRunner(
             graph=spec,
             provider_registry=registry,
             tool_registry=tool_registry,
+            # Forward every event to the global listener registry so
+            # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
+            # observes the same FlowEvent stream the streaming runner
+            # gets — even though there's no consumer queue here.
+            on_event=_collect,
         )
+        started = time.perf_counter()
         fr = runner.run(user_input)
-        return Result.from_flow_result(fr)
+        elapsed = time.perf_counter() - started
+
+        result = Result.from_flow_result(fr)
+        # FlowResult's ``duration_seconds`` is authoritative when
+        # populated; fall back to our wall-clock measurement for the
+        # trace if the engine left it at 0.
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        return result
 
     def stream(
         self,
@@ -109,8 +144,15 @@ class _RunCallable:
         *,
         provider_registry: ProviderRegistry | None = None,
         tool_registry: Any | None = None,
-    ) -> Iterator[Chunk]:
+    ) -> _Stream:
         """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Returns a :class:`_Stream` wrapper that is itself iterable (so
+        existing ``for chunk in qm.run.stream(...)`` loops work
+        unchanged) and exposes filter helpers — ``.tokens()``,
+        ``.tool_calls()``, ``.progress()``, ``.custom(name=...)`` —
+        for the common "pluck one chunk type out of the stream"
+        patterns.
 
         Terminates with a :class:`DoneChunk` (on success) or
         :class:`ErrorChunk` (on unrecoverable failure).  The graph
@@ -126,6 +168,26 @@ class _RunCallable:
         nodes are dispatched, so long agent loops unwind within a
         bounded time instead of leaking API costs in the background.
         """
+        return _Stream(self._iter_chunks(
+            graph=graph,
+            user_input=user_input,
+            provider_registry=provider_registry,
+            tool_registry=tool_registry,
+        ))
+
+    def _iter_chunks(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Iterator[Chunk]:
+        """Inner generator that powers :meth:`stream`.
+
+        Kept private: callers always go through ``stream()`` which
+        wraps the result in :class:`_Stream` for filter support.
+        """
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
 
@@ -140,7 +202,18 @@ class _RunCallable:
         # reaching into a private attribute.
         flow_id = uuid4()
 
+        # v0.3.0 trace: same collector the sync path uses, populated in
+        # arrival order on the runner thread. Safe to append from the
+        # event thread and read from the iterator thread because the
+        # final ``Trace`` is only built AFTER the runner thread joins.
+        trace_events: list[FlowEvent] = []
+
         def on_event(event: FlowEvent) -> None:
+            # Fan out to bolt-on instrumentation (telemetry, custom
+            # listeners, etc.) BEFORE queuing for the iterator — keeps
+            # the listener wall-clock close to the original event time.
+            _listeners.dispatch(event)
+            trace_events.append(event)
             q.put(event)
 
         runner = FlowRunner(
@@ -166,6 +239,7 @@ class _RunCallable:
                 q.put(None)
 
         thread = threading.Thread(target=_run_thread, name="qm-run-stream", daemon=True)
+        started = time.perf_counter()
         thread.start()
 
         try:
@@ -206,7 +280,17 @@ class _RunCallable:
             yield ErrorChunk(error="run.stream: runner produced no result")
             return
 
-        yield DoneChunk(result=Result.from_flow_result(fr))
+        elapsed = time.perf_counter() - started
+        result = Result.from_flow_result(fr)
+        # v0.3.0: populate the structured trace from the accumulated
+        # event stream. The collector callback appended every FlowEvent
+        # as it fired; we build the bucketed/by-node view once and
+        # attach before handing the caller the DoneChunk.
+        result.trace = Trace.from_events(
+            trace_events,
+            duration_seconds=fr.duration_seconds or elapsed,
+        )
+        yield DoneChunk(result=result)
 
 
 def _event_to_chunk(event: FlowEvent) -> Chunk | None:
@@ -243,6 +327,24 @@ def _event_to_chunk(event: FlowEvent) -> Chunk | None:
             tool=event.tool,
             result=event.raw if event.raw is not None else event.result,
             error=event.error,
+        )
+    if isinstance(event, ProgressEvent):
+        # Application-emitted progress signal (e.g. from inside a
+        # long-running tool). Interleaves with TokenChunk on the
+        # consumer's iterator — UIs can render "searching…" /
+        # "parsing…" cards without interrupting the model tokens.
+        return ProgressChunk(
+            message=event.message,
+            percent=event.percent,
+            data=dict(event.data),
+        )
+    if isinstance(event, CustomEvent):
+        # Caller-tagged structured event — consumers filter via
+        # ``stream.custom(name="retrieved_docs")`` for the specific
+        # milestone they care about.
+        return CustomChunk(
+            name=event.name,
+            payload=dict(event.payload),
         )
     if isinstance(event, UserInputRequired):
         return AwaitInputChunk(

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -33,6 +33,8 @@ from quartermaster_engine import (
     NodeFinished,
     NodeStarted,
     TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
     UserInputRequired,
 )
 
@@ -44,6 +46,8 @@ from ._chunks import (
     NodeFinishChunk,
     NodeStartChunk,
     TokenChunk,
+    ToolCallChunk,
+    ToolResultChunk,
 )
 from ._config import get_default_registry
 from ._result import Result
@@ -222,6 +226,23 @@ def _event_to_chunk(event: FlowEvent) -> Chunk | None:
         return NodeFinishChunk(
             node_name=getattr(event, "node_name", ""),
             output=event.result or "",
+        )
+    if isinstance(event, ToolCallStarted):
+        # Live "tool is being called now" card — fires before the tool
+        # actually runs.  Arguments are passed straight through so UIs
+        # can render them the moment the call is dispatched, instead of
+        # waiting for the final NodeFinish / Done event.
+        return ToolCallChunk(tool=event.tool, args=dict(event.arguments))
+    if isinstance(event, ToolCallFinished):
+        # Paired with ToolCallStarted.  ``result`` is the string the LLM
+        # sees next turn (``"[ERROR: ...]"`` sentinel on failure);
+        # ``raw`` is the structured payload when the tool returned one,
+        # ``None`` otherwise.  ``error`` is non-None only on failure —
+        # UIs can use it as the "red card" trigger.
+        return ToolResultChunk(
+            tool=event.tool,
+            result=event.raw if event.raw is not None else event.result,
+            error=event.error,
         )
     if isinstance(event, UserInputRequired):
         return AwaitInputChunk(

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -1,0 +1,246 @@
+"""The v0.2.0 ergonomic graph runner.
+
+Replaces the "import FlowRunner, build a node registry, construct the
+runner, call .run()" dance with a one-liner:
+
+    from quartermaster_sdk import Graph, run
+
+    graph = Graph("chat").user().agent().build()
+    result = run(graph, "Hello!")                 # sync
+    for chunk in run.stream(graph, "Hello!"):    # streaming
+        if chunk.type == "token":
+            print(chunk.content, end="")
+
+Provider is picked up from :func:`configure` or the
+``provider_registry=`` kwarg; no need for the integrator to touch
+``quartermaster_engine.FlowRunner`` or
+``quartermaster_engine.build_default_registry`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from typing import TYPE_CHECKING, Any, Iterator
+from uuid import uuid4
+
+from quartermaster_engine import (
+    FlowError,
+    FlowEvent,
+    FlowFinished,
+    FlowRunner,
+    NodeFinished,
+    NodeStarted,
+    TokenGenerated,
+    UserInputRequired,
+)
+
+from ._chunks import (
+    AwaitInputChunk,
+    Chunk,
+    DoneChunk,
+    ErrorChunk,
+    NodeFinishChunk,
+    NodeStartChunk,
+    TokenChunk,
+)
+from ._config import get_default_registry
+from ._result import Result
+
+if TYPE_CHECKING:
+    from quartermaster_graph import GraphBuilder, GraphSpec
+    from quartermaster_providers import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_graph(graph: GraphBuilder | GraphSpec) -> GraphSpec:
+    """Accept either a builder (auto-finalise) or a pre-built spec."""
+    if hasattr(graph, "build"):
+        return graph.build()
+    return graph
+
+
+class _RunCallable:
+    """Callable + ``.stream`` method exposed as ``qm.run``.
+
+    Packaged as a class so ``run`` and ``run.stream`` share the same
+    argument-resolution path without repeating boilerplate.
+    """
+
+    def __call__(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Result:
+        """Execute *graph* against *user_input* and return a :class:`Result`.
+
+        Args:
+            graph: Either a :class:`GraphBuilder` (auto-finalised) or
+                a pre-built :class:`GraphSpec`.
+            user_input: Primary user message injected into the graph.
+            provider_registry: Override the configured default registry.
+            tool_registry: Optional :class:`quartermaster_tools.ToolRegistry`
+                made available to ``agent()``-type nodes that specify
+                ``tools=[...]``.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+        )
+        fr = runner.run(user_input)
+        return Result.from_flow_result(fr)
+
+    def stream(
+        self,
+        graph: GraphBuilder | GraphSpec,
+        user_input: str = "",
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        tool_registry: Any | None = None,
+    ) -> Iterator[Chunk]:
+        """Run the graph and yield typed :class:`Chunk` events as they arrive.
+
+        Terminates with a :class:`DoneChunk` (on success) or
+        :class:`ErrorChunk` (on unrecoverable failure).  The graph
+        executes on a background thread so the caller can iterate the
+        yielded chunks synchronously — no ``async``/``await`` required.
+
+        **Cancellation:** breaking out of the loop early (``break``,
+        ``return`` from an enclosing function, raising inside the
+        consumer) calls :meth:`FlowRunner.stop` on the in-flight
+        ``flow_id``, which the engine checks in ``_execute_node``
+        before dispatching any further work.  Nodes already mid-flight
+        finish their current LLM/tool call — no hard kill — but no new
+        nodes are dispatched, so long agent loops unwind within a
+        bounded time instead of leaking API costs in the background.
+        """
+        spec = _resolve_graph(graph)
+        registry = provider_registry or get_default_registry()
+
+        q: queue.Queue[FlowEvent | None] = queue.Queue()
+        holder_lock = threading.Lock()
+        holder: dict[str, Any] = {}
+        # Pre-generate the flow_id so cancellation can call
+        # ``runner.stop(flow_id)`` even if the caller breaks out of the
+        # iterator before the first event fires.  ``FlowRunner.run``
+        # accepts an optional ``flow_id=`` and will use ours instead of
+        # minting its own — this is the documented public API, not
+        # reaching into a private attribute.
+        flow_id = uuid4()
+
+        def on_event(event: FlowEvent) -> None:
+            q.put(event)
+
+        runner = FlowRunner(
+            graph=spec,
+            provider_registry=registry,
+            tool_registry=tool_registry,
+            on_event=on_event,
+        )
+
+        def _run_thread() -> None:
+            try:
+                fr = runner.run(user_input, flow_id=flow_id)
+                with holder_lock:
+                    holder["result"] = fr
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.exception("run.stream: runner.run raised")
+                with holder_lock:
+                    holder["exception"] = exc
+            finally:
+                # Sentinel: signal the iterator loop that there are no
+                # more events.  Placed in ``finally`` so a runner crash
+                # doesn't hang the caller.
+                q.put(None)
+
+        thread = threading.Thread(target=_run_thread, name="qm-run-stream", daemon=True)
+        thread.start()
+
+        try:
+            while True:
+                # Short timeout so the caller can still get control back
+                # (e.g. to abort, log progress) if the runner stalls.
+                try:
+                    event = q.get(timeout=300.0)
+                except queue.Empty:
+                    logger.warning("run.stream: no event for 5 minutes; still waiting")
+                    continue
+                if event is None:
+                    break
+                chunk = _event_to_chunk(event)
+                if chunk is not None:
+                    yield chunk
+        finally:
+            # Caller abandoned the iterator — tell the runner to stop
+            # the flow by its pre-generated id.  ``_execute_node``
+            # short-circuits on the next dispatch, so nodes mid-LLM-call
+            # finish (no hard kill) but no new work is scheduled.
+            if thread.is_alive():
+                try:
+                    runner.stop(flow_id)
+                except Exception:  # pragma: no cover — defensive
+                    logger.exception("run.stream: runner.stop(%s) raised", flow_id)
+            thread.join(timeout=5.0)
+
+        with holder_lock:
+            exception = holder.get("exception")
+            fr = holder.get("result")
+
+        if exception is not None:
+            yield ErrorChunk(error=str(exception))
+            return
+
+        if fr is None:
+            yield ErrorChunk(error="run.stream: runner produced no result")
+            return
+
+        yield DoneChunk(result=Result.from_flow_result(fr))
+
+
+def _event_to_chunk(event: FlowEvent) -> Chunk | None:
+    """Translate an engine :class:`FlowEvent` into a public :class:`Chunk`.
+
+    Returns ``None`` for events we intentionally swallow (they fold into
+    ``DoneChunk`` at the end of the stream).
+    """
+    if isinstance(event, TokenGenerated):
+        return TokenChunk(content=event.token)
+    if isinstance(event, NodeStarted):
+        return NodeStartChunk(
+            node_name=event.node_name,
+            node_type=event.node_type.value,
+        )
+    if isinstance(event, NodeFinished):
+        return NodeFinishChunk(
+            node_name=getattr(event, "node_name", ""),
+            output=event.result or "",
+        )
+    if isinstance(event, UserInputRequired):
+        return AwaitInputChunk(
+            prompt=event.prompt,
+            options=list(event.options or []),
+        )
+    if isinstance(event, FlowError):
+        return ErrorChunk(error=event.error)
+    if isinstance(event, FlowFinished):
+        # DoneChunk is emitted explicitly after the thread joins so the
+        # caller gets the full Result (not just the final_output string
+        # this event carries).
+        return None
+    return None
+
+
+#: Publicly exported runner.  ``qm.run(graph, input)`` runs sync;
+#: ``qm.run.stream(graph, input)`` yields typed Chunk objects.
+run = _RunCallable()
+
+
+__all__ = ["run", "Result", "Chunk"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_stream_filters.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_stream_filters.py
@@ -1,0 +1,207 @@
+"""Filtered stream iterators for :func:`run.stream` / :func:`arun.stream`.
+
+v0.2.x callers wrote the same boilerplate over and over to pull specific
+chunk types out of the raw :class:`Chunk` stream::
+
+    for chunk in qm.run.stream(graph, "hi"):
+        if chunk.type == "token":
+            print(chunk.content, end="")
+
+v0.3.0 wraps the underlying iterator in a small object that exposes
+filter methods so consumers write::
+
+    for token in qm.run.stream(graph, "hi").tokens():
+        print(token, end="")
+
+    for call in qm.run.stream(graph, "hi").tool_calls():
+        ui.show_tool_card(call)
+
+    for prog in qm.run.stream(graph, "hi").progress():
+        ui.update_status(prog.message, prog.percent)
+
+    for c in qm.run.stream(graph, "hi").custom(name="docs"):
+        ui.add_doc(c.payload)
+
+Raw iteration continues to work unchanged — the wrapper is itself an
+iterator / async-iterator, so every existing ``for chunk in
+run.stream(...)`` call site keeps its exact semantics::
+
+    for chunk in qm.run.stream(graph, "hi"):   # still fine
+        ...
+
+Single-pass semantics
+---------------------
+The wrappers own the underlying generator. Calling a filter method
+(or raw iteration) drains it — there is no replay. Calling a second
+filter after the first, or raw-iterating after a filter, raises
+:class:`RuntimeError` so the mistake surfaces loudly instead of
+silently yielding zero chunks.
+
+Design decision: ``tokens()`` yields ``str``
+---------------------------------------------
+All other filters yield the full chunk object because they carry
+fields the consumer needs (``tool``, ``args``, ``message``,
+``percent``, ``payload``, ``name``, …). ``tokens()`` is the one case
+where the consumer almost always wants a bare string to concatenate
+into a UI — the whole point of "30 chars to get streamed text" is to
+cut out the ``.content`` hop. Callers who want the chunk itself can
+still pattern-match on the raw stream.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, Iterator
+
+from ._chunks import (
+    Chunk,
+    CustomChunk,
+    ProgressChunk,
+    TokenChunk,
+    ToolCallChunk,
+)
+
+
+_ALREADY_CONSUMED_MSG = "stream already consumed"
+
+
+class _Stream:
+    """Synchronous wrapper around the raw :class:`Chunk` generator.
+
+    Exposes ``.tokens()``, ``.tool_calls()``, ``.progress()``,
+    ``.custom(name=...)`` helpers plus a default ``__iter__`` that
+    yields every chunk unmodified.
+
+    The wrapper is single-pass: whichever consumer starts reading
+    first wins, and any second consumer raises :class:`RuntimeError`.
+    """
+
+    __slots__ = ("_source", "_consumed")
+
+    def __init__(self, source: Iterator[Chunk]) -> None:
+        self._source = source
+        self._consumed = False
+
+    def _claim(self) -> None:
+        """Mark the stream as claimed by the first consumer; raise on re-use.
+
+        Must be called before any consumer starts reading. Keeps every
+        entry point (``__iter__``, ``tokens``, ``tool_calls``,
+        ``progress``, ``custom``) in sync on a single flag.
+        """
+        if self._consumed:
+            raise RuntimeError(_ALREADY_CONSUMED_MSG)
+        self._consumed = True
+
+    # ── Raw iteration (preserves pre-v0.3.0 behaviour) ────────────────
+    def __iter__(self) -> Iterator[Chunk]:
+        self._claim()
+        return self._source
+
+    # ── Filter methods ────────────────────────────────────────────────
+    def tokens(self) -> Iterator[str]:
+        """Yield ``chunk.content`` for every :class:`TokenChunk`.
+
+        Yields ``str`` (not the chunk itself) because concatenation is
+        the overwhelming common case.
+        """
+        self._claim()
+        return self._yield_tokens()
+
+    def _yield_tokens(self) -> Iterator[str]:
+        for chunk in self._source:
+            if isinstance(chunk, TokenChunk):
+                yield chunk.content
+
+    def tool_calls(self) -> Iterator[ToolCallChunk]:
+        """Yield every :class:`ToolCallChunk` as it fires."""
+        self._claim()
+        return self._yield_type(ToolCallChunk)
+
+    def progress(self) -> Iterator[ProgressChunk]:
+        """Yield every :class:`ProgressChunk` as it fires."""
+        self._claim()
+        return self._yield_type(ProgressChunk)
+
+    def custom(self, name: str | None = None) -> Iterator[CustomChunk]:
+        """Yield :class:`CustomChunk` events, optionally filtered by ``name``.
+
+        ``name=None`` (the default) yields every custom chunk; passing
+        a specific ``name`` yields only the matching ones so UIs can
+        subscribe to a single milestone stream without inspecting
+        every payload.
+        """
+        self._claim()
+        return self._yield_custom(name)
+
+    # ── Internal helpers ──────────────────────────────────────────────
+    def _yield_type(self, chunk_cls: type) -> Iterator:
+        for chunk in self._source:
+            if isinstance(chunk, chunk_cls):
+                yield chunk
+
+    def _yield_custom(self, name: str | None) -> Iterator[CustomChunk]:
+        for chunk in self._source:
+            if isinstance(chunk, CustomChunk) and (name is None or chunk.name == name):
+                yield chunk
+
+
+class _AsyncStream:
+    """Async analogue of :class:`_Stream`.
+
+    Filter methods return async generators so consumers can write
+    ``async for token in qm.arun.stream(...).tokens(): ...`` without
+    materialising the whole stream first. Same single-pass guarantee
+    as the sync variant — :class:`RuntimeError` on double consumption.
+    """
+
+    __slots__ = ("_source", "_consumed")
+
+    def __init__(self, source: AsyncIterator[Chunk]) -> None:
+        self._source = source
+        self._consumed = False
+
+    def _claim(self) -> None:
+        if self._consumed:
+            raise RuntimeError(_ALREADY_CONSUMED_MSG)
+        self._consumed = True
+
+    # ── Raw async iteration ──────────────────────────────────────────
+    def __aiter__(self) -> AsyncIterator[Chunk]:
+        self._claim()
+        return self._source
+
+    # ── Filter methods ────────────────────────────────────────────────
+    def tokens(self) -> AsyncIterator[str]:
+        self._claim()
+        return self._yield_tokens()
+
+    async def _yield_tokens(self) -> AsyncIterator[str]:
+        async for chunk in self._source:
+            if isinstance(chunk, TokenChunk):
+                yield chunk.content
+
+    def tool_calls(self) -> AsyncIterator[ToolCallChunk]:
+        self._claim()
+        return self._yield_type(ToolCallChunk)
+
+    def progress(self) -> AsyncIterator[ProgressChunk]:
+        self._claim()
+        return self._yield_type(ProgressChunk)
+
+    def custom(self, name: str | None = None) -> AsyncIterator[CustomChunk]:
+        self._claim()
+        return self._yield_custom(name)
+
+    # ── Internal helpers ──────────────────────────────────────────────
+    async def _yield_type(self, chunk_cls: type) -> AsyncIterator:
+        async for chunk in self._source:
+            if isinstance(chunk, chunk_cls):
+                yield chunk
+
+    async def _yield_custom(self, name: str | None) -> AsyncIterator[CustomChunk]:
+        async for chunk in self._source:
+            if isinstance(chunk, CustomChunk) and (name is None or chunk.name == name):
+                yield chunk
+
+
+__all__ = ["_Stream", "_AsyncStream"]

--- a/quartermaster-sdk/src/quartermaster_sdk/_trace.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_trace.py
@@ -1,0 +1,320 @@
+"""Structured post-mortem trace for a Quartermaster flow run.
+
+Every :class:`quartermaster_sdk.Result` returned from :func:`run` or the
+terminal :class:`DoneChunk.result` of :func:`run.stream` carries a
+:class:`Trace` built from the full :class:`FlowEvent` stream the runner
+observed.  The trace gives the caller post-mortem access to everything
+that happened during the run — tokens, tool calls, progress, custom
+events — without having to re-iterate the event stream themselves::
+
+    result = qm.run(graph, "hi")
+    result.trace.text                       # full model output
+    result.trace.tool_calls                 # list[dict] tool-call records
+    result.trace.progress                   # list[ProgressEvent]
+    result.trace.custom(name="docs")        # filtered custom events
+    result.trace.by_node["research"].text   # tokens for a single node
+    result.trace.as_jsonl()                 # JSONL export for logs / fixtures
+
+The same shape is populated for streaming runs — the runner installs an
+``on_event`` collector that appends every :class:`FlowEvent` to a list,
+then builds the trace from that list once the run completes.
+
+Per-node bucketing
+------------------
+:attr:`Trace.by_node` is keyed by node *name* (the ``node_name`` string
+on :class:`NodeStarted` / :class:`NodeFinished`), not by UUID.  Events
+that carry a ``node_name`` (``NodeStarted``, ``NodeFinished``,
+``TokenGenerated``, ``ToolCallStarted``, ``ToolCallFinished``,
+``ProgressEvent``, ``CustomEvent``) are attributed to the node that was
+active when they fired.  Flow-scoped events (``FlowFinished``,
+``FlowError``) don't belong to any single node and land in a synthetic
+``"_flow"`` bucket so they're still reachable without polluting the
+per-node views.
+
+The "active node" is tracked by walking events in arrival order and
+latching ``NodeStarted.node_name`` until the matching
+``NodeFinished.node_name`` closes it — events that fire between those
+bookends (tokens, tool calls, progress, custom) inherit that node's
+name.  Events emitted *before* any ``NodeStarted`` (rare, but possible
+for flow-level setup) land in ``"_flow"`` as well.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING
+
+from quartermaster_engine import (
+    CustomEvent,
+    FlowError,
+    FlowEvent,
+    FlowFinished,
+    NodeFinished,
+    NodeStarted,
+    ProgressEvent,
+    TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
+    UserInputRequired,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+#: Synthetic bucket key for events that don't belong to any single node
+#: (flow-level events like :class:`FlowFinished` / :class:`FlowError`,
+#: and any event fired before the first :class:`NodeStarted`).
+_FLOW_BUCKET = "_flow"
+
+
+def _extract_tool_call(event: ToolCallFinished) -> dict:
+    """Translate a :class:`ToolCallFinished` event into the public dict
+    shape used by :attr:`Trace.tool_calls` and
+    :attr:`NodeTrace.tool_calls`.
+
+    Mirrors the ``tool_calls`` entry already written to
+    :attr:`NodeResult.data` by ``AgentExecutor`` so that both surfaces
+    (post-hoc trace inspection and in-flight capture introspection)
+    carry identical keys.
+    """
+    return {
+        "tool": event.tool,
+        "arguments": dict(event.arguments),
+        "result": event.result,
+        "raw": event.raw,
+        "error": event.error,
+        "iteration": event.iteration,
+    }
+
+
+@dataclass
+class NodeTrace:
+    """Per-node slice of a :class:`Trace`.
+
+    Scoped to a single node (the one whose name keys it in
+    :attr:`Trace.by_node`).  Same accessor shape as :class:`Trace` so
+    callers can write ``result.trace.by_node["research"].text`` the same
+    way they write ``result.trace.text``.
+
+    Attributes:
+        node_name: The ``node_name`` string this trace belongs to.
+        events: Every :class:`FlowEvent` attributed to this node, in
+            arrival order.
+    """
+
+    node_name: str
+    events: list[FlowEvent] = field(default_factory=list)
+
+    @property
+    def text(self) -> str:
+        """Concatenation of every :class:`TokenGenerated.token` for this node."""
+        return "".join(
+            event.token for event in self.events if isinstance(event, TokenGenerated)
+        )
+
+    @property
+    def tool_calls(self) -> list[dict]:
+        """Tool-call records derived from this node's
+        :class:`ToolCallFinished` events.
+
+        Each dict has keys ``tool``, ``arguments``, ``result``, ``raw``,
+        ``error``, ``iteration`` — identical shape to the entries in
+        ``result["<agent_node>"].data["tool_calls"]`` so downstream code
+        can move between the trace and the capture without remapping.
+        """
+        return [
+            _extract_tool_call(event)
+            for event in self.events
+            if isinstance(event, ToolCallFinished)
+        ]
+
+    @property
+    def progress(self) -> list[ProgressEvent]:
+        """Every :class:`ProgressEvent` emitted from inside this node."""
+        return [event for event in self.events if isinstance(event, ProgressEvent)]
+
+    def custom(self, name: str | None = None) -> list[CustomEvent]:
+        """Return every :class:`CustomEvent` for this node, optionally
+        filtered by ``name``.
+
+        ``name=None`` (the default) returns every custom event; a
+        specific ``name`` returns only the matching ones so callers can
+        subscribe to a single milestone stream without inspecting every
+        payload.
+        """
+        return [
+            event
+            for event in self.events
+            if isinstance(event, CustomEvent)
+            and (name is None or event.name == name)
+        ]
+
+
+@dataclass
+class Trace:
+    """Structured view of everything that happened during a flow run.
+
+    Populated automatically on every :class:`Result` — both sync
+    (:func:`run`) and streaming (:class:`DoneChunk.result`) surfaces
+    attach the same object so downstream code doesn't branch on the
+    run mode.  Events are captured via the runner's ``on_event``
+    callback, which fires for every :class:`FlowEvent` the engine
+    emits.
+
+    Attributes:
+        events: Every :class:`FlowEvent` in arrival order.  This is the
+            source of truth — all aggregate views derive from it.
+        by_node: Per-node slices of :attr:`events`, keyed by
+            ``node_name``.  Flow-scoped events (no ``node_name``) are
+            collected into a synthetic ``"_flow"`` bucket so the caller
+            can still reach them without them clogging the per-node
+            views.
+        duration_seconds: Wall-clock duration of the run, mirroring
+            :attr:`Result.duration_seconds`.
+    """
+
+    events: list[FlowEvent] = field(default_factory=list)
+    by_node: dict[str, NodeTrace] = field(default_factory=dict)
+    duration_seconds: float = 0.0
+
+    @property
+    def text(self) -> str:
+        """Concatenation of every :class:`TokenGenerated.token`, in order.
+
+        Equivalent to walking the event stream and gluing ``token``
+        strings together — the "full model output" view regardless of
+        how many nodes contributed tokens.
+        """
+        return "".join(
+            event.token for event in self.events if isinstance(event, TokenGenerated)
+        )
+
+    @property
+    def tool_calls(self) -> list[dict]:
+        """Every tool-call record across every node.
+
+        Each dict has keys ``tool``, ``arguments``, ``result``, ``raw``,
+        ``error``, ``iteration``.  Use :attr:`NodeTrace.tool_calls`
+        via :attr:`by_node` if you need to scope to a single agent.
+        """
+        return [
+            _extract_tool_call(event)
+            for event in self.events
+            if isinstance(event, ToolCallFinished)
+        ]
+
+    @property
+    def progress(self) -> list[ProgressEvent]:
+        """Every :class:`ProgressEvent` across the whole run."""
+        return [event for event in self.events if isinstance(event, ProgressEvent)]
+
+    def custom(self, name: str | None = None) -> list[CustomEvent]:
+        """Return every :class:`CustomEvent`, optionally filtered by ``name``.
+
+        ``name=None`` yields every custom event; a specific ``name``
+        yields only the matching ones so UIs can subscribe to a single
+        milestone stream without inspecting every payload.
+        """
+        return [
+            event
+            for event in self.events
+            if isinstance(event, CustomEvent)
+            and (name is None or event.name == name)
+        ]
+
+    def as_jsonl(self) -> str:
+        """Return the trace serialised as JSONL (one event per line).
+
+        Uses ``dataclasses.asdict`` to flatten each event, then
+        ``json.dumps(..., default=str)`` to coerce ``UUID`` /
+        ``datetime`` / enum values to strings.  The output is suitable
+        for log shipping and test fixtures — every line is an
+        independent JSON object keyed by the dataclass field names.
+        """
+        lines = []
+        for event in self.events:
+            lines.append(json.dumps(asdict(event), default=str))
+        return "\n".join(lines)
+
+    @classmethod
+    def from_events(
+        cls, events: list[FlowEvent], duration_seconds: float = 0.0
+    ) -> Trace:
+        """Build a :class:`Trace` from a list of :class:`FlowEvent`.
+
+        Walks ``events`` in arrival order, latching the currently-active
+        node name from :class:`NodeStarted` / :class:`NodeFinished` so
+        events fired between those bookends (tokens, tool calls,
+        progress, custom) are attributed to the right
+        :class:`NodeTrace` in :attr:`by_node`.
+
+        Flow-scoped events (:class:`FlowFinished`, :class:`FlowError`,
+        :class:`UserInputRequired` — they have no ``node_name``) land
+        in the synthetic ``"_flow"`` bucket alongside any events fired
+        before the first :class:`NodeStarted`.
+        """
+        by_node: dict[str, NodeTrace] = {}
+        current_node: str | None = None
+
+        def bucket(name: str) -> NodeTrace:
+            """Fetch-or-create the :class:`NodeTrace` for ``name``."""
+            if name not in by_node:
+                by_node[name] = NodeTrace(node_name=name)
+            return by_node[name]
+
+        for event in events:
+            # Decide which bucket this event belongs to.
+            #
+            # NodeStarted sets the "active" node for subsequent events
+            # (tokens, tool calls, progress, custom) and is itself
+            # stored under that node.  NodeFinished closes the bucket
+            # and lands in it too.  Anything that carries an explicit
+            # node_name (rare — most events use the latched value) wins
+            # over the latched state.
+            if isinstance(event, NodeStarted):
+                current_node = event.node_name
+                bucket(current_node).events.append(event)
+            elif isinstance(event, NodeFinished):
+                # NodeFinished has ``node_name`` on the engine side —
+                # but defensively fall back to the latched value if an
+                # older engine event is missing it.
+                name = getattr(event, "node_name", None) or current_node
+                if name:
+                    bucket(name).events.append(event)
+                else:
+                    bucket(_FLOW_BUCKET).events.append(event)
+                # Close the active node — subsequent events (until the
+                # next NodeStarted) are flow-scoped.
+                current_node = None
+            elif isinstance(
+                event,
+                (
+                    TokenGenerated,
+                    ToolCallStarted,
+                    ToolCallFinished,
+                    ProgressEvent,
+                    CustomEvent,
+                ),
+            ):
+                # Node-scoped events.  Use the latched node name; fall
+                # back to the flow bucket for the edge case where the
+                # event fires outside any NodeStarted/NodeFinished pair
+                # (e.g. a misconfigured node, or a caller emitting from
+                # flow-level setup code).
+                name = current_node or _FLOW_BUCKET
+                bucket(name).events.append(event)
+            else:
+                # FlowFinished, FlowError, UserInputRequired, or any
+                # future FlowEvent subtype that isn't node-scoped.
+                bucket(_FLOW_BUCKET).events.append(event)
+
+        return cls(
+            events=list(events),
+            by_node=by_node,
+            duration_seconds=duration_seconds,
+        )
+
+
+__all__ = ["Trace", "NodeTrace"]

--- a/quartermaster-sdk/src/quartermaster_sdk/telemetry.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/telemetry.py
@@ -1,0 +1,439 @@
+"""OpenTelemetry instrumentation for Quartermaster flows.
+
+Bolt-on tracing — call :func:`instrument` once at app boot and every
+:func:`quartermaster_sdk.run` / :func:`quartermaster_sdk.arun` /
+``run.stream`` will emit GenAI-conventioned OpenTelemetry spans without
+any further callsite changes.
+
+    import quartermaster_sdk as qm
+    from quartermaster_sdk import telemetry
+
+    qm.configure(provider="ollama", default_model="gemma4:26b")
+    telemetry.instrument()                     # uses global tracer provider
+    # or with explicit provider:
+    # telemetry.instrument(tracer_provider=my_provider)
+
+    result = qm.run(graph, "hi")               # spans flow to your exporter
+
+The implementation hooks into the SDK's :mod:`._listeners` registry,
+which the runners already invoke from inside their ``on_event=`` callback
+to :class:`FlowRunner`.  We never touch the engine itself.
+
+Span model
+----------
+
+* One root ``qm.flow`` span per flow_id, opened on the first event we
+  see for that flow and closed on :class:`~quartermaster_engine.FlowFinished`
+  / :class:`~quartermaster_engine.FlowError`.
+* One ``qm.node.<node_name>`` span per node, opened on
+  :class:`~quartermaster_engine.NodeStarted`, closed on
+  :class:`~quartermaster_engine.NodeFinished`.  Parented to the flow span.
+* One ``qm.tool.<tool>`` span per tool call (matched by ``iteration``),
+  opened on :class:`~quartermaster_engine.ToolCallStarted`, closed on
+  :class:`~quartermaster_engine.ToolCallFinished`.  Parented to the
+  enclosing node span.
+* :class:`~quartermaster_engine.TokenGenerated` /
+  :class:`~quartermaster_engine.ProgressEvent` /
+  :class:`~quartermaster_engine.CustomEvent` are recorded as span events
+  on the active node span — never as their own spans (would be far too
+  noisy at LLM token granularity).
+
+Attributes follow the OpenTelemetry GenAI semantic conventions:
+``gen_ai.system``, ``gen_ai.operation.name``, ``gen_ai.tool.name``,
+``gen_ai.tool.call.arguments``, ``gen_ai.usage.input_tokens``,
+``gen_ai.usage.output_tokens``.  See
+https://opentelemetry.io/docs/specs/semconv/gen-ai/ .
+
+Scope & limitations
+-------------------
+
+* Single-process only.  The active-span dict is module-level state
+  guarded by a :class:`threading.Lock`; cross-process distribution is
+  the responsibility of whatever exporter the caller wires up
+  (e.g. OTLP → Jaeger / Tempo / Honeycomb).
+* The OpenTelemetry SDK is an *optional* dependency.  Install with
+  ``pip install 'quartermaster-sdk[telemetry]'``.  Importing this module
+  works without OTEL installed; only :func:`instrument` requires it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any
+from uuid import UUID
+
+from quartermaster_engine import (
+    CustomEvent,
+    FlowError,
+    FlowEvent,
+    FlowFinished,
+    NodeFinished,
+    NodeStarted,
+    ProgressEvent,
+    TokenGenerated,
+    ToolCallFinished,
+    ToolCallStarted,
+)
+
+from . import _listeners
+
+logger = logging.getLogger(__name__)
+
+# ── Module-level state ───────────────────────────────────────────────
+#
+# Active spans are tracked here; we cannot rely on
+# ``opentelemetry.trace.use_span`` context-manager scoping because the
+# FlowEvent stream is delivered out-of-band from a worker thread, after
+# the event-source code has already returned.  All access goes through
+# ``_state_lock`` so concurrent flows on different threads don't trample
+# each other.
+_state_lock = threading.Lock()
+
+# Set when ``instrument()`` succeeds; tested by ``uninstrument()`` and
+# by ``instrument()`` itself to avoid double-registration.
+_listener: Any = None  # callable[[FlowEvent], None]
+_tracer: Any = None  # opentelemetry.trace.Tracer
+
+# Open spans, keyed by stable identifiers we synthesise from event fields.
+# - flow_id (UUID)            → root flow span
+# - (flow_id, node_id) (UUIDs) → per-node span
+# - (flow_id, node_id, "tool", iteration: int) → per-tool-call span
+_active_spans: dict[Any, Any] = {}
+
+# OTEL semantic-convention constants.  We hard-code rather than import
+# from ``opentelemetry.semconv`` because the GenAI SemConv module moved
+# packages a few times in the 1.2x → 1.4x window — string literals are
+# simpler and don't pin us to a specific SDK version.
+_GEN_AI_SYSTEM = "gen_ai.system"
+_GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+_GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+_GEN_AI_TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments"
+_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+
+# Quartermaster-specific attributes (custom prefix ``qm.*`` so they
+# don't collide with future SemConv reservations).
+_QM_FLOW_ID = "qm.flow.id"
+_QM_NODE_ID = "qm.node.id"
+_QM_NODE_NAME = "qm.node.name"
+_QM_NODE_TYPE = "qm.node.type"
+
+
+def _safe_json(value: Any) -> str:
+    """Serialise *value* to JSON, falling back to ``repr`` on failure.
+
+    Tool-call arguments can contain anything the LLM dreamt up — bytes,
+    custom objects, NaN floats — and ``json.dumps`` choking would leak
+    the exception into the engine thread and abort the listener.  This
+    helper keeps the listener bullet-proof while still getting the
+    common case (plain dict of primitives) right.
+    """
+    try:
+        return json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:  # pragma: no cover — defensive
+        return repr(value)
+
+
+def _flow_key(flow_id: UUID) -> UUID:
+    """Stable key for the root flow span — just the flow_id."""
+    return flow_id
+
+
+def _node_key(flow_id: UUID, node_id: UUID) -> tuple[UUID, UUID]:
+    """Stable key for a per-node span."""
+    return (flow_id, node_id)
+
+
+def _tool_key(flow_id: UUID, node_id: UUID, iteration: int) -> tuple:
+    """Stable key for a per-tool-call span (one per agent iteration)."""
+    return (flow_id, node_id, "tool", iteration)
+
+
+def _ensure_flow_span(event: FlowEvent) -> Any:
+    """Open the root ``qm.flow`` span on first sight of *event.flow_id*.
+
+    Idempotent — returns the existing span if we've already seen this
+    flow.  Caller holds ``_state_lock``.
+    """
+    key = _flow_key(event.flow_id)
+    span = _active_spans.get(key)
+    if span is not None:
+        return span
+    span = _tracer.start_span("qm.flow")
+    span.set_attribute(_GEN_AI_SYSTEM, "quartermaster")
+    span.set_attribute(_GEN_AI_OPERATION_NAME, "flow")
+    span.set_attribute(_QM_FLOW_ID, str(event.flow_id))
+    _active_spans[key] = span
+    return span
+
+
+def _start_node_span(event: NodeStarted) -> None:
+    """Open a child span for a node beginning execution."""
+    # OTEL needs explicit parent context for cross-thread parent linkage
+    # (the runner's worker thread doesn't share the OTEL context-vars
+    # with whoever called ``instrument()``).  We attach a context whose
+    # active span is the flow span so the new node span gets parented
+    # correctly even though we're outside the original flow context.
+    from opentelemetry import trace
+
+    with _state_lock:
+        flow_span = _ensure_flow_span(event)
+        ctx = trace.set_span_in_context(flow_span)
+        span = _tracer.start_span(
+            f"qm.node.{event.node_name or event.node_id}",
+            context=ctx,
+        )
+        span.set_attribute(_GEN_AI_SYSTEM, "quartermaster")
+        # The engine's NodeType is a string-enum; .value gives the
+        # serialised form integrators see in their graph definitions.
+        span.set_attribute(
+            _GEN_AI_OPERATION_NAME,
+            event.node_type.value if event.node_type is not None else "unknown",
+        )
+        span.set_attribute(_QM_NODE_NAME, event.node_name)
+        span.set_attribute(_QM_NODE_ID, str(event.node_id))
+        span.set_attribute(_QM_NODE_TYPE, event.node_type.value)
+        _active_spans[_node_key(event.flow_id, event.node_id)] = span
+
+
+def _finish_node_span(event: NodeFinished) -> None:
+    """Close the matching node span and surface usage attributes."""
+    with _state_lock:
+        span = _active_spans.pop(_node_key(event.flow_id, event.node_id), None)
+    if span is None:
+        # Missed the start (instrument() called mid-flight, or duplicate
+        # finish) — nothing to close.
+        return
+    # Pull token-usage hints from output_data when the node populated
+    # them.  Different node types report different shapes; we look for
+    # the common keys without mandating any particular schema.
+    output = event.output_data or {}
+    in_tok = (
+        output.get("input_tokens")
+        or output.get("prompt_tokens")
+        or output.get("usage", {}).get("input_tokens")
+        if isinstance(output.get("usage"), dict)
+        else None
+    )
+    out_tok = (
+        output.get("output_tokens")
+        or output.get("completion_tokens")
+        or output.get("usage", {}).get("output_tokens")
+        if isinstance(output.get("usage"), dict)
+        else None
+    )
+    if isinstance(in_tok, int):
+        span.set_attribute(_GEN_AI_USAGE_INPUT_TOKENS, in_tok)
+    if isinstance(out_tok, int):
+        span.set_attribute(_GEN_AI_USAGE_OUTPUT_TOKENS, out_tok)
+    span.end()
+
+
+def _start_tool_span(event: ToolCallStarted) -> None:
+    """Open a tool span nested under the agent-node span that issued it."""
+    from opentelemetry import trace
+
+    with _state_lock:
+        # Parent the tool span on the enclosing node span when we have
+        # one; fall back to the flow span otherwise.  Direct reach into
+        # ``_active_spans`` is fine — we're under ``_state_lock``.
+        parent = _active_spans.get(_node_key(event.flow_id, event.node_id))
+        if parent is None:
+            parent = _active_spans.get(_flow_key(event.flow_id))
+        ctx = trace.set_span_in_context(parent) if parent is not None else None
+        span = _tracer.start_span(
+            f"qm.tool.{event.tool}",
+            context=ctx,
+        )
+        span.set_attribute(_GEN_AI_SYSTEM, "quartermaster")
+        span.set_attribute(_GEN_AI_OPERATION_NAME, "execute_tool")
+        span.set_attribute(_GEN_AI_TOOL_NAME, event.tool)
+        span.set_attribute(
+            _GEN_AI_TOOL_CALL_ARGUMENTS,
+            _safe_json(dict(event.arguments or {})),
+        )
+        _active_spans[_tool_key(event.flow_id, event.node_id, event.iteration)] = span
+
+
+def _finish_tool_span(event: ToolCallFinished) -> None:
+    """Close the tool span and mark ERROR status if the tool raised."""
+    from opentelemetry.trace import Status, StatusCode
+
+    with _state_lock:
+        span = _active_spans.pop(
+            _tool_key(event.flow_id, event.node_id, event.iteration),
+            None,
+        )
+    if span is None:
+        return
+    if event.error:
+        span.set_status(Status(StatusCode.ERROR, event.error))
+        span.set_attribute("error.message", event.error)
+    span.end()
+
+
+def _record_event_on_active_span(event: FlowEvent, name: str, attrs: dict[str, Any]) -> None:
+    """Add an OTEL event to the active node span (preferred) or flow span."""
+    with _state_lock:
+        node_id = getattr(event, "node_id", None)
+        span = None
+        if node_id is not None:
+            span = _active_spans.get(_node_key(event.flow_id, node_id))
+        if span is None:
+            span = _active_spans.get(_flow_key(event.flow_id))
+    if span is None:
+        return
+    # OTEL attributes must be primitives or sequences of primitives —
+    # stringify anything dict-shaped via _safe_json.
+    safe_attrs: dict[str, Any] = {}
+    for k, v in attrs.items():
+        if isinstance(v, (str, bool, int, float)):
+            safe_attrs[k] = v
+        elif v is None:
+            continue
+        else:
+            safe_attrs[k] = _safe_json(v)
+    try:
+        span.add_event(name, attributes=safe_attrs)
+    except Exception:  # pragma: no cover — defensive
+        logger.exception("telemetry: add_event(%r) failed", name)
+
+
+def _finish_flow_span(event: FlowEvent, *, error: str | None = None) -> None:
+    """Close the root flow span (and any orphan child spans for that flow)."""
+    from opentelemetry.trace import Status, StatusCode
+
+    with _state_lock:
+        flow_span = _active_spans.pop(_flow_key(event.flow_id), None)
+        # Mop up any node / tool spans we never saw a finish for.
+        # They'd otherwise leak forever — bad for memory and for
+        # exporters that batch on span end.
+        orphans: list[Any] = []
+        for key in list(_active_spans):
+            if isinstance(key, tuple) and key and key[0] == event.flow_id:
+                orphans.append(_active_spans.pop(key))
+    for orphan in orphans:
+        try:
+            orphan.end()
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("telemetry: failed to end orphan span")
+    if flow_span is None:
+        return
+    if error:
+        flow_span.set_status(Status(StatusCode.ERROR, error))
+        flow_span.set_attribute("error.message", error)
+    flow_span.end()
+
+
+def _on_event(event: FlowEvent) -> None:
+    """The single listener registered on :mod:`_listeners`."""
+    try:
+        # Lazy: even FlowFinished should ensure a flow span exists in
+        # the pathological case of an empty flow that emits only the
+        # terminal event — without this, _finish_flow_span pops nothing
+        # and we lose the trace.
+        if not isinstance(event, (FlowFinished, FlowError)):
+            with _state_lock:
+                _ensure_flow_span(event)
+
+        if isinstance(event, NodeStarted):
+            _start_node_span(event)
+        elif isinstance(event, NodeFinished):
+            _finish_node_span(event)
+        elif isinstance(event, ToolCallStarted):
+            _start_tool_span(event)
+        elif isinstance(event, ToolCallFinished):
+            _finish_tool_span(event)
+        elif isinstance(event, TokenGenerated):
+            # Recorded as a span event on the node — one-per-token would
+            # blow out exporters at LLM throughput, so we attach the
+            # token to the active node span as an event with the token
+            # text as an attribute.  Most exporters dedupe by event name
+            # and surface counts in their UI.
+            _record_event_on_active_span(
+                event, "token", {"gen_ai.token.value": event.token}
+            )
+        elif isinstance(event, ProgressEvent):
+            _record_event_on_active_span(
+                event,
+                "progress",
+                {
+                    "message": event.message,
+                    "percent": event.percent,
+                    **(event.data or {}),
+                },
+            )
+        elif isinstance(event, CustomEvent):
+            _record_event_on_active_span(
+                event,
+                event.name or "custom",
+                dict(event.payload or {}),
+            )
+        elif isinstance(event, FlowError):
+            _finish_flow_span(event, error=event.error)
+        elif isinstance(event, FlowFinished):
+            _finish_flow_span(event)
+    except Exception:  # pragma: no cover — defensive
+        logger.exception("telemetry: listener crashed on %r", type(event).__name__)
+
+
+def instrument(
+    *,
+    tracer_provider: Any | None = None,
+    instrumenting_module_name: str = "quartermaster_sdk",
+) -> None:
+    """Register the OTEL listener; every subsequent flow emits spans.
+
+    Args:
+        tracer_provider: An :class:`opentelemetry.sdk.trace.TracerProvider`
+            (or compatible).  Defaults to the global provider returned
+            by :func:`opentelemetry.trace.get_tracer_provider`, so most
+            integrators don't need to pass anything.
+        instrumenting_module_name: Library name reported on each span;
+            shows up as ``otel.library.name`` in many exporters.
+
+    Idempotent: calling :func:`instrument` more than once is a no-op
+    until :func:`uninstrument` is called.
+    """
+    global _listener, _tracer
+
+    try:
+        from opentelemetry import trace
+    except ImportError as exc:  # pragma: no cover — depends on extras
+        raise ImportError(
+            "OpenTelemetry not installed. "
+            "Run: pip install 'quartermaster-sdk[telemetry]'"
+        ) from exc
+
+    with _state_lock:
+        if _listener is not None:
+            # Already instrumented — caller probably double-bootstrapped
+            # something.  No harm done; just bail.
+            return
+        provider = tracer_provider or trace.get_tracer_provider()
+        _tracer = provider.get_tracer(instrumenting_module_name)
+        _listener = _on_event
+
+    _listeners.register(_on_event)
+
+
+def uninstrument() -> None:
+    """Reverse of :func:`instrument` — remove the OTEL listener.
+
+    Any in-flight spans are left as they are; they'll close naturally
+    when their flow finishes.  Calling :func:`uninstrument` before
+    :func:`instrument` (or twice in a row) is a no-op.
+    """
+    global _listener, _tracer
+    with _state_lock:
+        if _listener is None:
+            return
+        listener = _listener
+        _listener = None
+        _tracer = None
+    _listeners.unregister(listener)
+
+
+__all__ = ["instrument", "uninstrument"]

--- a/quartermaster-sdk/tests/test_v020_surface.py
+++ b/quartermaster-sdk/tests/test_v020_surface.py
@@ -1,0 +1,465 @@
+"""Tests for the v0.2.0 ergonomic surface.
+
+Covers the four primary new-in-0.2.0 public entry points:
+
+* :func:`quartermaster_sdk.configure` — module-level default registry
+* :func:`quartermaster_sdk.run` — one-liner graph runner returning a
+  :class:`Result`
+* :func:`quartermaster_sdk.run.stream` — typed :class:`Chunk` stream
+* :func:`quartermaster_sdk.instruction` / :func:`instruction_form` —
+  single-shot prompt helpers with no ``Graph`` boilerplate
+
+Plus the underlying primitives: auto-start, optional End, ``capture_as=``
+threading through :attr:`Result.captures`.
+
+We mock the provider with :class:`MockProvider` so the suite runs with
+no real LLM.  ``instruction_form`` uses a Pydantic model; the mock is
+primed to return canned JSON.
+"""
+
+from __future__ import annotations
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Build a ProviderRegistry with a MockProvider registered as ``ollama``.
+
+    Both text (streamed) and native-response channels are primed so
+    tests that pick either path see a consistent reply.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+# ── configure() ───────────────────────────────────────────────────────
+
+
+class TestConfigure:
+    def test_configure_with_registry(self):
+        reg, _ = _mock_registry()
+        returned = qm.configure(registry=reg)
+        assert returned is reg
+        assert qm.get_default_registry() is reg
+
+    def test_configure_rejects_mixed_args(self):
+        reg, _ = _mock_registry()
+        with pytest.raises(ValueError, match="registry= OR base_url"):
+            qm.configure(registry=reg, base_url="http://localhost:11434")
+
+    def test_get_default_registry_raises_before_configure(self):
+        with pytest.raises(RuntimeError, match="No default provider registry"):
+            qm.get_default_registry()
+
+    def test_env_default_model_picked_up(self, monkeypatch):
+        monkeypatch.setenv("QM_DEFAULT_MODEL", "gemma4:26b")
+        reg, _ = _mock_registry()
+        qm.configure(registry=reg)
+        # registry= path uses the env var for get_default_model()
+        assert qm.get_default_model() == "gemma4:26b"
+
+
+# ── Graph builder v0.2.0 ──────────────────────────────────────────────
+
+
+class TestBuilderPassthrough:
+    """Regression: ``qm.run()`` accepts a ``GraphBuilder`` directly —
+    ``.build()`` is purely optional.  This pins the ergonomic shortcut
+    advertised in the v0.2.0 READMEs and every migrated example so a
+    future refactor of ``_resolve_graph`` can't silently force callers
+    back into the ``.build()`` boilerplate."""
+
+    def test_run_accepts_builder_without_explicit_build(self):
+        reg, _ = _mock_registry("no build call")
+        qm.configure(registry=reg)
+        builder = qm.Graph("x").instruction("One")
+        # Pass the BUILDER (not .build()).  run() finalises internally.
+        result = qm.run(builder, "hi")
+        assert result.success
+        assert result.text == "no build call"
+
+    def test_run_accepts_pre_built_spec_too(self):
+        """The inverse — passing the result of ``.build()`` still works."""
+        reg, _ = _mock_registry("pre built")
+        qm.configure(registry=reg)
+        spec = qm.Graph("x").instruction("One").build()
+        result = qm.run(spec, "hi")
+        assert result.success
+        assert result.text == "pre built"
+
+    def test_run_stream_accepts_builder_without_explicit_build(self):
+        reg, _ = _mock_registry("streamed")
+        qm.configure(registry=reg)
+        builder = qm.Graph("x").instruction("One")
+        chunks = list(qm.run.stream(builder, "hi"))
+        assert chunks[-1].type == "done"
+        assert chunks[-1].result.text == "streamed"
+
+
+class TestAutoStart:
+    def test_graph_constructor_creates_start_node(self):
+        graph = qm.Graph("x").instruction("Plain").build()
+        starts = [n for n in graph.nodes if n.type.value.startswith("Start")]
+        assert len(starts) == 1, "exactly one Start node should exist"
+
+    def test_explicit_start_call_is_idempotent(self):
+        """Calling .start() after auto-start must NOT create a second Start."""
+        graph = qm.Graph("x").start().instruction("Plain").build()
+        starts = [n for n in graph.nodes if n.type.value.startswith("Start")]
+        assert len(starts) == 1
+
+    def test_auto_start_opt_out(self):
+        """``auto_start=False`` restores the pre-0.2.0 manual path."""
+        with pytest.raises(ValueError, match="start node"):
+            qm.Graph("x", auto_start=False).instruction("Plain").build()
+
+
+class TestOptionalEnd:
+    def test_graph_without_end_validates_clean(self):
+        # Just builds — no .end() call.  Previously this raised "no_end".
+        graph = qm.Graph("x").instruction("Plain").build()
+        assert graph is not None
+
+
+# ── run() + capture_as + Result ──────────────────────────────────────
+
+
+class TestRunAndCaptures:
+    def test_run_returns_result_with_text(self):
+        reg, _ = _mock_registry("Pozdravljen!")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One", capture_as="one").build()
+        result = qm.run(graph, "hi")
+        assert result.success
+        assert result.text == "Pozdravljen!"
+        assert isinstance(result, qm.Result)
+
+    def test_capture_as_populates_captures_dict(self):
+        reg, _ = _mock_registry("hello")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("Named", capture_as="reply").build()
+        result = qm.run(graph, "?")
+        assert "reply" in result.captures
+        assert result.captures["reply"].output_text == "hello"
+
+    def test_result_getitem_shorthand(self):
+        reg, _ = _mock_registry("hello")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("Named", capture_as="reply").build()
+        result = qm.run(graph, "?")
+        # result["reply"] is the shorthand for result.captures["reply"]
+        assert result["reply"].output_text == "hello"
+
+    def test_missing_capture_key_raises_with_known_keys(self):
+        reg, _ = _mock_registry("hello")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("Named", capture_as="reply").build()
+        result = qm.run(graph, "?")
+        with pytest.raises(KeyError, match="Available captures: reply"):
+            _ = result["nope"]
+
+    def test_run_stream_yields_typed_chunks_ending_with_done(self):
+        reg, _ = _mock_registry("streaming words")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+
+        chunks = list(qm.run.stream(graph, "hi"))
+        types = [c.type for c in chunks]
+        # Must end with a DoneChunk that carries a populated Result.
+        assert types[-1] == "done"
+        last = chunks[-1]
+        assert isinstance(last, qm.DoneChunk)
+        assert last.result.success
+        # Intermediate events should include at least one node_start / node_finish.
+        assert "node_start" in types
+        assert "node_finish" in types
+
+    def test_run_uses_configured_registry_when_none_passed(self):
+        reg, mock = _mock_registry("configured")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+        result = qm.run(graph, "?")
+        assert result.success
+        assert mock.call_count >= 1
+
+    def test_run_override_registry_wins(self):
+        reg_a, _ = _mock_registry("A")
+        reg_b, _ = _mock_registry("B")
+        qm.configure(registry=reg_a)
+        graph = qm.Graph("x").instruction("One").build()
+        result = qm.run(graph, "?", provider_registry=reg_b)
+        assert result.text == "B"
+
+
+# ── instruction() / instruction_form() ───────────────────────────────
+
+
+class TestInstruction:
+    def test_instruction_returns_str(self):
+        reg, _ = _mock_registry("gotcha")
+        qm.configure(registry=reg)
+        reply = qm.instruction(system="sys", user="usr")
+        assert reply == "gotcha"
+
+    def test_instruction_requires_model(self):
+        reg, _ = _mock_registry()
+        # Configure without default_model — instruction() must complain
+        reg_no_default = ProviderRegistry(auto_configure=False)
+        reg_no_default.register_instance("ollama", MockProvider())
+        reg_no_default.set_default_provider("ollama")
+        qm.configure(registry=reg_no_default)
+        with pytest.raises(ValueError, match="no model resolved"):
+            qm.instruction(user="x")
+
+
+class TestInstructionForm:
+    class _Classification(BaseModel):
+        category: str
+        priority: str
+
+    def test_instruction_form_returns_pydantic_model(self):
+        canned = '{"category":"order","priority":"urgent"}'
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        out = qm.instruction_form(
+            self._Classification, system="Classify.", user="urgent order 42"
+        )
+        assert isinstance(out, self._Classification)
+        assert out.category == "order"
+        assert out.priority == "urgent"
+
+    def test_instruction_form_strips_markdown_fence(self):
+        """Models sometimes insist on fencing JSON in ```json. Must be tolerated."""
+        canned = '```json\n{"category":"ok","priority":"normal"}\n```'
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        out = qm.instruction_form(self._Classification, system="c", user="u")
+        assert out.category == "ok"
+
+    def test_instruction_form_raises_on_schema_mismatch(self):
+        canned = '{"not_the_right":"shape"}'
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        with pytest.raises(RuntimeError, match="did not match schema"):
+            qm.instruction_form(self._Classification, system="c", user="u")
+
+    def test_instruction_form_rejects_non_pydantic_schema(self):
+        reg, _ = _mock_registry("{}")
+        qm.configure(registry=reg)
+        with pytest.raises(ValueError, match="pydantic.BaseModel subclass"):
+            qm.instruction_form(dict, system="c", user="u")  # type: ignore[arg-type]
+
+
+# ── Tool-name prefix stripping ───────────────────────────────────────
+
+
+class TestToolNamePrefixStripping:
+    """Regression: Gemma-family models emit ``default_api:foo``; OpenAI
+    native wire uses ``functions:foo``; MCP bridge uses ``mcp:foo``.  All
+    three must resolve to the same registered tool."""
+
+    def test_strip_helper(self):
+        from quartermaster_engine.example_runner import _normalise_tool_name
+
+        assert _normalise_tool_name("default_api:list_orders") == "list_orders"
+        assert _normalise_tool_name("default_api.list_orders") == "list_orders"
+        assert _normalise_tool_name("functions:list_orders") == "list_orders"
+        assert _normalise_tool_name("functions.list_orders") == "list_orders"
+        assert _normalise_tool_name("mcp:list_orders") == "list_orders"
+        # Bare names pass through unchanged.
+        assert _normalise_tool_name("list_orders") == "list_orders"
+
+
+class TestMarkdownFenceStripping:
+    """Regression for the v0.2.0 reviewer HIGH: the old implementation
+    used ``str.strip("`")`` which ate backticks from anywhere in the
+    string — corrupting JSON whose string values contained literal
+    backticks.  The new regex-anchored stripper only touches the fence."""
+
+    def test_preserves_backticks_inside_json_strings(self):
+        from quartermaster_sdk._helpers import _strip_markdown_fence
+
+        raw = "```json\n" + '{"sql":"SELECT `id` FROM users"}' + "\n```"
+        assert _strip_markdown_fence(raw) == '{"sql":"SELECT `id` FROM users"}', (
+            "fence stripper must preserve backticks that appear inside string values"
+        )
+
+    def test_bare_triple_backtick_fence(self):
+        from quartermaster_sdk._helpers import _strip_markdown_fence
+
+        raw = '```\n{"ok":true}\n```'
+        assert _strip_markdown_fence(raw) == '{"ok":true}'
+
+    def test_unfenced_passes_through(self):
+        from quartermaster_sdk._helpers import _strip_markdown_fence
+
+        raw = '{"plain":"value"}'
+        assert _strip_markdown_fence(raw) == raw
+
+    def test_instruction_form_survives_backticks_in_json(self):
+        """The integration case: ``instruction_form`` returns a valid
+        Pydantic model even when the canned response contains backticks
+        inside a string field."""
+
+        class Sample(BaseModel):
+            query: str
+
+        canned = "```json\n" + '{"query":"SELECT `id` FROM users"}' + "\n```"
+        reg, _ = _mock_registry(canned)
+        qm.configure(registry=reg)
+        out = qm.instruction_form(Sample, system="c", user="u")
+        # The backticks survive — they were part of the JSON value, not the fence.
+        assert out.query == "SELECT `id` FROM users"
+
+
+class TestStreamEarlyExitCancels:
+    """Regression for the v0.2.0 reviewer HIGHs: abandoning the
+    generator early must call ``FlowRunner.stop(flow_id)`` (via the
+    pre-generated UUID) and join the runner thread within the
+    documented timeout — not leak the thread *or* let the flow keep
+    burning API calls in the background."""
+
+    def test_break_out_of_stream_finishes_promptly(self):
+        import threading as _threading
+        import time as _time
+
+        reg, _ = _mock_registry("streaming response tokens")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+
+        before = _threading.active_count()
+        for _chunk in qm.run.stream(graph, "hi"):
+            break  # abandon the iterator immediately
+        # Allow the join(timeout=5.0) in the generator's finally to run.
+        _time.sleep(0.2)
+        after = _threading.active_count()
+        # Some background threads are OK (pytest, etc.), but our named
+        # "qm-run-stream" must have exited.
+        leaked = [
+            t
+            for t in _threading.enumerate()
+            if t.name == "qm-run-stream" and t.is_alive()
+        ]
+        assert leaked == [], (
+            f"run.stream thread leaked after early break; still alive: {leaked}. "
+            f"active count went from {before} to {after}."
+        )
+
+    def test_stream_uses_pre_generated_flow_id(self, monkeypatch):
+        """The cancel path must have a flow_id to stop.  Pre-0.2.0 (in
+        the buggy intermediate commit) it captured from the first event,
+        racing with early break.  Now the flow_id is minted up front
+        and passed as ``runner.run(..., flow_id=...)`` — so even a break
+        before the first event has a valid id to stop."""
+        reg, _ = _mock_registry("ok")
+        qm.configure(registry=reg)
+        graph = qm.Graph("x").instruction("One").build()
+
+        captured: dict[str, Any] = {}
+
+        from quartermaster_engine import FlowRunner
+
+        original_run = FlowRunner.run
+
+        def capture_run(self, input_message, flow_id=None):
+            captured["flow_id_passed"] = flow_id
+            return original_run(self, input_message, flow_id=flow_id)
+
+        monkeypatch.setattr(FlowRunner, "run", capture_run)
+
+        # Consume the full stream (no break) to confirm the happy path.
+        chunks = list(qm.run.stream(graph, "hi"))
+        assert chunks[-1].type == "done"
+        assert captured["flow_id_passed"] is not None, (
+            "run.stream must pre-generate a flow_id and forward it to "
+            "FlowRunner.run(flow_id=...), otherwise cancellation can't "
+            "target the right flow."
+        )
+
+
+class TestStreamAwaitInputChunk:
+    """Coverage gap caught by code-reviewer: ``AwaitInputChunk`` (the
+    ``UserInputRequired`` → chunk mapping) wasn't exercised."""
+
+    def test_user_node_with_no_input_yields_await_chunk(self):
+        """In non-interactive mode the User node passes through the
+        input without pausing, but we can still verify the chunk
+        mapping exists and covers the UserInputRequired path."""
+        from quartermaster_engine import UserInputRequired
+
+        from quartermaster_sdk._runner import _event_to_chunk
+
+        event = UserInputRequired(
+            flow_id=None,  # type: ignore[arg-type]
+            node_id=None,  # type: ignore[arg-type]
+            prompt="Your input?",
+            options=["A", "B"],
+        )
+        chunk = _event_to_chunk(event)
+        assert isinstance(chunk, qm.AwaitInputChunk)
+        assert chunk.prompt == "Your input?"
+        assert chunk.options == ["A", "B"]
+        assert chunk.type == "await_input"
+
+
+class TestCaptureAsValidationWarning:
+    """Code-reviewer MEDIUM: ``capture_as="llm_model"`` (or any other
+    reserved metadata key) emits a warning — captures still work, but
+    the collision is visible in logs / validator output."""
+
+    def test_capture_as_shadowing_reserved_key_emits_warning(self):
+        """Building a graph with capture_as="llm_model" triggers a
+        warning (not an error) from validate_graph."""
+        from quartermaster_graph.validation import validate_graph
+
+        graph = qm.Graph("x").instruction("One", capture_as="llm_model").build()
+        issues = validate_graph(graph)
+        warnings = [i for i in issues if i.code == "capture_as_shadows_reserved_key"]
+        assert len(warnings) == 1
+        assert warnings[0].severity == "warning"
+
+    def test_normal_capture_as_emits_no_warning(self):
+        from quartermaster_graph.validation import validate_graph
+
+        graph = qm.Graph("x").instruction("One", capture_as="notes").build()
+        issues = validate_graph(graph)
+        warnings = [i for i in issues if i.code == "capture_as_shadows_reserved_key"]
+        assert warnings == []

--- a/quartermaster-sdk/tests/test_v022_async_runner.py
+++ b/quartermaster-sdk/tests/test_v022_async_runner.py
@@ -1,0 +1,111 @@
+"""Smoke tests for the v0.2.2 async runner.
+
+Covers the new :func:`quartermaster_sdk.arun` coroutine and its
+``.stream`` async-iterator counterpart.  The implementation sits on
+top of the existing sync ``FlowRunner`` via :func:`asyncio.to_thread`,
+so the happy-path assertions here mirror the sync suite in
+``test_v020_surface.py`` but exercise the ``await`` / ``async for``
+call sites instead.
+
+Provider is stubbed with :class:`MockProvider` — no real LLM is hit.
+"""
+
+from __future__ import annotations
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Copy of the helper from test_v020_surface.py.
+
+    A ProviderRegistry wired to a MockProvider registered as ``ollama``,
+    with both streamed-token and native-response channels primed so the
+    engine picks a consistent reply regardless of which path it takes.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+# ── arun() ────────────────────────────────────────────────────────────
+
+
+async def test_arun_returns_result():
+    """``await qm.arun(graph, input)`` resolves to a populated ``Result``.
+
+    This is the direct async analogue of ``qm.run(...)`` — the sync body
+    runs on an ``asyncio.to_thread`` worker but the public contract is
+    identical: a :class:`Result` whose ``.text`` contains the mock's
+    canned reply and whose ``.success`` is ``True``.
+    """
+    reg, _ = _mock_registry("async canned")
+    qm.configure(registry=reg)
+
+    graph = qm.Graph("x").instruction("One").build()
+    result = await qm.arun(graph, "hi")
+
+    assert isinstance(result, qm.Result)
+    assert result.success
+    assert result.text == "async canned"
+
+
+async def test_arun_stream_yields_chunks():
+    """``async for chunk in qm.arun.stream(graph, input)`` yields the
+    same typed :class:`Chunk` sequence as the sync ``run.stream``, and
+    terminates with a :class:`DoneChunk` carrying the final result.
+
+    Verifies at least one node-lifecycle pair (``node_start`` →
+    ``node_finish``) surfaces between the open and close of the stream,
+    so we know events are marshalling across the thread→loop boundary
+    and not just the terminal done chunk.
+    """
+    reg, _ = _mock_registry("streaming async words")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    chunks = [chunk async for chunk in qm.arun.stream(graph, "hi")]
+    types = [c.type for c in chunks]
+
+    # Must end with a DoneChunk that carries a populated Result.
+    assert types[-1] == "done"
+    last = chunks[-1]
+    assert isinstance(last, qm.DoneChunk)
+    assert last.result.success
+    assert last.result.text == "streaming async words"
+    # Lifecycle events crossed the thread→loop boundary successfully.
+    assert "node_start" in types
+    assert "node_finish" in types

--- a/quartermaster-sdk/tests/test_v022_tool_streaming.py
+++ b/quartermaster-sdk/tests/test_v022_tool_streaming.py
@@ -1,0 +1,375 @@
+"""Tests for v0.2.2 live tool-call streaming.
+
+Covers the four new surface guarantees introduced in v0.2.2:
+
+1. The engine's new ``ToolCallStarted`` / ``ToolCallFinished`` events
+   arrive during ``qm.run.stream(...)`` as typed
+   :class:`ToolCallChunk` / :class:`ToolResultChunk` chunks, in the
+   correct ordering relative to ``NodeStartChunk`` / ``NodeFinishChunk``
+   / ``DoneChunk``.
+2. A tool that raises surfaces via ``ToolResultChunk.error`` (non-None)
+   while ``.result`` carries the ``[ERROR: ...]`` sentinel string the
+   model sees on the next turn.
+3. The non-streaming ``qm.run(...)`` path populates the agent node's
+   ``NodeResult.data["tool_calls"]`` with the same shape as the streaming
+   events — so callers reading ``result["agent"].data["tool_calls"]``
+   after a sync run get the exact same record the stream surfaced.
+4. Provider-side tool-name prefixes (``default_api:``, ``functions:``,
+   ``mcp:``) are stripped in BOTH the streamed ``ToolCallChunk.tool`` AND
+   the sync ``data["tool_calls"][0]["tool"]`` — so UIs never show the
+   internal namespacing.
+
+A :class:`MockProvider` primed with two ``NativeResponse`` entries
+simulates an AgentExecutor loop: first turn requests a tool, second
+turn returns plain text and terminates the loop.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, ToolCall, TokenResponse
+
+
+# ── Test fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+def _tool_aware_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Build a :class:`ProviderRegistry` whose :class:`MockProvider`
+    replays a two-turn agent loop:
+
+    * turn 1 — model returns one ``ToolCall(tool_name, parameters)``
+    * turn 2 — model returns final text with ``tool_calls=[]`` so the
+      agent executor terminates.
+
+    ``final_text`` lands on ``NodeResult.output_text`` and on
+    ``Result.text`` so the test can assert the flow completed.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg, mock
+
+
+class _OkTool:
+    """A tool that returns a structured success payload the agent
+    executor's ``_execute_tool_call`` will surface as both the LLM-facing
+    prompt string AND the ``raw`` dict on ``ToolCallFinished``."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True, "echo": "hello"}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        # Agent executor reads ``result.data`` for structured payload.
+        r.data = dict(self._data)
+        return r
+
+
+class _RaisingTool:
+    """A tool whose ``safe_run`` raises — exercises the
+    ``[ERROR: ...]`` + ``error`` branch of ``_execute_tool_call``."""
+
+    def safe_run(self, **kwargs: Any):
+        raise RuntimeError("boom")
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's expected interface:
+    ``.get(name) → tool`` and ``.to_openai_tools() → list[dict]``.
+
+    Registered names here are the *stripped* public names (``"x"``),
+    mirroring how integrators register tools in production — the prefix
+    normalisation happens inside the agent executor before lookup.
+    """
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise KeyError(name) from exc
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+def _graph_with_agent() -> Any:
+    """Build a ``start → user → agent(tools=["x"]) → end`` graph with a
+    captured agent output so non-streaming tests can read it back via
+    ``result["agent"]``."""
+    return (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+
+# ── 1. Streaming event ordering ──────────────────────────────────────
+
+
+class TestToolCallStreaming:
+    """The engine's new ``ToolCallStarted`` / ``ToolCallFinished`` events
+    must reach the SDK stream as typed :class:`ToolCallChunk` /
+    :class:`ToolResultChunk` in the expected ordering."""
+
+    def test_tool_call_events_fire_during_stream(self):
+        reg, _ = _tool_aware_registry(
+            tool_name="x",
+            tool_args={"q": "hello"},
+            final_text="Done.",
+        )
+        qm.configure(registry=reg)
+
+        tool_reg = _ToolRegistry({"x": _OkTool({"ok": True, "echo": "hi"})})
+        graph = _graph_with_agent()
+
+        chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
+        types = [c.type for c in chunks]
+
+        # We expect, in order:
+        #   node_start (agent) → tool_call (x) → tool_result (x) →
+        #   node_finish (agent) → done
+        # Other node_start/finish pairs (e.g. user input passthrough)
+        # may appear but the agent-scoped subsequence must be intact.
+        assert "node_start" in types, f"no node_start in {types}"
+        assert "tool_call" in types, f"no tool_call in {types}"
+        assert "tool_result" in types, f"no tool_result in {types}"
+        assert "node_finish" in types, f"no node_finish in {types}"
+        assert types[-1] == "done", f"expected done last, got {types}"
+
+        # Ordering: the tool_call chunk must come AFTER at least one
+        # node_start (the agent node was started) and BEFORE the done.
+        tool_call_idx = types.index("tool_call")
+        tool_result_idx = types.index("tool_result")
+        first_node_start_idx = types.index("node_start")
+        done_idx = types.index("done")
+        assert first_node_start_idx < tool_call_idx < tool_result_idx < done_idx, (
+            f"out-of-order chunks: {types}"
+        )
+        # tool_result immediately pairs with tool_call — nothing else
+        # may slip between them for a synchronous tool.
+        assert tool_result_idx == tool_call_idx + 1, (
+            f"tool_result must immediately follow tool_call, got: {types}"
+        )
+
+        # Payload shape on the two new chunk types.
+        tool_call_chunk = next(c for c in chunks if c.type == "tool_call")
+        assert isinstance(tool_call_chunk, qm.ToolCallChunk)
+        assert tool_call_chunk.tool == "x"
+        assert tool_call_chunk.args == {"q": "hello"}
+
+        tool_result_chunk = next(c for c in chunks if c.type == "tool_result")
+        assert isinstance(tool_result_chunk, qm.ToolResultChunk)
+        assert tool_result_chunk.tool == "x"
+        assert tool_result_chunk.error is None
+        # ``result`` carries the structured ``raw`` payload when the
+        # tool returned a success envelope — mirrors ``_event_to_chunk``.
+        assert tool_result_chunk.result == {"ok": True, "echo": "hi"}
+
+
+# ── 2. Error surfacing ───────────────────────────────────────────────
+
+
+class TestToolErrorChunk:
+    """When the tool raises, ``ToolResultChunk.error`` carries the error
+    message and ``.result`` carries the ``[ERROR: ...]`` sentinel the
+    LLM sees on the next turn."""
+
+    def test_tool_call_error_surfaces_via_result_chunk_error(self):
+        reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+        qm.configure(registry=reg)
+
+        tool_reg = _ToolRegistry({"x": _RaisingTool()})
+        graph = _graph_with_agent()
+
+        chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
+        tool_result = next((c for c in chunks if c.type == "tool_result"), None)
+        assert tool_result is not None, "no tool_result chunk emitted"
+        assert isinstance(tool_result, qm.ToolResultChunk)
+
+        # The raising tool path sets ``error`` to the exception message,
+        # and ``result`` to the ``[ERROR: ...]`` sentinel fed back to the
+        # LLM (since ``raw`` is None on failure, the chunk's ``result``
+        # falls back to the prompt-facing sentinel).
+        assert tool_result.error is not None, "error must be non-None on failure"
+        assert "boom" in tool_result.error
+        assert isinstance(tool_result.result, str)
+        assert tool_result.result.startswith("[ERROR:"), (
+            f"expected [ERROR: ...] sentinel, got {tool_result.result!r}"
+        )
+
+
+# ── 3. Non-streaming run populates data["tool_calls"] ────────────────
+
+
+class TestNonStreamingToolCallCapture:
+    """``qm.run(graph, ...)`` (sync) populates
+    ``result["agent"].data["tool_calls"]`` with the same shape the
+    streaming events carry — so callers don't need to choose between
+    streaming vs introspection."""
+
+    def test_nonstreaming_run_populates_tool_calls_on_capture(self):
+        reg, _ = _tool_aware_registry(
+            tool_name="x",
+            tool_args={"q": "world"},
+            final_text="wrapped",
+        )
+        qm.configure(registry=reg)
+
+        tool_reg = _ToolRegistry({"x": _OkTool({"value": 42})})
+        graph = _graph_with_agent()
+
+        result = qm.run(graph, "hi", tool_registry=tool_reg)
+        assert result.success, result.error
+        assert result.text == "wrapped"
+
+        agent_capture = result["agent"]
+        tool_calls = agent_capture.data.get("tool_calls")
+        assert isinstance(tool_calls, list), (
+            f"expected data['tool_calls'] to be a list, got {type(tool_calls)}"
+        )
+        assert len(tool_calls) == 1, f"expected exactly 1 tool call, got {tool_calls}"
+
+        entry = tool_calls[0]
+        # Keys exactly match the ToolCallFinished event fields so both
+        # surfaces (streaming chunks + NodeResult data) stay in sync.
+        expected_keys = {"tool", "arguments", "result", "raw", "error", "iteration"}
+        assert set(entry) == expected_keys, (
+            f"keys mismatch — missing {expected_keys - set(entry)}, "
+            f"extra {set(entry) - expected_keys}"
+        )
+        assert entry["tool"] == "x"
+        assert entry["arguments"] == {"q": "world"}
+        assert entry["error"] is None
+        assert entry["raw"] == {"value": 42}
+        assert entry["iteration"] == 1
+
+
+# ── 4. Prefix normalisation on BOTH surfaces ─────────────────────────
+
+
+class TestToolPrefixNormalisation:
+    """The provider sometimes emits ``default_api:list_orders`` (Gemma
+    family) or ``functions:foo`` (OpenAI native) or ``mcp:foo`` (MCP
+    bridge).  The engine strips the prefix before dispatching the tool
+    AND before emitting ``ToolCallStarted`` / ``ToolCallFinished``, so
+    BOTH the streamed ``ToolCallChunk.tool`` and the sync
+    ``data['tool_calls'][0]['tool']`` show the bare public name."""
+
+    def test_tool_prefix_normalised_in_events(self):
+        reg, _ = _tool_aware_registry(
+            tool_name="default_api:list_orders",
+            tool_args={"status": "open"},
+            final_text="ack",
+        )
+        qm.configure(registry=reg)
+
+        # Tool is registered under the BARE name "list_orders" — the
+        # prefix is a provider-side quirk, not something integrators
+        # choose when they register tools.
+        tool_reg = _ToolRegistry(
+            {"list_orders": _OkTool({"orders": [1, 2, 3]})},
+            schema_name="list_orders",
+        )
+        graph = (
+            qm.Graph("chat")
+            .user()
+            .agent("Tooled", tools=["list_orders"], capture_as="agent")
+            .build()
+        )
+
+        # --- Streaming surface: ToolCallChunk.tool is stripped ---
+        chunks = list(qm.run.stream(graph, "hi", tool_registry=tool_reg))
+        tool_call_chunk = next(
+            (c for c in chunks if c.type == "tool_call"), None
+        )
+        assert tool_call_chunk is not None, "no tool_call chunk emitted"
+        assert isinstance(tool_call_chunk, qm.ToolCallChunk)
+        assert tool_call_chunk.tool == "list_orders", (
+            f"prefix should be stripped in streaming event, got {tool_call_chunk.tool!r}"
+        )
+
+        # --- Non-streaming surface: data['tool_calls'][0]['tool'] ---
+        # Re-run for the sync path (the streamed run already drained the
+        # mock's queued native responses).
+        reg2, _ = _tool_aware_registry(
+            tool_name="default_api:list_orders",
+            tool_args={"status": "open"},
+            final_text="ack",
+        )
+        qm.configure(registry=reg2)
+        tool_reg2 = _ToolRegistry(
+            {"list_orders": _OkTool({"orders": [1, 2, 3]})},
+            schema_name="list_orders",
+        )
+        result = qm.run(graph, "hi", tool_registry=tool_reg2)
+        assert result.success, result.error
+        tool_calls = result["agent"].data["tool_calls"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["tool"] == "list_orders", (
+            "prefix should be stripped in NodeResult.data['tool_calls'], "
+            f"got {tool_calls[0]['tool']!r}"
+        )

--- a/quartermaster-sdk/tests/test_v030_filtered_iterators.py
+++ b/quartermaster-sdk/tests/test_v030_filtered_iterators.py
@@ -1,0 +1,482 @@
+"""Tests for v0.3.0 filtered stream iterators.
+
+v0.3.0 wraps the raw ``Iterator[Chunk]`` / ``AsyncIterator[Chunk]``
+returned from ``qm.run.stream(...)`` / ``qm.arun.stream(...)`` in a
+small object exposing filter methods — ``.tokens()``, ``.tool_calls()``,
+``.progress()``, ``.custom(name=...)`` — so callers don't write the
+``if chunk.type == "token": print(chunk.content)`` boilerplate.
+
+The wrapper is still iterable / async-iterable, so every pre-0.3 code
+path that did ``for chunk in qm.run.stream(...)`` keeps working
+unchanged. This file pins both sides of the guarantee: filters yield
+the right subset, and raw iteration still yields the full stream.
+
+Single-pass contract: the wrapper owns the underlying generator. First
+consumer drains it; a second filter (or raw iter after a filter)
+raises ``RuntimeError("stream already consumed")``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse, ToolCall
+
+
+# ── Fixtures / helpers ────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Minimal mock registry — copy of the helper from test_v020_surface.py.
+
+    Token responses default to a single-chunk streamed reply and the
+    native channel is primed with the same text so either path the
+    engine picks yields a consistent string.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+def _multi_token_registry(tokens: list[str]) -> tuple[ProviderRegistry, MockProvider]:
+    """Primed mock that streams ``tokens`` as one TokenResponse per token.
+
+    ``MockProvider`` consumes its ``responses`` queue one entry per
+    streamed call, so each entry becomes one ``TokenGenerated`` event
+    which maps 1:1 to a :class:`TokenChunk`. That lets
+    ``test_tokens_filter_yields_strings_only`` assert the exact string
+    sequence produced by ``.tokens()``.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=t, stop_reason="stop") for t in tokens],
+        native_responses=[
+            NativeResponse(
+                text_content="".join(tokens),
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+# Tool-aware helpers — lifted from test_v022_tool_streaming.py so these
+# tests stay self-contained (they're the lowest-friction way to
+# provoke ToolCall / Progress / Custom chunks).
+
+
+def _tool_aware_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> tuple[ProviderRegistry, MockProvider]:
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg, mock
+
+
+class _OkTool:
+    """Plain tool that returns a structured payload. See the v0.2.2 suite."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = dict(self._data)
+        return r
+
+
+class _ProgressEmittingTool:
+    """Tool whose ``safe_run`` body emits progress + custom events.
+
+    Mirrors the documented ``@tool()`` pattern: look up the current
+    :class:`ExecutionContext` via :func:`current_context` and fire
+    ``emit_progress`` / ``emit_custom``. The agent-executor binds the
+    context before dispatching ``safe_run``, so these become real
+    :class:`ProgressChunk` / :class:`CustomChunk` entries in the stream.
+    """
+
+    def __init__(
+        self,
+        progress_message: str | None = None,
+        progress_percent: float | None = None,
+        customs: list[tuple[str, dict[str, Any]]] | None = None,
+    ):
+        self._progress_message = progress_message
+        self._progress_percent = progress_percent
+        self._customs = list(customs or [])
+
+    def safe_run(self, **kwargs: Any):
+        ctx = qm.current_context()
+        if ctx is not None:
+            if self._progress_message is not None:
+                ctx.emit_progress(self._progress_message, percent=self._progress_percent)
+            for name, payload in self._customs:
+                ctx.emit_custom(name, payload)
+
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = {"emitted": True}
+        return r
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's interface."""
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        return self._tools[name]
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+def _graph_with_agent() -> Any:
+    return (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+
+# ── 1. .tokens() yields strings ──────────────────────────────────────
+
+
+def test_tokens_filter_yields_strings_only():
+    """A stream primed with three one-token responses yields exactly
+    ``["a", "b", "c"]`` through ``.tokens()``.
+
+    Proves two things at once:
+
+    * filter returns ``str`` (not ``TokenChunk``) — the documented
+      shortcut so callers don't write ``chunk.content`` in the hot path.
+    * non-token chunks (node_start, node_finish, done) are filtered
+      out silently.
+    """
+    reg, _ = _multi_token_registry(["a", "b", "c"])
+    qm.configure(registry=reg)
+    # Three instruction nodes — one streamed TokenResponse per node.
+    graph = (
+        qm.Graph("x")
+        .instruction("A")
+        .instruction("B")
+        .instruction("C")
+        .build()
+    )
+
+    stream = qm.run.stream(graph, "hi")
+    tokens = list(stream.tokens())
+
+    assert tokens == ["a", "b", "c"], (
+        f"expected ['a', 'b', 'c'] from .tokens(), got {tokens!r}"
+    )
+
+
+# ── 2. .tool_calls() yields ToolCallChunks ───────────────────────────
+
+
+def test_tool_calls_filter_yields_tool_call_chunks():
+    """When a tool fires during the stream, ``.tool_calls()`` yields
+    the typed :class:`ToolCallChunk` — not the paired ``ToolResultChunk``,
+    not the surrounding node lifecycle events.
+    """
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hello"})
+    qm.configure(registry=reg)
+    tool_reg = _ToolRegistry({"x": _OkTool({"ok": True})})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    calls = list(stream.tool_calls())
+
+    assert len(calls) == 1, f"expected exactly 1 tool_call, got {calls}"
+    assert all(isinstance(c, qm.ToolCallChunk) for c in calls), (
+        f"all entries must be ToolCallChunk, got {[type(c) for c in calls]}"
+    )
+    assert calls[0].tool == "x"
+    assert calls[0].args == {"q": "hello"}
+
+
+# ── 3. .progress() yields ProgressChunks ─────────────────────────────
+
+
+def test_progress_filter():
+    """A tool that calls ``current_context().emit_progress(...)`` inside
+    ``safe_run`` surfaces as a :class:`ProgressChunk` on the stream —
+    ``.progress()`` pulls it out verbatim.
+    """
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+    qm.configure(registry=reg)
+    tool = _ProgressEmittingTool(
+        progress_message="searching", progress_percent=0.5
+    )
+    tool_reg = _ToolRegistry({"x": tool})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    progress_chunks = list(stream.progress())
+
+    assert len(progress_chunks) == 1, (
+        f"expected 1 progress chunk, got {progress_chunks}"
+    )
+    assert isinstance(progress_chunks[0], qm.ProgressChunk)
+    assert progress_chunks[0].message == "searching"
+    assert progress_chunks[0].percent == 0.5
+
+
+# ── 4. .custom(name=...) filters by name ─────────────────────────────
+
+
+def test_custom_filter_by_name():
+    """Two ``emit_custom`` calls ("a", "b") surface as two
+    :class:`CustomChunk` entries; ``.custom(name="a")`` yields only the
+    matching one.
+    """
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+    qm.configure(registry=reg)
+    tool = _ProgressEmittingTool(
+        customs=[("a", {"v": 1}), ("b", {"v": 2})]
+    )
+    tool_reg = _ToolRegistry({"x": tool})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    a_only = list(stream.custom(name="a"))
+
+    assert len(a_only) == 1, f"expected 1 chunk named 'a', got {a_only}"
+    assert isinstance(a_only[0], qm.CustomChunk)
+    assert a_only[0].name == "a"
+    assert a_only[0].payload == {"v": 1}
+
+
+def test_custom_filter_without_name_yields_all():
+    """``.custom()`` with no ``name=`` yields every custom chunk."""
+    reg, _ = _tool_aware_registry(tool_name="x", tool_args={"q": "hi"})
+    qm.configure(registry=reg)
+    tool = _ProgressEmittingTool(
+        customs=[("a", {"v": 1}), ("b", {"v": 2})]
+    )
+    tool_reg = _ToolRegistry({"x": tool})
+    graph = _graph_with_agent()
+
+    stream = qm.run.stream(graph, "hi", tool_registry=tool_reg)
+    all_customs = list(stream.custom())
+
+    assert len(all_customs) == 2
+    names = {c.name for c in all_customs}
+    assert names == {"a", "b"}
+
+
+# ── 5. Raw iteration still works (regression guard) ──────────────────
+
+
+def test_raw_iteration_still_works():
+    """Pre-v0.3 code paths that did ``for chunk in qm.run.stream(...)``
+    must keep yielding the full chunk sequence unchanged — the wrapper
+    object is itself iterable and delegates to the underlying generator.
+    """
+    reg, _ = _mock_registry("streaming words")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    chunks = [c for c in stream]
+    types = [c.type for c in chunks]
+
+    # Same terminal guarantee as test_v020_surface — DoneChunk last,
+    # populated Result, at least one node lifecycle pair.
+    assert types[-1] == "done"
+    last = chunks[-1]
+    assert isinstance(last, qm.DoneChunk)
+    assert last.result.success
+    assert "node_start" in types
+    assert "node_finish" in types
+
+
+# ── 6. Single-pass contract ──────────────────────────────────────────
+
+
+def test_double_consumption_raises():
+    """Calling a filter twice on the same wrapper raises ``RuntimeError``
+    with the documented ``"stream already consumed"`` message — so the
+    mistake shows up immediately instead of silently yielding zero
+    chunks from a drained generator.
+    """
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    # First consumer drains the generator — we don't care what it yields.
+    list(stream.tokens())
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        list(stream.tokens())
+
+
+def test_filter_then_raw_iter_raises():
+    """Any two entry points on the same wrapper share the single-pass
+    flag — filter-then-raw-iter trips the same guard."""
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    list(stream.tokens())
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        for _ in stream:
+            pass
+
+
+def test_raw_iter_then_filter_raises():
+    """Inverse of the previous — raw iteration first, filter second."""
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.run.stream(graph, "hi")
+    list(stream)
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        list(stream.tokens())
+
+
+# ── 7. Async equivalents ─────────────────────────────────────────────
+
+
+async def test_async_tokens_filter():
+    """Async analogue of test_tokens_filter_yields_strings_only —
+    ``async for token in qm.arun.stream(...).tokens()`` yields ``str``."""
+    reg, _ = _multi_token_registry(["a", "b", "c"])
+    qm.configure(registry=reg)
+    graph = (
+        qm.Graph("x")
+        .instruction("A")
+        .instruction("B")
+        .instruction("C")
+        .build()
+    )
+
+    stream = qm.arun.stream(graph, "hi")
+    tokens = [t async for t in stream.tokens()]
+
+    assert tokens == ["a", "b", "c"], (
+        f"expected ['a', 'b', 'c'] from async .tokens(), got {tokens!r}"
+    )
+
+
+async def test_async_raw_iteration():
+    """Regression: ``async for chunk in qm.arun.stream(...)`` continues
+    to yield the raw full chunk sequence — the async wrapper is itself
+    async-iterable and delegates to the underlying async generator.
+    """
+    reg, _ = _mock_registry("streaming async words")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.arun.stream(graph, "hi")
+    chunks = [c async for c in stream]
+    types = [c.type for c in chunks]
+
+    assert types[-1] == "done"
+    last = chunks[-1]
+    assert isinstance(last, qm.DoneChunk)
+    assert last.result.success
+    assert "node_start" in types
+    assert "node_finish" in types
+
+
+async def test_async_double_consumption_raises():
+    """The single-pass guarantee applies to the async wrapper too."""
+    reg, _ = _mock_registry("hi")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    stream = qm.arun.stream(graph, "hi")
+    _ = [t async for t in stream.tokens()]
+
+    with pytest.raises(RuntimeError, match="stream already consumed"):
+        _ = [t async for t in stream.tokens()]

--- a/quartermaster-sdk/tests/test_v030_telemetry.py
+++ b/quartermaster-sdk/tests/test_v030_telemetry.py
@@ -1,0 +1,334 @@
+"""Tests for the v0.3.0 OpenTelemetry instrumentation module.
+
+Covers four guarantees of :mod:`quartermaster_sdk.telemetry`:
+
+1. After :func:`telemetry.instrument`, every node executed by
+   :func:`qm.run` produces a ``qm.node.<name>`` OpenTelemetry span.
+2. Tool calls during an agent node produce a ``qm.tool.<name>`` span
+   parented to the agent's ``qm.node.<name>`` span.
+3. :func:`telemetry.uninstrument` removes the listener so subsequent
+   flows emit zero spans.
+4. ``ProgressEvent`` from inside a tool surfaces as an OTEL span event
+   with name ``progress`` on the active node span.
+
+All tests run only when the optional ``opentelemetry`` extra is
+installed — skipped cleanly otherwise so the bare-bones SDK test suite
+stays portable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import openai  # noqa: F401 — eager import; see test_ollama_chat.py for context
+
+import pytest
+
+# Skip the entire module if OTEL isn't installed — keeps the bare SDK
+# test run green for users who haven't pulled the [telemetry] extra.
+pytest.importorskip("opentelemetry")
+
+# Imported here so missed imports surface as ImportError, not skip.
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+import quartermaster_sdk as qm
+from quartermaster_engine.context.current_context import current_context
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import (
+    NativeResponse,
+    TokenResponse,
+    ToolCall,
+)
+from quartermaster_sdk import telemetry
+from quartermaster_sdk import _listeners as _listeners_mod
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def exporter() -> InMemorySpanExporter:
+    """Fresh in-memory span exporter wired to a private TracerProvider.
+
+    A private provider per test prevents cross-test span pollution and
+    avoids stomping on whatever the global provider is configured for.
+    """
+    provider = TracerProvider()
+    exp = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    yield exp, provider
+    exp.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(exporter):
+    """Reset SDK config + telemetry state between tests."""
+    qm.reset_config()
+    # Make sure a stray instrument() from a previous test doesn't leak.
+    telemetry.uninstrument()
+    _listeners_mod.clear()
+    yield
+    telemetry.uninstrument()
+    _listeners_mod.clear()
+    qm.reset_config()
+
+
+def _mock_registry(text: str = "ok") -> ProviderRegistry:
+    """Single-shot mock provider — same shape as test_v022_async_runner."""
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg
+
+
+def _agent_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> ProviderRegistry:
+    """Mock provider primed for a 2-turn agent loop (one tool call)."""
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg
+
+
+class _OkTool:
+    """Tool that always succeeds with a fixed payload."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = dict(self._data)
+        return r
+
+
+class _ProgressTool:
+    """Tool that emits a ``ProgressEvent`` while running."""
+
+    def safe_run(self, **kwargs: Any):
+        ctx = current_context()
+        if ctx is not None:
+            ctx.emit_progress("loading", percent=0.5, data={"step": "fetch"})
+
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = {"ok": True}
+        return r
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's expected interface."""
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        return self._tools[name]
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+# ── 1. Node spans ────────────────────────────────────────────────────
+
+
+def test_instrument_creates_span_per_node(exporter):
+    """Each executed node yields a ``qm.node.<name>`` OTEL span.
+
+    A two-instruction graph executes Start → Instruction → Instruction →
+    End plus the auto-injected user node, so we expect at least the
+    two named instruction spans plus a root flow span.
+    """
+    exp, provider = exporter
+    qm.configure(registry=_mock_registry("ok"))
+    telemetry.instrument(tracer_provider=provider)
+
+    graph = (
+        qm.Graph("x")
+        .instruction("first")
+        .instruction("second")
+        .build()
+    )
+    result = qm.run(graph, "hi")
+    assert result.success, result.error
+
+    spans = exp.get_finished_spans()
+    names = [s.name for s in spans]
+    # Root flow span always present once a single event fired.
+    assert "qm.flow" in names, f"missing qm.flow span; got {names}"
+    # Both named instruction nodes produced their own spans.
+    assert "qm.node.first" in names, f"missing first node span; got {names}"
+    assert "qm.node.second" in names, f"missing second node span; got {names}"
+
+    # Each node span carries the GenAI semconv attributes.
+    for span in spans:
+        if span.name.startswith("qm.node."):
+            assert span.attributes.get("gen_ai.system") == "quartermaster"
+            assert "gen_ai.operation.name" in span.attributes
+
+
+# ── 2. Tool spans nested under agent ─────────────────────────────────
+
+
+def test_instrument_creates_tool_spans_under_agent_node(exporter):
+    """Tool spans are parented to the enclosing agent node span."""
+    exp, provider = exporter
+    qm.configure(registry=_agent_registry(tool_name="x", final_text="done"))
+    telemetry.instrument(tracer_provider=provider)
+
+    tool_reg = _ToolRegistry({"x": _OkTool({"echo": "hi"})})
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    spans = exp.get_finished_spans()
+    names = [s.name for s in spans]
+
+    # Tool span exists.
+    tool_spans = [s for s in spans if s.name == "qm.tool.x"]
+    assert tool_spans, f"no qm.tool.x span; got {names}"
+    tool_span = tool_spans[0]
+
+    # Tool span carries gen_ai.tool.* attributes.
+    assert tool_span.attributes.get("gen_ai.tool.name") == "x"
+    assert "gen_ai.tool.call.arguments" in tool_span.attributes
+
+    # The agent node span exists and is the tool span's parent.
+    agent_spans = [s for s in spans if s.name == "qm.node.Tooled"]
+    assert agent_spans, f"no qm.node.Tooled span; got {names}"
+    agent_span = agent_spans[0]
+
+    assert tool_span.parent is not None, "tool span has no parent context"
+    assert tool_span.parent.span_id == agent_span.context.span_id, (
+        "tool span parent must be the agent node span; "
+        f"tool.parent.span_id={tool_span.parent.span_id} "
+        f"agent.span_id={agent_span.context.span_id}"
+    )
+
+
+# ── 3. Uninstrument removes the listener ─────────────────────────────
+
+
+def test_uninstrument_removes_listener(exporter):
+    """After uninstrument(), no spans flow to the exporter."""
+    exp, provider = exporter
+    qm.configure(registry=_mock_registry("ok"))
+
+    telemetry.instrument(tracer_provider=provider)
+    telemetry.uninstrument()
+
+    graph = qm.Graph("x").instruction("One").build()
+    result = qm.run(graph, "hi")
+    assert result.success
+
+    spans = exp.get_finished_spans()
+    assert len(spans) == 0, (
+        f"expected zero spans after uninstrument, got {[s.name for s in spans]}"
+    )
+
+
+# ── 4. Progress events become span events ────────────────────────────
+
+
+def test_progress_event_becomes_span_event(exporter):
+    """Tool-emitted ProgressEvent appears as a span event named ``progress``."""
+    exp, provider = exporter
+    qm.configure(registry=_agent_registry(tool_name="p", final_text="done"))
+    telemetry.instrument(tracer_provider=provider)
+
+    tool_reg = _ToolRegistry({"p": _ProgressTool()}, schema_name="p")
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Loader", tools=["p"], capture_as="agent")
+        .build()
+    )
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    spans = exp.get_finished_spans()
+
+    # Search every node-or-tool span for a "progress" event — it lives
+    # on whichever span was active when ``emit_progress`` fired.
+    progress_events: list[Any] = []
+    for span in spans:
+        for evt in span.events:
+            if evt.name == "progress":
+                progress_events.append((span.name, evt))
+
+    assert progress_events, (
+        f"no 'progress' span event found; spans={[(s.name, [e.name for e in s.events]) for s in spans]}"
+    )
+    # Payload made it through the OTEL boundary.
+    span_name, evt = progress_events[0]
+    assert evt.attributes.get("message") == "loading"
+    assert evt.attributes.get("percent") == 0.5

--- a/quartermaster-sdk/tests/test_v030_trace.py
+++ b/quartermaster-sdk/tests/test_v030_trace.py
@@ -1,0 +1,457 @@
+"""Tests for v0.3.0 structured trace.
+
+Covers the :class:`quartermaster_sdk.Trace` / :class:`NodeTrace` surface
+that every :class:`Result` now carries:
+
+* ``result.trace.text`` — concatenated :class:`TokenGenerated` tokens
+* ``result.trace.tool_calls`` — dicts extracted from
+  :class:`ToolCallFinished` events
+* ``result.trace.by_node["name"]`` — per-node :class:`NodeTrace` buckets
+* ``result.trace.progress`` / ``result.trace.custom(name=...)`` — event
+  filter shortcuts
+* ``result.trace.as_jsonl()`` — JSONL export
+* Populated for both streaming (``DoneChunk.result``) and non-streaming
+  runs
+* ``result.trace.duration_seconds`` — wall-clock
+
+The :class:`MockProvider` / ``_OkTool`` / ``_ToolRegistry`` shim pattern
+is lifted wholesale from :mod:`tests.test_v022_tool_streaming`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import openai  # noqa: F401 — eager import, see test_ollama_chat.py for context
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse, ToolCall
+
+
+# ── Test fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset module-level config between tests."""
+    qm.reset_config()
+    yield
+    qm.reset_config()
+
+
+def _mock_registry(
+    text: str = "canned",
+    native_text: str | None = None,
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Mirror of :func:`test_v020_surface._mock_registry`.
+
+    Primes both the streamed-token and the native-response channels so
+    a graph built without ``agent()`` gets the same string from either
+    path the engine might take.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content=native_text if native_text is not None else text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    return reg, mock
+
+
+def _tool_aware_registry(
+    tool_name: str = "x",
+    tool_args: dict[str, Any] | None = None,
+    final_text: str = "Done.",
+) -> tuple[ProviderRegistry, MockProvider]:
+    """Mirror of :func:`test_v022_tool_streaming._tool_aware_registry`."""
+    mock = MockProvider(
+        responses=[TokenResponse(content=final_text, stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="",
+                thinking=[],
+                tool_calls=[
+                    ToolCall(
+                        tool_name=tool_name,
+                        tool_id="call_1",
+                        parameters=tool_args or {"q": "hello"},
+                    )
+                ],
+                stop_reason="tool_calls",
+            ),
+            NativeResponse(
+                text_content=final_text,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg, mock
+
+
+class _OkTool:
+    """Same success-envelope tool used by v0.2.2 tests."""
+
+    def __init__(self, data: dict[str, Any] | None = None):
+        self._data = data or {"ok": True, "echo": "hello"}
+
+    def safe_run(self, **kwargs: Any):
+        class _R:
+            success = True
+
+        r = _R()
+        r.data = dict(self._data)
+        return r
+
+
+class _ToolRegistry:
+    """Minimal shim matching the agent executor's expected interface —
+    ``.get(name)`` plus ``.to_openai_tools()``.
+
+    Keeps the same contract as ``test_v022_tool_streaming._ToolRegistry``
+    so a tool registered under its bare public name can be invoked by
+    name from a :class:`MockProvider`-driven agent loop.
+    """
+
+    def __init__(self, tools: dict[str, Any], schema_name: str = "x"):
+        self._tools = tools
+        self._schema_name = schema_name
+
+    def get(self, name: str):
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise KeyError(name) from exc
+
+    def to_openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": self._schema_name,
+                    "description": "stub",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+
+# ── 1. ``trace.text`` aggregates all tokens ──────────────────────────
+
+
+def test_trace_text_aggregates_all_tokens():
+    """The mock provider streams ``"hello world"`` — the trace's
+    :attr:`Trace.text` must be exactly that string, concatenated from
+    every :class:`TokenGenerated` event regardless of which node emitted
+    it."""
+    reg, _ = _mock_registry("hello world")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    result = qm.run(graph, "hi")
+
+    assert isinstance(result.trace, qm.Trace)
+    # The mock's streamed response is a single TokenResponse — the
+    # engine delivers it as one token, so ``trace.text`` equals the
+    # whole canned reply. Using ``result.text`` as the oracle keeps
+    # this robust to how the mock is tokenised internally.
+    assert result.trace.text == result.text == "hello world"
+
+
+# ── 2. Tool-call records extracted from ToolCallFinished events ──────
+
+
+def test_trace_tool_calls_extracted_from_events():
+    """One tool call → exactly one :class:`ToolCallFinished` event →
+    exactly one dict in :attr:`Trace.tool_calls` carrying every field
+    the spec requires (``tool``, ``arguments``, ``result``, ``raw``,
+    ``error``, ``iteration``)."""
+    reg, _ = _tool_aware_registry(
+        tool_name="x", tool_args={"q": "world"}, final_text="ack"
+    )
+    qm.configure(registry=reg)
+
+    tool_reg = _ToolRegistry({"x": _OkTool({"value": 42})})
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    tool_calls = result.trace.tool_calls
+    assert isinstance(tool_calls, list), (
+        f"expected list, got {type(tool_calls)}"
+    )
+    assert len(tool_calls) == 1, f"expected exactly 1 tool call, got {tool_calls}"
+
+    entry = tool_calls[0]
+    expected_keys = {"tool", "arguments", "result", "raw", "error", "iteration"}
+    assert set(entry) == expected_keys, (
+        f"keys mismatch — missing {expected_keys - set(entry)}, "
+        f"extra {set(entry) - expected_keys}"
+    )
+    assert entry["tool"] == "x"
+    assert entry["arguments"] == {"q": "world"}
+    assert entry["error"] is None
+    assert entry["raw"] == {"value": 42}
+    assert isinstance(entry["iteration"], int)
+
+
+# ── 3. by_node buckets events by node name ──────────────────────────
+
+
+def test_trace_by_node_buckets_events_by_name():
+    """Two named instruction nodes; each :class:`NodeTrace.events` must
+    contain only the events from its own node (the ``NodeStarted`` /
+    ``NodeFinished`` pair plus any tokens scoped to it).
+
+    The :class:`MockProvider` is primed with two responses so the engine
+    can serve each instruction node independently — the test asserts
+    that the two per-node buckets in :attr:`Trace.by_node` carry
+    disjoint event lists keyed by the two node names.
+    """
+    mock = MockProvider(
+        responses=[
+            TokenResponse(content="first-out", stop_reason="stop"),
+            TokenResponse(content="second-out", stop_reason="stop"),
+        ],
+        native_responses=[
+            NativeResponse(
+                text_content="first-out",
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+            NativeResponse(
+                text_content="second-out",
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            ),
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("ollama", mock)
+    reg.set_default_provider("ollama")
+    reg.set_default_model("ollama", "mock-model")
+    qm.configure(registry=reg)
+
+    # The ``instruction(name, ...)`` first arg IS the node's name — no
+    # second ``name=`` kwarg. The trace buckets on that same string
+    # via :class:`NodeStarted.node_name` / :class:`NodeFinished.node_name`.
+    graph = (
+        qm.Graph("x")
+        .instruction("node_a")
+        .instruction("node_b")
+        .build()
+    )
+
+    result = qm.run(graph, "hi")
+    assert result.success, result.error
+
+    assert "node_a" in result.trace.by_node, (
+        f"node_a missing from by_node keys: {list(result.trace.by_node)}"
+    )
+    assert "node_b" in result.trace.by_node, (
+        f"node_b missing from by_node keys: {list(result.trace.by_node)}"
+    )
+
+    node_a_trace = result.trace.by_node["node_a"]
+    node_b_trace = result.trace.by_node["node_b"]
+
+    # Each per-node bucket carries at least the NodeStarted and
+    # NodeFinished events for that node plus its own tokens — we
+    # don't hard-code counts (the engine may emit other events too)
+    # but the two buckets must be disjoint by identity.
+    assert isinstance(node_a_trace, qm.NodeTrace)
+    assert node_a_trace.node_name == "node_a"
+    assert isinstance(node_b_trace, qm.NodeTrace)
+    assert node_b_trace.node_name == "node_b"
+
+    # No event in node_a's bucket may appear in node_b's bucket.
+    a_ids = {id(e) for e in node_a_trace.events}
+    b_ids = {id(e) for e in node_b_trace.events}
+    assert a_ids.isdisjoint(b_ids), (
+        "by_node buckets must be disjoint — event overlap indicates "
+        "the latch logic leaked events across nodes"
+    )
+
+    # Per-node text accessor must scope correctly.  Tokens emitted for
+    # node_a are the ones the engine generated for that node; combining
+    # them must equal that node's share of ``result.trace.text``.
+    combined = node_a_trace.text + node_b_trace.text
+    assert combined == result.trace.text, (
+        f"per-node text should concat to trace.text: "
+        f"got {combined!r} vs {result.trace.text!r}"
+    )
+
+
+# ── 4. Progress + custom filters ─────────────────────────────────────
+
+
+def test_trace_progress_and_custom_filters():
+    """A tool emits one :class:`ProgressEvent` and one
+    :class:`CustomEvent`.  After the run:
+
+    * ``result.trace.progress`` must carry the progress event
+    * ``result.trace.custom(name="x")`` must carry only the matching
+      custom event (here named ``"x"``) — zero matches for a different
+      name.
+    """
+    # Tool that emits progress + custom via the contextvar on each call.
+    class _EmittingTool:
+        """Emit progress/custom when invoked by the agent loop."""
+
+        def safe_run(self, **kwargs: Any):
+            ctx = qm.current_context()
+            # Contract: the agent executor runs inside
+            # ``bind_current_context(...)`` so ctx is non-None here.
+            assert ctx is not None, (
+                "current_context() returned None inside tool — "
+                "contextvar propagation is broken"
+            )
+            ctx.emit_progress("emitting", percent=0.5)
+            ctx.emit_custom("x", {"hello": "world"})
+
+            class _R:
+                success = True
+
+            r = _R()
+            r.data = {"ok": True}
+            return r
+
+    reg, _ = _tool_aware_registry(
+        tool_name="x", tool_args={"q": "q"}, final_text="ok"
+    )
+    qm.configure(registry=reg)
+    tool_reg = _ToolRegistry({"x": _EmittingTool()})
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent("Tooled", tools=["x"], capture_as="agent")
+        .build()
+    )
+
+    result = qm.run(graph, "hi", tool_registry=tool_reg)
+    assert result.success, result.error
+
+    # Progress filter: one event, with the message & percent we emitted.
+    progress = result.trace.progress
+    assert len(progress) == 1, f"expected 1 progress event, got {progress}"
+    assert progress[0].message == "emitting"
+    assert progress[0].percent == 0.5
+
+    # Custom filter by name: only matching events come back.
+    custom_x = result.trace.custom(name="x")
+    assert len(custom_x) == 1, f"expected 1 custom event named 'x', got {custom_x}"
+    assert custom_x[0].name == "x"
+    assert custom_x[0].payload == {"hello": "world"}
+
+    # Different name filter → zero matches.
+    assert result.trace.custom(name="other") == [], (
+        "filter by non-matching name must return []"
+    )
+
+    # No-arg filter returns every custom event (just the one here).
+    assert len(result.trace.custom()) == 1
+
+
+# ── 5. JSONL round-trip ──────────────────────────────────────────────
+
+
+def test_trace_as_jsonl_roundtrips():
+    """:meth:`Trace.as_jsonl` produces one valid JSON object per line,
+    and the number of lines equals the number of events in the trace.
+    """
+    reg, _ = _mock_registry("abc")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    result = qm.run(graph, "hi")
+    jsonl = result.trace.as_jsonl()
+
+    # Every line must parse as JSON.
+    lines = jsonl.splitlines()
+    assert len(lines) == len(result.trace.events), (
+        f"line count {len(lines)} != event count {len(result.trace.events)}"
+    )
+    for line in lines:
+        parsed = json.loads(line)
+        assert isinstance(parsed, dict), f"line not a JSON object: {line}"
+        # ``flow_id`` is required on every FlowEvent (it's the only
+        # base-class field) — its presence is the cheapest sanity check
+        # that ``asdict`` serialised the dataclass correctly.
+        assert "flow_id" in parsed, f"line missing flow_id: {line}"
+
+
+# ── 6. Streaming run populates trace on DoneChunk.result ────────────
+
+
+def test_trace_populated_for_streaming_run():
+    """Drain :func:`run.stream` to the terminal :class:`DoneChunk` and
+    assert its :attr:`Result.trace.text` matches the streamed canned
+    reply — the streaming path installs the same collector as the
+    sync path so both surfaces expose the trace.
+    """
+    reg, _ = _mock_registry("streamed reply")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    chunks = list(qm.run.stream(graph, "hi"))
+
+    done = chunks[-1]
+    assert isinstance(done, qm.DoneChunk)
+    assert isinstance(done.result.trace, qm.Trace)
+    assert done.result.trace.text == "streamed reply"
+    # The trace must also carry events (i.e. the collector actually ran
+    # — a default-constructed Trace() has an empty event list, which
+    # would pass the .text check above trivially).
+    assert len(done.result.trace.events) > 0, (
+        "streaming path produced a Trace with zero events — "
+        "on_event collector didn't run"
+    )
+
+
+# ── 7. Duration recorded ─────────────────────────────────────────────
+
+
+def test_trace_duration_seconds_recorded():
+    """:attr:`Trace.duration_seconds` is populated to a positive value
+    after a run — either mirroring :attr:`Result.duration_seconds` or
+    falling back to the runner's wall-clock measurement.
+    """
+    reg, _ = _mock_registry("x")
+    qm.configure(registry=reg)
+    graph = qm.Graph("x").instruction("One").build()
+
+    result = qm.run(graph, "hi")
+
+    assert result.trace.duration_seconds > 0, (
+        f"expected positive duration, got {result.trace.duration_seconds!r}"
+    )

--- a/quartermaster-tools/pyproject.toml
+++ b/quartermaster-tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-tools"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tool abstraction framework and chain-of-responsibility handler pattern for AI agent orchestration"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 web = ["httpx>=0.25.0"]
-llm = ["quartermaster-providers>=0.2.0"]
+llm = ["quartermaster-providers>=0.2.1"]
 database = ["sqlalchemy>=2.0"]
 vector = ["chromadb>=0.4", "sentence-transformers>=2.2"]
 privacy = ["presidio-analyzer>=2.2"]

--- a/quartermaster-tools/pyproject.toml
+++ b/quartermaster-tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartermaster-tools"
-version = "0.1.6"
+version = "0.2.0"
 description = "Tool abstraction framework and chain-of-responsibility handler pattern for AI agent orchestration"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 web = ["httpx>=0.25.0"]
-llm = ["quartermaster-providers>=0.1.6"]
+llm = ["quartermaster-providers>=0.2.0"]
 database = ["sqlalchemy>=2.0"]
 vector = ["chromadb>=0.4", "sentence-transformers>=2.2"]
 privacy = ["presidio-analyzer>=2.2"]

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/quartermaster-tools/src/quartermaster_tools/__init__.py
+++ b/quartermaster-tools/src/quartermaster_tools/__init__.py
@@ -71,7 +71,7 @@ from quartermaster_tools.types import (
     ToolResult,
 )
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 __all__ = [
     "AbstractLocalTool",
     "AbstractTool",

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,7 +3143,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-providers" }
 dependencies = [
     { name = "httpx" },
@@ -3197,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3254,6 +3254,10 @@ privacy = [
 providers-all = [
     { name = "quartermaster-providers", extra = ["all"] },
 ]
+telemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+]
 tools-all = [
     { name = "quartermaster-tools", extra = ["all"] },
 ]
@@ -3267,6 +3271,8 @@ web = [
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.41.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.41.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -3292,11 +3298,11 @@ requires-dist = [
     { name = "quartermaster-tools", extras = ["web"], marker = "extra == 'web'", editable = "quartermaster-tools" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
 ]
-provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "web", "browser", "database", "vector", "privacy", "observability", "tools-all", "mcp", "code-runner", "all", "dev"]
+provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "web", "browser", "database", "vector", "privacy", "observability", "tools-all", "mcp", "code-runner", "all", "dev", "telemetry"]
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3370,7 +3376,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "quartermaster-code-runner"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-code-runner" }
 dependencies = [
     { name = "docker" },
@@ -3005,7 +3005,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-engine"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-engine" }
 dependencies = [
     { name = "quartermaster-graph" },
@@ -3051,7 +3051,7 @@ provides-extras = ["sqlite", "redis", "all", "dev"]
 
 [[package]]
 name = "quartermaster-graph"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-graph" }
 dependencies = [
     { name = "pydantic" },
@@ -3079,7 +3079,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-mcp-client"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-mcp-client" }
 dependencies = [
     { name = "httpx" },
@@ -3109,7 +3109,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-nodes"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-nodes" }
 dependencies = [
     { name = "jinja2" },
@@ -3143,7 +3143,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "quartermaster-providers"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-providers" }
 dependencies = [
     { name = "httpx" },
@@ -3197,7 +3197,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "all", "dev"]
 
 [[package]]
 name = "quartermaster-sdk"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-sdk" }
 dependencies = [
     { name = "quartermaster-engine" },
@@ -3296,7 +3296,7 @@ provides-extras = ["openai", "anthropic", "google", "groq", "providers-all", "we
 
 [[package]]
 name = "quartermaster-tools"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "quartermaster-tools" }
 dependencies = [
     { name = "simpleeval" },
@@ -3370,7 +3370,7 @@ provides-extras = ["web", "llm", "database", "vector", "privacy", "observability
 
 [[package]]
 name = "quartermaster-workspace"
-version = "0.1.5"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
develop has been behind master since the v0.2.1 release (PR #14) — the standard back-merge never happened. Rather than back-merge release commits one by one, this PR brings ALL the v0.2.2 + v0.3.0 work onto develop in one pass.

## Commits this lands on develop

**v0.2.2 (already on master, PR #16):**
- \`1c42d96\` Add async runner (qm.arun / qm.arun.stream)
- \`969360f\` Live tool-call streaming: ToolCallStarted / ToolCallFinished events

**v0.3.0 (open as PR #17 against master):**
- \`a4d21c1\` Filtered stream iterators (\`.tokens()\` / \`.tool_calls()\` / \`.progress()\` / \`.custom()\`)
- \`8c137d6\` OpenTelemetry instrumentation module
- \`a93a075\` Structured Trace / NodeTrace on Result
- \`559e197\` Events foundation: ProgressEvent, CustomEvent, current_context

## After this lands

develop will be at the same code level as the v0.3.0 PR head, so any new feature branches cut from develop start with the full v0.2.2 + v0.3.0 surface in place.

## Conflicts

Likely some version-string conflicts on \`pyproject.toml\` / \`__init__.py\` files where develop says \`0.2.0\` and this branch (rooted on master) says \`0.2.1\`. Resolution: keep the higher version everywhere (\`0.2.1\` from this branch). Trivial.

If GitHub flags conflicts I can't resolve through the UI, ping me and I'll resolve locally.