### PR TITLE
v0.3.1: revert .end() overload, add .back() node, drop .start(), telemetry auto-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ The LLM classifies input and picks ONE branch. No merge needed.
 ```python
 agent = (
     Graph("Router")
-    .start()
     .user("Describe your issue")
     .instruction("Classify", system_instruction="Classify as: Technical or General.")
     .decision("Category?", options=["Technical", "General"])
@@ -188,7 +187,6 @@ All branches run concurrently, then merge.
 ```python
 agent = (
     Graph("Code Review")
-    .start()
     .user("Paste your code")
     .parallel()
     .branch()
@@ -208,7 +206,6 @@ agent = (
 ```python
 agent = (
     Graph("Registration")
-    .start()
     .user("Welcome!")
     .user_form("Details", parameters=[
         {"name": "full_name", "type": "text", "label": "Name", "required": "true"},
@@ -314,9 +311,9 @@ quartermaster-code-runner   Standalone Docker code execution
 
 ## Key Concepts
 
-- **Graph** -- A directed graph (supports cycles via `connect()` for loops) of nodes and edges. Built with the fluent `Graph("name").start().user("Input")...end()` API.
+- **Graph** -- A directed graph (supports cycles via `connect()` for loops) of nodes and edges. Built with the fluent `Graph("name").user("Input")...end()` API (Start node auto-inserted).
 - **GraphSpec** -- The serializable graph model (`GraphSpec` in quartermaster-graph). `qm.run(graph, ...)` finalises the builder for you; explicit `Graph.build()` only matters when you want the validated spec to serialise / inspect. `AgentGraph` remains as a deprecated backward-compat alias.
-- **User Node** -- Every graph starts with `.user()` after `.start()` to collect user input.
+- **User Node** -- Every graph typically begins with `.user()` to collect user input (Start node is auto-inserted).
 - **Nodes** -- Units of work: LLM calls, decisions, user input, memory, tools, templates.
 - **Edges** -- Directed connections between nodes. Decision/IF/Switch edges carry labels.
 - **Thoughts** -- Runtime containers that carry text and variables (metadata) between nodes.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -13,7 +13,7 @@ from quartermaster_engine.stores.memory_store import InMemoryStore
 from quartermaster_engine.dispatchers.sync_dispatcher import SyncDispatcher
 
 runner = FlowRunner(
-    graph=graph,                          # Graph instance from Graph("name").start()...end()
+    graph=graph,                          # Graph instance from Graph("name").user()...end()
     node_registry=SimpleNodeRegistry(),   # Maps node types to executors
     store=InMemoryStore(),                # Execution state storage (optional)
     dispatcher=SyncDispatcher(),          # Execution strategy (optional)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,6 @@ from quartermaster_graph import Graph
 
 graph = (
     Graph("My First Agent")
-    .start()
     .user("What would you like to know?")
     .instruction("Analyze input", model="gpt-4o", temperature=0.7)
     .end()
@@ -111,7 +110,6 @@ Make it more interesting with a decision node:
 ```python
 graph = (
     Graph("Sentiment Analyzer")
-    .start()
     .user("Enter text to analyze")
     .instruction(
         "Classify sentiment",

--- a/docs/graph-building.md
+++ b/docs/graph-building.md
@@ -23,12 +23,11 @@ graph = Graph("My Agent", description="Processes user queries")
 
 ### Linear Chains
 
-The simplest pattern is a linear sequence of nodes. Every graph should have a `.user()` node after `.start()` to collect input:
+The simplest pattern is a linear sequence of nodes. Every graph should have a `.user()` node near the top to collect input (the Start node is auto-inserted since v0.2.0):
 
 ```python
 graph = (
     Graph("Simple Chain")
-    .start()
     .user("Enter text to process")
     .instruction("Step 1", model="gpt-4o", system_instruction="Summarize the input.")
     .instruction("Step 2", model="gpt-4o", system_instruction="Translate to French.")
@@ -46,7 +45,6 @@ next node.
 ```python
 graph = (
     Graph("Router")
-    .start()
     .user("What would you like help with?")
     .instruction(
         "Classify",
@@ -75,7 +73,6 @@ For boolean conditions, use `.if_node()`:
 ```python
 graph = (
     Graph("Conditional")
-    .start()
     .user("Enter your text")
     .if_node("Check length", expression="len(input) > 100")
     .on("true")
@@ -106,7 +103,6 @@ Two flavours:
 ```python
 graph = (
     Graph("Parallel with Merge")
-    .start()
     .user("Enter your request")
     .instruction("Prepare")
     .parallel()
@@ -130,7 +126,6 @@ branch with `.branch()`, and rejoin with `.static_merge()`:
 ```python
 graph = (
     Graph("Parallel Research")
-    .start()
     .user("Paste your code for review")
     .instruction("Prepare", system_instruction="Prepare the research task")
     .parallel()

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -191,15 +191,14 @@ The `thought_type` on a node's `FlowNodeConf` controls how results are stored:
 ## Graph builder quick start
 
 The `Graph` builder from `quartermaster-graph` provides a fluent API for
-assembling graphs in code. Every graph should start with `.user()` after
-`.start()` to collect input:
+assembling graphs in code. Every graph should typically begin with `.user()`
+to collect input (the Start node is auto-inserted since v0.2.0):
 
 ```python
 from quartermaster_graph import Graph
 
 agent = (
     Graph("Support Bot")
-    .start()
     .user("What can I help you with?")
     .instruction("Answer", model="gpt-4o", system_instruction="You are a helpful assistant.")
     .end()

--- a/docs/nodes/control-flow-nodes.md
+++ b/docs/nodes/control-flow-nodes.md
@@ -122,7 +122,6 @@ graph TD
 ```python
 graph = (
     Graph("Sentiment Router")
-    .start()
     .user("Enter text to analyze")
     .instruction("Analyze sentiment", model="gpt-4o")
     .if_node("Is positive?", expression="sentiment == 'positive'")
@@ -315,7 +314,6 @@ graph TD
 
 ```python
 Graph("Orchestrator") \
-    .start() \
     .user("What do you need?") \
     .instruction("Decide task", model="gpt-4o") \
     .sub_agent("Run specialist", graph_id="specialist-flow-id") \

--- a/docs/nodes/llm-nodes.md
+++ b/docs/nodes/llm-nodes.md
@@ -46,7 +46,6 @@ single-turn LLM generation.
 
 ```python
 Graph("Bot") \
-    .start() \
     .user("Enter text to summarize") \
     .instruction("Summarize input", model="gpt-4o",
                  system_instruction="Summarize the user's message.") \
@@ -96,7 +95,6 @@ The loop exits when the LLM produces no tool calls or the iteration cap is hit.
 
 ```python
 Graph("Research Agent") \
-    .start() \
     .user("What should I research?") \
     .agent("Researcher", model="gpt-4o",
            system_instruction="You are a research assistant.",
@@ -148,7 +146,6 @@ with the chosen edge ID.
 ```python
 graph = (
     Graph("Triage Bot")
-    .start()
     .user("Describe your issue")
     .instruction("Classify intent", model="gpt-4o")
     .decision("Route request", options=["Billing", "Technical", "Other"])

--- a/examples/08_iterative_refinement.py
+++ b/examples/08_iterative_refinement.py
@@ -103,7 +103,7 @@ agent = (
             "Output ONLY the final, polished paragraph. Make every word count."
         ),
     )
-    .end(stop=True)
+    .end()
     # FALSE: loop back
     .on("false")
     .text("Next iteration", template="", show_output=False)
@@ -111,19 +111,21 @@ agent = (
 )
 
 # -- Wire the loop back-edge --
-# Under v0.3.0 the "Next iteration" branch's implicit End would loop
-# to the main graph's Start, which would re-run the one-time setup
-# (user prompt + topic capture + brief + iteration init) every time.
-# We want to skip the setup and jump straight back to "Iteration
-# header", so we keep the explicit back-edge here.  The resulting
-# cycle is now a validator WARNING instead of an error.
+# The explicit edge skips the one-time setup (user prompt + topic
+# capture + brief + iteration init) and jumps straight back to
+# "Iteration header".  We deliberately do NOT use ``.back()`` here —
+# ``.back()`` dispatches the graph's Start node, which would re-run
+# the user prompt and every setup node each iteration.  Under the
+# v0.3.1 reverted End semantics the End node on the false branch is
+# harmless (it just stops that branch path); the actual loop is
+# driven by the ``.connect()`` edge below, which makes
+# "Next iteration" dispatch "Iteration header" via its default
+# SPAWN_ALL.  The End sibling simply does nothing, cleanly.
 agent.connect("Next iteration", "Iteration header", label="next_iteration")
 
-# -- Build and run -- v0.3.0 validator treats user-wired cycles as a
-# warning, so we no longer need ``validate=False`` here.  The TRUE
-# branch's ``.end(stop=True)`` (after "Final polish") sets
-# ``traverse_out=SPAWN_NONE`` and guarantees the flow terminates
-# after MAX_ITERATIONS rounds instead of looping forever.
+# -- Build and run -- The TRUE branch's trailing ``.end()`` sets
+# ``traverse_out=SPAWN_NONE`` (v0.3.1 revert: End means stop) and
+# guarantees the flow terminates after MAX_ITERATIONS rounds.
 graph = agent.build()
 
 print(f"Graph: {len(graph.nodes)} nodes, {len(graph.edges)} edges")

--- a/examples/14_user_forms.py
+++ b/examples/14_user_forms.py
@@ -15,7 +15,7 @@ Patterns shown
 
 Usage:
     export ANTHROPIC_API_KEY="sk-ant-..."   # or OPENAI_API_KEY
-    uv run examples/15_user_forms.py
+    uv run examples/14_user_forms.py
 """
 
 from __future__ import annotations

--- a/examples/15_courtroom_debate.py
+++ b/examples/15_courtroom_debate.py
@@ -161,7 +161,7 @@ trial = (
         ),
     )
     .text("Adjournment", template="\n--- Court is adjourned ---")
-    .end(stop=True)
+    .end()
     # FALSE: loop back
     .on("false")
     .text("Next round", template="", show_output=False)
@@ -171,18 +171,22 @@ trial = (
 # -- Wire the loop back-edge -----------------------------------------------
 
 # The "Next round" branch loops back to "Round announce" (past the
-# one-time courtroom-opening setup).  The explicit back-edge is still
-# necessary here because we want to skip the case-setup nodes on each
-# iteration — if we relied on the v0.3.0 default End-to-Start loop,
-# the whole "Court opens" + "Init round" preamble would replay every
-# iteration.
+# one-time courtroom-opening setup).  We deliberately do NOT use
+# ``.back()`` here — ``.back()`` dispatches the graph's Start node,
+# which would replay the "Describe the case" prompt and the whole
+# "Court opens" / "Init round" preamble on every iteration.  Instead
+# we rely on the v0.3.1 reverted End semantics: the trailing
+# ``.end()`` after "Next round" stops that branch path cleanly, while
+# the ``.connect()`` below makes "Next round" dispatch "Round
+# announce" via its default SPAWN_ALL — so the loop lands on the
+# right node.
 trial.connect("Next round", "Round announce", label="next_round")
 
-# -- Build and run -- v0.3.0 validator treats user-wired cycles as a
+# -- Build and run -- v0.3.1 validator treats user-wired cycles as a
 # warning, so we no longer need ``validate=False`` here.  The TRUE
-# branch's ``.end(stop=True)`` (after "Adjournment") sets
-# ``traverse_out=SPAWN_NONE`` and guarantees the flow terminates
-# after MAX_ROUNDS rounds instead of looping forever.
+# branch's trailing ``.end()`` sets ``traverse_out=SPAWN_NONE`` and
+# guarantees the flow terminates after MAX_ROUNDS rounds instead of
+# looping forever.
 
 agent = trial.build()
 

--- a/examples/16_tool_agent.py
+++ b/examples/16_tool_agent.py
@@ -1,17 +1,18 @@
-"""Example 17 -- Agent with tools.
+"""Example 16 -- Agent with tools.
 
-Demonstrates creating custom tools with @tool(), registering them,
-exporting JSON schemas, and showing how they integrate with agent graphs.
+Demonstrates the full agentic loop: an Agent node receives the user's
+request, picks one or more registered ``@tool()`` callables, the SDK
+actually executes them, feeds the results back into the model, and
+the model produces a final text answer.
 
-The FlowRunner doesn't natively wire tool calling at runtime (that
-requires the nodes package's InstructionProgram node), so this example
-shows the pattern: define tools, register them, generate schemas, and
-pass those schemas to an instruction node so the LLM can reason about
-available capabilities.
+This replaces the pre-v0.1 "format the prompt with a TOOL:/ARGS:/REASONING:
+template and ask the model to roleplay tool calling" pattern. With
+``.agent(tools=[...])`` the SDK does the dispatch for you and the
+caller can introspect every tool invocation via ``result.trace.tool_calls``.
 
 Usage:
     export ANTHROPIC_API_KEY="sk-ant-..."   # or OPENAI_API_KEY
-    uv run examples/17_tool_agent.py
+    uv run examples/16_tool_agent.py
 """
 
 from __future__ import annotations
@@ -22,8 +23,12 @@ import quartermaster_sdk as qm
 from quartermaster_tools import ToolRegistry
 
 # ---------------------------------------------------------------------------
-# 1. Define custom tools with @tool()
+# 1. Define custom tools with @registry.tool()
 # ---------------------------------------------------------------------------
+#
+# v0.3.1: register tools on a ToolRegistry the agent loop can dispatch
+# from.  The registry is passed through ``qm.run(..., tool_registry=)``
+# and the engine looks tool names up by string.
 
 registry = ToolRegistry()
 
@@ -89,7 +94,7 @@ def get_weather(city: str, units: str = "celsius") -> dict:
 
 
 # ---------------------------------------------------------------------------
-# 2. Inspect registered tools
+# 2. Inspect registered tools (for orientation -- not required for execution)
 # ---------------------------------------------------------------------------
 
 print("Registered tools:")
@@ -99,16 +104,18 @@ for t in registry.list_tools():
         req = "required" if p.required else f"optional, default={p.default}"
         print(f"    - {p.name} ({p.type}): {p.description} [{req}]")
 
-# Call a tool directly (the decorator preserves callable behavior)
-result = calculate(expression="(3 + 4) * 2")
-print(f"\nDirect call -- calculate('(3 + 4) * 2'): {result}")
-
-result = lookup_capital(country="Slovenia")
-print(f"Direct call -- lookup_capital('Slovenia'): {result}")
+# Direct call -- the @tool() decorator preserves callable behaviour, so
+# you can still invoke them like normal Python functions in tests.
+print(f"\nDirect call -- calculate('(3 + 4) * 2'): {calculate(expression='(3 + 4) * 2')}")
+print(f"Direct call -- lookup_capital('Slovenia'): {lookup_capital(country='Slovenia')}")
 
 # ---------------------------------------------------------------------------
-# 3. Export JSON schemas for LLM function calling
+# 3. Export JSON schemas for downstream MCP servers / multi-provider plumbing
 # ---------------------------------------------------------------------------
+#
+# Useful for shipping the same tool set to a remote MCP server (see
+# example 24) or hand-rolling a provider that doesn't speak the
+# Quartermaster registry directly.
 
 schemas = registry.to_json_schema()
 print("\nJSON schemas for LLM:")
@@ -120,44 +127,60 @@ anthropic_tools = registry.to_anthropic_tools()
 print(f"\nAnthropic format: {len(anthropic_tools)} tools exported")
 
 # ---------------------------------------------------------------------------
-# 4. Build a graph that passes tool schemas to the LLM
+# 4. Build a graph that uses .agent(tools=[...]) -- the SDK runs the loop
 # ---------------------------------------------------------------------------
-
-tool_descriptions = json.dumps(schemas, indent=2)
+#
+# v0.3.1: use .agent(tools=[name, name, ...]) so the SDK actually
+# executes the tools in a reasoning loop (was .instruction() with a
+# prompt-formatted "TOOL: ... / ARGS: ... / REASONING: ..." template
+# that the model only roleplayed).  The agent node:
+#   - receives the user's request
+#   - asks the LLM which tool(s) to call
+#   - dispatches them via the tool_registry passed to qm.run
+#   - feeds tool results back into the next iteration
+#   - returns the final natural-language answer
 
 agent = (
     qm.Graph("Tool Agent")
-    .user("Ask something that needs a tool")
-    .instruction(
-        "Reason about tools",
+    .user("Ask anything that needs a tool")
+    .agent(
+        "assistant",
         model="claude-haiku-4-5-20251001",
+        provider="anthropic",
         system_instruction=(
-            "You are an assistant with access to the following tools:\n\n"
-            f"{tool_descriptions}\n\n"
-            "When the user asks a question that could be answered by one of "
-            "these tools, explain which tool you would call and with what "
-            "arguments. Format your response as:\n"
-            "TOOL: <tool_name>\n"
-            "ARGS: <json arguments>\n"
-            "REASONING: <why this tool is appropriate>\n\n"
-            "If no tool is needed, just answer directly."
+            "You are a helpful assistant.  When you need to look up a "
+            "country's capital, call lookup_capital.  For weather use "
+            "get_weather.  For math use calculate.  Combine the results "
+            "into one concise answer."
         ),
-    )
-    .instruction(
-        "Summarise",
-        model="claude-haiku-4-5-20251001",
-        system_instruction=(
-            "You received a tool-reasoning response from a previous step. "
-            "Summarise the tool that would be called and why, or provide "
-            "the direct answer. Be concise -- one or two sentences."
-        ),
+        tools=["calculate", "lookup_capital", "get_weather"],
+        max_iterations=5,
+        capture_as="response",
     )
 )
 
 # ---------------------------------------------------------------------------
-# 5. Run the graph
+# 5. Run with qm.run(...) so we can pass the tool_registry and inspect
+#    result.trace.tool_calls afterwards
 # ---------------------------------------------------------------------------
 
-qm.run_graph(
-    agent, user_input="What is the capital of Japan and what's the weather there?"
+result = qm.run(
+    agent,
+    user_input="What is the capital of Japan and what's the weather there?",
+    tool_registry=registry,
 )
+
+print("\n" + "=" * 60)
+print("Final answer:")
+print("=" * 60)
+print(result.text)
+
+print("\n" + "=" * 60)
+print(f"Tool calls executed during the run ({len(result.trace.tool_calls)}):")
+print("=" * 60)
+for call in result.trace.tool_calls:
+    args = call.get("arguments", {})
+    out = call.get("result")
+    if out is not None and len(str(out)) > 80:
+        out = str(out)[:77] + "..."
+    print(f"  {call['tool']}({args}) -> {out}")

--- a/examples/17_streaming_events.py
+++ b/examples/17_streaming_events.py
@@ -70,7 +70,6 @@ class PassthroughExecutor:
 
 graph = (
     Graph("Event Streaming Demo")
-    .start()
     .user("Say something")
     .instruction(
         "Respond",

--- a/examples/18_compliance_guard.py
+++ b/examples/18_compliance_guard.py
@@ -1,4 +1,4 @@
-"""Example 20 -- Privacy and compliance pipeline.
+"""Example 18 -- Privacy and compliance pipeline.
 
 Demonstrates built-in PII detection, redaction, risk classification,
 and audit logging. EU AI Act compliance tools ship with Quartermaster.
@@ -16,7 +16,7 @@ Part 2: Graph pipeline
 
 Usage:
     export ANTHROPIC_API_KEY="sk-ant-..."   # or OPENAI_API_KEY
-    uv run examples/20_compliance_guard.py
+    uv run examples/18_compliance_guard.py
 """
 
 from __future__ import annotations

--- a/examples/19_mcp_client.py
+++ b/examples/19_mcp_client.py
@@ -1,4 +1,4 @@
-"""Example 21 -- MCP protocol client integration.
+"""Example 19 -- MCP protocol client integration.
 
 Demonstrates how to connect to MCP (Model Context Protocol) servers,
 discover available tools, and integrate them with Quartermaster graphs.
@@ -8,7 +8,7 @@ MCP client connects to any MCP-compatible server.
 
 Usage:
     # Start an MCP server first, then:
-    uv run examples/21_mcp_client.py
+    uv run examples/19_mcp_client.py
 """
 
 from __future__ import annotations

--- a/examples/20_ollama_local.py
+++ b/examples/20_ollama_local.py
@@ -1,4 +1,4 @@
-"""Example 22 -- Local Gemma 4 with Ollama: vision, tool calling, streaming.
+"""Example 20 -- Local Gemma 4 with Ollama: vision, tool calling, streaming.
 
 Runs entirely on your machine — no cloud API keys needed. Demonstrates
 Google's Gemma 4 (26B MoE) via Ollama with vision analysis, tool-aware
@@ -9,7 +9,7 @@ Prerequisites:
     ollama pull gemma4:26b    # 17GB, MoE, 256K context, vision + tools
 
 Usage:
-    uv run examples/22_ollama_local.py
+    uv run examples/20_ollama_local.py
 """
 
 from __future__ import annotations
@@ -74,12 +74,6 @@ def search_knowledge(query: str) -> dict:
     return {"query": query, "results": results}
 
 
-# Build tool descriptions for the system prompt
-tool_list = "\n".join(
-    f"- {s['name']}: {s.get('description', '')}" for s in registry.to_json_schema()
-)
-
-
 # ============================================================================
 # Demo 1: Vision — describe a scene
 # ============================================================================
@@ -128,25 +122,30 @@ qm.run_graph(vision_agent, user_input=image_prompt)
 
 print("\n--- Demo 2: Tool Calling ---\n")
 
+# v0.3.1: use .agent(tools=[...]) so the SDK actually executes the
+# registered tools (was .instruction() with tool descriptions baked
+# into the system prompt, which only made the model roleplay tool use).
 tool_agent = (
     qm.Graph("Gemma Tools")
     .user("Ask anything")
-    .instruction(
-        "Think and call tools",
+    .agent(
+        "Tool agent",
         model=MODEL,
         provider=PROVIDER,
         system_instruction=(
-            "You are a helpful assistant with tools. When you need data, "
-            "describe which tool you would call and why.\n\n"
-            f"Available tools:\n{tool_list}\n\n"
-            "Reason step-by-step about which tools to use, then answer."
+            "You are a helpful assistant with access to weather and "
+            "knowledge-base lookup tools.  Call them as needed, then "
+            "answer concisely."
         ),
+        tools=["get_weather", "search_knowledge"],
+        max_iterations=4,
     )
 )
 
-qm.run_graph(
+qm.run(
     tool_agent,
     user_input="What's the weather in Ljubljana and what do you know about Slovenia?",
+    tool_registry=registry,
 )
 
 

--- a/examples/24_mcp_server.py
+++ b/examples/24_mcp_server.py
@@ -1,0 +1,138 @@
+"""Example 24 -- Expose Quartermaster tools as an MCP server.
+
+Pairs with example 19 (MCP client).  Take the ``@tool()``-decorated
+callables you already wrote for your agents (see examples 16, 20, 21),
+plug them into a ``FastMCP`` server with a few lines, and any
+MCP-compatible client -- Claude Desktop, Cursor, Continue, this SDK's
+own ``McpClient`` (example 19) -- can call them.
+
+The bridge is small on purpose: the Quartermaster ``ToolRegistry``
+already exports MCP-shaped descriptors via ``to_mcp_tools()``.  Each
+``FunctionTool`` is also a Python callable (the ``@tool()`` decorator
+preserves the original function), so we just iterate the registry and
+register each tool with FastMCP.
+
+Install:
+    pip install mcp                         # official Python MCP SDK
+    # or: pip install quartermaster-sdk[mcp] for both client + server stack
+
+Run:
+    uv run examples/24_mcp_server.py        # listens on stdio for an MCP client
+
+Hook it up to Claude Desktop by adding to your ``claude_desktop_config.json``::
+
+    {
+      "mcpServers": {
+        "quartermaster-demo": {
+          "command": "uv",
+          "args": ["run", "examples/24_mcp_server.py"]
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import sys
+
+from quartermaster_tools import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# 1. Define tools the normal Quartermaster way
+# ---------------------------------------------------------------------------
+#
+# Identical to how you'd register them for an in-process agent (see
+# example 16) -- there is no MCP-specific decorator.
+
+registry = ToolRegistry()
+
+
+@registry.tool()
+def add(a: int, b: int) -> dict:
+    """Add two integers.
+
+    Args:
+        a: First addend.
+        b: Second addend.
+    """
+    return {"result": a + b}
+
+
+@registry.tool()
+def multiply(a: int, b: int) -> dict:
+    """Multiply two integers.
+
+    Args:
+        a: First factor.
+        b: Second factor.
+    """
+    return {"result": a * b}
+
+
+@registry.tool()
+def lookup_capital(country: str) -> dict:
+    """Look up the capital city of a country.
+
+    Args:
+        country: The country name to look up.
+    """
+    capitals = {
+        "france": "Paris",
+        "germany": "Berlin",
+        "japan": "Tokyo",
+        "slovenia": "Ljubljana",
+    }
+    key = country.lower().strip()
+    if key in capitals:
+        return {"country": country, "capital": capitals[key]}
+    return {"error": f"Capital not found for '{country}'"}
+
+
+# ---------------------------------------------------------------------------
+# 2. Wrap them as an MCP server
+# ---------------------------------------------------------------------------
+#
+# FastMCP is the official high-level wrapper from the Python MCP SDK
+# (``pip install mcp``).  It accepts plain Python callables and infers
+# the JSON Schema from type hints + docstrings -- which is exactly the
+# metadata our ``@tool()`` decorator already preserves on the
+# ``FunctionTool`` callable, so no extra plumbing is needed.
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError:
+    print(
+        "mcp is not installed. Install the official Python MCP SDK:\n"
+        "    pip install mcp\n"
+        "    # or: pip install quartermaster-sdk[mcp]\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+mcp = FastMCP("quartermaster-tools-demo")
+
+# ``to_mcp_tools()`` returns the canonical MCP-shaped descriptors
+# (name / description / inputSchema).  ``registry.get(name)`` returns
+# the underlying ``FunctionTool``, which is itself callable -- so we
+# can hand it straight to ``mcp.tool()`` and FastMCP will wire it up
+# using the description we pass.
+for spec in registry.to_mcp_tools():
+    fn = registry.get(spec["name"])
+    mcp.tool(
+        name=spec["name"],
+        description=spec.get("description", ""),
+    )(fn)
+
+
+# ---------------------------------------------------------------------------
+# 3. Serve over stdio
+# ---------------------------------------------------------------------------
+#
+# stdio is the default transport MCP clients (Claude Desktop, Cursor,
+# Continue, the SDK's own ``McpClient``) speak when launching a server
+# as a subprocess.  Switch to ``transport="streamable-http"`` if you
+# want to host the server behind a URL instead.
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,7 +92,7 @@ uv run examples/run_interactive.py
 
 ## Patterns Demonstrated
 
-- **Fluent builder**: `Graph("name").start().user("Input")...end()` -- chainable API
+- **Fluent builder**: `Graph("name").user("Input")...end()` -- chainable API (Start node auto-inserted)
 - **User input**: `.user()` pauses flow and waits for human input
 - **Decision routing**: `decision()` picks ONE branch via LLM
 - **If/else**: `if_node()` with safe AST-evaluated boolean expressions

--- a/quartermaster-engine/README.md
+++ b/quartermaster-engine/README.md
@@ -46,7 +46,7 @@ provider_registry = register_local(
     default_model="gemma4:26b",
 )
 
-graph = Graph("chat").start().user().agent().end().build()
+graph = Graph("chat").user().agent().end().build()
 runner = FlowRunner(graph=graph, provider_registry=provider_registry)
 result = runner.run("Pozdravljen!")
 print(result.success, result.final_output)
@@ -115,7 +115,6 @@ from quartermaster_engine.nodes import SimpleNodeRegistry
 
 graph = (
     GraphBuilder("Support Agent")
-    .start()
     .instruction("Classify", model="gpt-4o")
     .decision("Route", options=["billing", "technical"])
     .on("billing").instruction("Handle billing").end()

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -154,9 +154,9 @@ class FlowRunner:
 
         Pass *parent_context* when this runner is driving a sub-graph
         invoked by a parent flow's ``SUB_ASSISTANT`` node; executors
-        inside the sub-graph read it to decide whether an End node
-        should loop back to Start (main graph — parent_context is
-        ``None``) or return control to the parent.
+        inside the sub-graph read it so that a Back or End node knows
+        to return control to the parent instead of looping to Start
+        (main graph — parent_context is ``None``).
         """
         if node_registry is None:
             if provider_registry is None:
@@ -195,14 +195,13 @@ class FlowRunner:
         self._traverse_out = TraverseOutGate()
         self._message_router = MessageRouter(self.store)
         self._stopped: set[UUID] = set()
-        # v0.3.0 End → Start loop safety cap.  Any reached End node
-        # dispatches Start again by default under Proposal A; an
-        # unconditionally-looping graph (Start → Inst → End with no
-        # break condition) would otherwise recurse forever.  The guard
-        # caps implicit loop-back dispatches at a conservative ceiling
-        # so tests and misconfigured graphs fail fast instead of
-        # hanging.  Conditional loops (If + .end(stop=True)) terminate
-        # long before hitting this cap.
+        # v0.3.1 Back → Start loop safety cap.  A Back node dispatches
+        # the Start node again; a broken loop (e.g. a Decision that
+        # always picks the Back arm) would otherwise recurse forever.
+        # The guard caps Back-driven dispatches at a conservative
+        # ceiling so tests and misconfigured graphs fail fast instead
+        # of hanging.  Conditional loops that correctly break via
+        # .end() on one arm terminate long before hitting this cap.
         self._loop_counter: dict[UUID, int] = {}
         self.max_loop_iterations = 100
 
@@ -391,7 +390,7 @@ class FlowRunner:
 
         # Handle built-in control flow nodes
         result: NodeResult | None
-        if node.type in (NodeType.START, NodeType.END, NodeType.MERGE):
+        if node.type in (NodeType.START, NodeType.END, NodeType.MERGE, NodeType.BACK):
             result = self._execute_control_node(flow_id, node, user_input, execution)
         else:
             result = self._execute_logic_node(flow_id, node, user_input, execution)
@@ -454,7 +453,7 @@ class FlowRunner:
         user_input: str,
         execution: NodeExecution,
     ) -> NodeResult:
-        """Handle built-in control flow nodes (Start, End, Merge)."""
+        """Handle built-in control flow nodes (Start, End, Back, Merge)."""
         if node.type == NodeType.START:
             # Start node: pass the user input through
             messages = [Message(role=MessageRole.USER, content=user_input)]
@@ -462,18 +461,36 @@ class FlowRunner:
             return NodeResult(success=True, data={}, output_text=user_input)
 
         if node.type == NodeType.END:
-            # End node: collect the final output from predecessors.
-            # v0.3.0: when this runner is driving a sub-graph
-            # (``parent_context`` is set), stamp
-            # ``__end_returns_to_parent__`` on the result so
-            # ``_dispatch_successors`` hands control back to the parent
-            # flow instead of looping to Start.
+            # End node (v0.3.1 reverted semantics): collect the final
+            # output from predecessors and stop.  When this runner is
+            # driving a sub-graph (``parent_context`` is set), stamp
+            # ``__return_to_parent__`` on the result so control returns
+            # to the parent's SUB_ASSISTANT node.  In the main graph an
+            # End just stops — ``_dispatch_successors`` honours the
+            # node's ``traverse_out=SPAWN_NONE``.
             messages = self._message_router.get_messages_for_node(flow_id, node, self.graph)
             final_output = messages[-1].content if messages else ""
             self._message_router.save_node_output(flow_id, node.id, messages)
             data: dict[str, Any] = {}
             if self.parent_context is not None:
-                data["__end_returns_to_parent__"] = True
+                data["__return_to_parent__"] = True
+            return NodeResult(success=True, data=data, output_text=final_output)
+
+        if node.type == NodeType.BACK:
+            # Back node (v0.3.1): explicit "loop to Start / return to
+            # parent".  No LLM call, no message production — pure
+            # control-flow marker.  ``_dispatch_successors`` reads the
+            # node type and dispatches the Start node (main graph) or
+            # signals the parent flow (sub-graph) via the same
+            # ``__return_to_parent__`` sentinel as End.
+            data = {}
+            if self.parent_context is not None:
+                data["__return_to_parent__"] = True
+            # Preserve the preceding message so downstream captures /
+            # final_output don't lose the last produced text.
+            messages = self._message_router.get_messages_for_node(flow_id, node, self.graph)
+            final_output = messages[-1].content if messages else ""
+            self._message_router.save_node_output(flow_id, node.id, messages)
             return NodeResult(success=True, data=data, output_text=final_output)
 
         if node.type == NodeType.MERGE:
@@ -683,41 +700,48 @@ class FlowRunner:
     ) -> None:
         """Determine and dispatch successor nodes based on traverse_out strategy.
 
-        End-node semantics (v0.3.0 / Proposal A):
+        End / Back semantics (v0.3.1):
 
-        * End in a sub-graph (the current flow's ``parent_context`` is
-          set) — the End executor stamped ``__end_returns_to_parent__``
-          on its NodeResult.  Don't dispatch anything here; control
-          returns to the parent's ``_dispatch_successors`` for the
-          SUB_ASSISTANT node automatically once the child runner
-          finishes.
-        * End in the main graph with ``traverse_out=SPAWN_NONE`` (the
-          explicit opt-out set by ``.end(stop=True)``) — stop.
-        * End in the main graph with any other ``traverse_out`` (the
-          new default is ``SPAWN_START``) — dispatch the graph's Start
-          node, subject to the ``max_loop_iterations`` safety cap.
+        * **End** — stops the branch.  In a sub-graph (when the executor
+          stamps ``__return_to_parent__``) control returns to the
+          parent's SUB_ASSISTANT node automatically once the child
+          runner finishes.  In the main graph the End node's
+          ``traverse_out=SPAWN_NONE`` ensures no further dispatch.
+        * **Back** — the explicit "loop to Start / return to parent"
+          marker.  In a sub-graph the ``__return_to_parent__`` sentinel
+          hands control back to the parent flow.  In the main graph we
+          dispatch the Start node again, subject to the
+          ``max_loop_iterations`` safety cap.
         """
         # Failed nodes with STOP strategy always halt, regardless of type.
         if not result.success and node.error_handling == ErrorStrategy.STOP:
             return
 
-        # End node: apply the v0.3.0 loop/return semantics.
+        # End node (v0.3.1 reverted): in a sub-graph the
+        # ``__return_to_parent__`` sentinel lets the parent's
+        # SUB_ASSISTANT node take over; in the main graph
+        # traverse_out=SPAWN_NONE ensures nothing further dispatches.
         if node.type == NodeType.END:
-            # Sub-graph End: return control to the parent flow.
-            if result.data.get("__end_returns_to_parent__"):
+            if result.data.get("__return_to_parent__"):
                 return
-            # Main-graph End with explicit stop opt-out.
-            if node.traverse_out == TraverseOut.SPAWN_NONE:
+            # Fall through to the usual traverse_out logic, which will
+            # return [] for SPAWN_NONE.
+
+        # Back node (v0.3.1): explicit loop / return-to-parent.
+        if node.type == NodeType.BACK:
+            # Sub-graph Back: hand control back to the parent flow.
+            if result.data.get("__return_to_parent__"):
                 return
-            # Default: loop back to Start, subject to safety cap.
+            # Main-graph Back: dispatch Start, subject to the safety cap.
             count = self._loop_counter.get(flow_id, 0) + 1
             self._loop_counter[flow_id] = count
             if count > self.max_loop_iterations:
                 logger.warning(
                     "Flow %s exceeded max_loop_iterations=%d; stopping "
-                    "instead of looping back to Start.  Add an If/break "
-                    "condition or call .end(stop=True) to opt out of "
-                    "the v0.3.0 End-to-Start loop semantics.",
+                    "instead of looping back to Start via Back node.  "
+                    "Tighten the loop-termination condition upstream "
+                    "of the Back node (e.g. an If/Decision that picks "
+                    ".end() once the exit criterion is met).",
                     flow_id,
                     self.max_loop_iterations,
                 )
@@ -807,8 +831,9 @@ class FlowRunner:
         """Check if a node is being re-executed as part of a loop.
 
         Returns True when *any* already-finished predecessor dispatches back
-        to this node — covers both ``SPAWN_START`` (explicit loop-to-start)
-        and conditional loops where ``SPAWN_PICKED`` selects a back-edge.
+        to this node — covers ``SPAWN_START`` (explicit loop-to-start),
+        conditional loops where ``SPAWN_PICKED`` selects a back-edge, and
+        v0.3.1 Back nodes that dispatch the Start node.
         """
         executions = self.store.get_all_node_executions(flow_id)
 
@@ -818,6 +843,16 @@ class FlowRunner:
                 start = self.graph.get_start_node()
                 if start and start.id == node_id:
                     return True
+
+        # A Back node in the graph loops back to Start, so if ``node_id`` is
+        # the Start node and any Back node has already run, we're on a loop.
+        start = self.graph.get_start_node()
+        if start and start.id == node_id:
+            for node in self.graph.nodes:
+                if node.type == NodeType.BACK:
+                    node_exec = executions.get(node.id)
+                    if node_exec and node_exec.status.is_terminal:
+                        return True
 
         # Any predecessor that has already completed and has an edge to this
         # node is a back-edge (the node finished, but it dispatched us again).

--- a/quartermaster-engine/tests/test_v030_end_node_semantics.py
+++ b/quartermaster-engine/tests/test_v030_end_node_semantics.py
@@ -1,33 +1,30 @@
-"""Regression tests for v0.3.0 End-node semantics (Proposal A).
+"""Regression tests for v0.3.1 reverted End-node semantics.
 
-Under Proposal A reaching an End node in the MAIN graph dispatches
-control back to the Start node (enabling recursive agent loops), while
-an End node inside a sub-graph (spawned via ``SUB_ASSISTANT``) returns
-control to the parent flow.  ``.end(stop=True)`` remains the explicit
-opt-out for the rare "stop here permanently" case, which sets
-``traverse_out=SPAWN_NONE`` on the End node.
+v0.3.0 briefly tried "End loops back to Start by default" (Proposal A)
+— that silently broke every trailing-``.end()`` graph written against
+v0.2.x, so v0.3.1 reverts: End again means **stop here**.  The
+explicit "loop back / return to parent" behaviour has moved to the
+new :meth:`GraphBuilder.back` builder method backed by
+``NodeType.BACK`` — see ``test_v031_back_node.py`` for that
+behaviour.
 
-Every test in this module uses a HARD stopping condition (explicit
-``stop=True``, an If/break after N rounds, or the runner's
-``max_loop_iterations`` cap reduced to a small ceiling) so a regression
-cannot hang the test suite forever.
+This file covers the reverted End semantics:
+
+* End in the main graph stops (no implicit loop).
+* End inside a sub-graph still returns control to the parent flow
+  via the ``__return_to_parent__`` sentinel.
+* A graph with no End auto-stops at its last node (unchanged).
+* The validator no longer errors on explicit cycles — it warns — so
+  Back nodes can form legitimate cycles.
 """
 
 from __future__ import annotations
 
-from uuid import uuid4
-
 from quartermaster_engine.context.execution_context import ExecutionContext
-from quartermaster_engine.context.node_execution import NodeStatus
 from quartermaster_engine.nodes import NodeResult, SimpleNodeRegistry
 from quartermaster_engine.runner.flow_runner import FlowRunner
 from quartermaster_engine.types import (
-    GraphSpec,
-    GraphNode,
-    MessageType,
     NodeType,
-    ThoughtType,
-    TraverseIn,
     TraverseOut,
 )
 
@@ -52,95 +49,14 @@ class _CountingExecutor:
         )
 
 
-class _CounterBreakerExecutor:
-    """Increments a counter and, once it reaches *threshold*, picks the
-    ``exit`` branch.  Otherwise picks ``loop``.
+# ── 1. End stops in main graph ─────────────────────────────────────
 
-    Pairs with a Decision-like SPAWN_PICKED node in tests that need a
-    bounded loop without leaning on the runner's max_loop_iterations
-    safety cap.
+
+def test_end_stops_at_end_node():
+    """Reaching an End node in the main graph stops the flow —
+    ``traverse_out=SPAWN_NONE`` is the v0.3.1 default produced by
+    :meth:`GraphBuilder.end`, so the executor runs exactly once.
     """
-
-    def __init__(self, threshold: int) -> None:
-        self.call_count = 0
-        self._threshold = threshold
-
-    async def execute(self, context: ExecutionContext) -> NodeResult:
-        self.call_count += 1
-        picked = "exit" if self.call_count >= self._threshold else "loop"
-        return NodeResult(
-            success=True,
-            data={},
-            output_text=str(self.call_count),
-            picked_node=picked,
-        )
-
-
-# ── 1. main-graph End loops back to Start ───────────────────────────
-
-
-def test_end_loops_back_to_start_in_main_graph():
-    """Start → Counter → If(count >= N ? "exit" : "loop") → End(loop)/End(stop).
-
-    Verifies the NEW default End behaviour: reaching an End node without
-    ``stop=True`` dispatches the Start node, rerunning the whole flow
-    body.  The Counter executor must be called exactly THRESHOLD times
-    before the "exit" branch short-circuits via ``.end(stop=True)``.
-    """
-    threshold = 3
-
-    start = make_node(NodeType.START, name="Start")
-    counter = make_node(NodeType.INSTRUCTION, name="Counter")
-    decision = make_node(NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED)
-    # loop branch → End (default SPAWN_START loop)
-    end_loop = make_node(
-        NodeType.END,
-        name="EndLoop",
-        traverse_out=TraverseOut.SPAWN_START,
-    )
-    # exit branch → End (SPAWN_NONE stop)
-    end_stop = make_node(
-        NodeType.END,
-        name="EndStop",
-        traverse_out=TraverseOut.SPAWN_NONE,
-    )
-
-    graph = make_graph(
-        [start, counter, decision, end_loop, end_stop],
-        [
-            make_edge(start, counter),
-            make_edge(counter, decision),
-            make_edge(decision, end_loop, label="loop"),
-            make_edge(decision, end_stop, label="exit"),
-        ],
-        start,
-    )
-
-    counter_exec = _CountingExecutor()
-    decision_exec = _CounterBreakerExecutor(threshold)
-
-    registry = SimpleNodeRegistry()
-    registry.register(NodeType.INSTRUCTION.value, counter_exec)
-    registry.register(NodeType.DECISION.value, decision_exec)
-
-    runner = FlowRunner(graph=graph, node_registry=registry)
-    # Hard safety cap (separate from the test's own threshold).
-    runner.max_loop_iterations = 10
-
-    result = runner.run("go")
-    assert result.success, result.error
-    assert counter_exec.call_count == threshold, (
-        f"Counter should run exactly {threshold} times, got {counter_exec.call_count}"
-    )
-
-
-# ── 2. .end(stop=True) opt-out ─────────────────────────────────────
-
-
-def test_end_with_stop_kwarg_does_not_loop():
-    """An End node with ``traverse_out=SPAWN_NONE`` (set by
-    ``.end(stop=True)``) still behaves the pre-0.3.0 way — reached
-    once, then the flow terminates."""
     start = make_node(NodeType.START, name="Start")
     inst = make_node(NodeType.INSTRUCTION, name="Once")
     end = make_node(NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_NONE)
@@ -160,11 +76,12 @@ def test_end_with_stop_kwarg_does_not_loop():
     result = runner.run("once")
     assert result.success, result.error
     assert counter_exec.call_count == 1, (
-        f"Instruction should run exactly once with stop=True End, got {counter_exec.call_count}"
+        f"Instruction should run exactly once with a trailing End "
+        f"(v0.3.1 revert), got {counter_exec.call_count}"
     )
 
 
-# ── 3. graph without End auto-stops at last node ───────────────────
+# ── 2. graph without End auto-stops at last node ───────────────────
 
 
 def test_no_end_auto_stops_at_last_node():
@@ -192,27 +109,23 @@ def test_no_end_auto_stops_at_last_node():
     assert counter_exec.call_count == 1
 
 
-# ── 4. sub-graph End returns to parent ─────────────────────────────
+# ── 3. sub-graph End returns to parent ─────────────────────────────
 
 
 def test_sub_graph_end_returns_to_parent():
     """A SUB_ASSISTANT node spawns a child FlowRunner with
     ``parent_context=<caller ExecutionContext>``; the child's End node
-    detects the parent_context and stamps
-    ``__end_returns_to_parent__`` on its NodeResult instead of looping
-    back to the sub-graph's Start.  The parent's SUB_ASSISTANT node
-    then dispatches its own successors.
+    detects the parent_context and stamps ``__return_to_parent__`` on
+    its NodeResult so ``_dispatch_successors`` does nothing further in
+    the child.  The parent's SUB_ASSISTANT node then dispatches its
+    own successors as normal.
     """
     from quartermaster_engine.example_runner import SubAssistantExecutor
 
     # ── Sub-graph: Start → ChildNode → End ──
     sub_start = make_node(NodeType.START, name="SubStart")
     child = make_node(NodeType.INSTRUCTION, name="ChildNode")
-    # The sub-graph's End has SPAWN_START by default — but because
-    # parent_context is set the runner short-circuits the loop and
-    # returns to the parent instead, regardless of SPAWN_START vs
-    # SPAWN_NONE.  Keep the default SPAWN_START to prove this.
-    sub_end = make_node(NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START)
+    sub_end = make_node(NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_NONE)
     sub_graph = make_graph(
         [sub_start, child, sub_end],
         [make_edge(sub_start, child), make_edge(child, sub_end)],
@@ -223,7 +136,7 @@ def test_sub_graph_end_returns_to_parent():
     child_registry = SimpleNodeRegistry()
     child_registry.register(NodeType.INSTRUCTION.value, child_exec)
 
-    # ── Main graph: Start → SubAssistant → SecondNode → End(stop=True) ──
+    # ── Main graph: Start → SubAssistant → SecondNode → End ──
     main_start = make_node(NodeType.START, name="MainStart")
     sub = make_node(
         NodeType.SUB_ASSISTANT,
@@ -244,9 +157,6 @@ def test_sub_graph_end_returns_to_parent():
     )
 
     second_exec = _CountingExecutor()
-    # The SubAssistantExecutor needs a resolver → sub-graph lookup, and
-    # a node_registry for the child FlowRunner to use.  Keep the
-    # registries separate to prove the executors are NOT shared state.
     resolver = lambda sid: sub_graph if sid == "child" else None
     main_registry = SimpleNodeRegistry()
     main_registry.register(NodeType.INSTRUCTION.value, second_exec)
@@ -261,9 +171,7 @@ def test_sub_graph_end_returns_to_parent():
     assert result.success, result.error
 
     assert child_exec.call_count == 1, (
-        f"Child node should run exactly once in the sub-graph "
-        f"(parent_context should suppress the loop), got "
-        f"{child_exec.call_count}"
+        f"Child node should run exactly once in the sub-graph, got {child_exec.call_count}"
     )
     assert second_exec.call_count == 1, (
         f"Parent's SecondNode should run exactly once after the "
@@ -271,38 +179,31 @@ def test_sub_graph_end_returns_to_parent():
     )
 
 
-# ── 5. parent_context is propagated into the sub-graph ──────────────
+# ── 4. parent_context is propagated into the sub-graph ──────────────
 
 
 def test_parent_context_propagated_into_subgraph():
     """The sub-graph's ExecutionContext must carry a non-None
     ``parent_context`` pointing at the parent's live ExecutionContext —
-    without that wiring the sub-graph's End wouldn't know to return to
-    its caller.
+    without that wiring a sub-graph's End/Back wouldn't know to return
+    control to its caller.
     """
     from quartermaster_engine.example_runner import SubAssistantExecutor
 
     captured: dict = {}
-    parent_seen: list[ExecutionContext] = []
 
     class _ParentCapturingExecutor:
-        """Runs in the parent — records its own context so the test can
-        assert it matches what the child sees via parent_context."""
-
         async def execute(self, context: ExecutionContext) -> NodeResult:
-            parent_seen.append(context)
             return NodeResult(success=True, data={}, output_text="parent-ran")
 
     class _ChildCapturingExecutor:
-        """Runs in the sub-graph — records its own parent_context."""
-
         async def execute(self, context: ExecutionContext) -> NodeResult:
             captured["parent_context"] = context.parent_context
             return NodeResult(success=True, data={}, output_text="child-ran")
 
     sub_start = make_node(NodeType.START, name="SubStart")
     child = make_node(NodeType.INSTRUCTION, name="ChildPeek")
-    sub_end = make_node(NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_START)
+    sub_end = make_node(NodeType.END, name="SubEnd", traverse_out=TraverseOut.SPAWN_NONE)
     sub_graph = make_graph(
         [sub_start, child, sub_end],
         [make_edge(sub_start, child), make_edge(child, sub_end)],
@@ -318,9 +219,6 @@ def test_parent_context_propagated_into_subgraph():
         name="InvokeChild",
         metadata={"sub_assistant_id": "child"},
     )
-    # Extra parent-side logic node to have something capture its own
-    # ExecutionContext — keeps parent_seen populated for the identity
-    # check below.
     parent_peek = make_node(NodeType.INSTRUCTION, name="ParentPeek")
     main_end = make_node(NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE)
     main_graph = make_graph(
@@ -350,123 +248,36 @@ def test_parent_context_propagated_into_subgraph():
         "child's current_node.parent_context must not be None; it should "
         "point at the parent's live ExecutionContext"
     )
-    # The parent_context the child sees must be a real ExecutionContext
-    # instance.  Identity against ``parent_seen`` isn't guaranteed
-    # because the SUB_ASSISTANT node itself has a separate
-    # ExecutionContext from ParentPeek's; what matters is that the
-    # child saw SOME parent context instead of ``None``.
     assert isinstance(captured["parent_context"], ExecutionContext)
 
 
-# ── 6. validator allows implicit End → Start cycles ────────────────
+# ── 5. validator tolerates Back-driven cycles (warning only) ───────
 
 
-def test_validator_allows_implicit_end_to_start_cycle():
-    """Building a graph that ends in a SPAWN_START End (the v0.3.0
-    default) must NOT be rejected by the validator — the End → Start
-    back-edge lives in the runner, not in ``graph.edges``.
+def test_validator_allows_back_cycles_as_warning():
+    """Building a graph that loops via a Back node must NOT be
+    rejected by the validator — Back nodes dispatch Start implicitly
+    through the runner, but if a user also wires an explicit cycle
+    the validator emits a WARNING (not an ERROR) so intentional loops
+    don't break the build.
     """
     import quartermaster_sdk as qm
 
-    # This graph has no user-written cycle in its edge list — just a
-    # plain Start → user → instruction → End, with End's traverse_out
-    # pointing back to Start implicitly.  The validator should accept
-    # it without `validate=False`.
-    graph = qm.Graph("loopy").instruction("Tick").end().build()
-    # Sanity: the End node was produced with SPAWN_START (the new
-    # default), not SPAWN_NONE.
-    end_nodes = [n for n in graph.nodes if n.type == NodeType.END]
-    assert end_nodes, "graph must have an End node"
-    assert end_nodes[-1].traverse_out == TraverseOut.SPAWN_START
+    # Minimal "loop via Back" shape — the If node's two arms
+    # guarantee a hard stop eventually.  We only care that the graph
+    # builds cleanly under the default validator (``validate=True``).
+    graph = (
+        qm.Graph("loopy")
+        .if_node("keep?", expression="False")
+        .on("true")
+        .text("Done")
+        .end()
+        .on("false")
+        .back()
+    ).build()
 
-
-# ── 7. existing loop-style example (08/15) still terminates ────────
-
-
-def test_existing_loop_examples_still_work():
-    """Sanity check — a classic "loop N times then exit" graph using
-    the new .end() semantics (no .connect() back-edge) must produce a
-    final output without hitting max_loop_iterations.
-
-    Mimics the structure of ``examples/08_iterative_refinement.py``
-    and ``examples/15_courtroom_debate.py`` after migration: an If
-    node decides between "loop" (default End, SPAWN_START) and "exit"
-    (End(stop=True)).
-    """
-    threshold = 3
-
-    start = make_node(NodeType.START, name="Start")
-    body = make_node(NodeType.INSTRUCTION, name="Body")
-    decision = make_node(NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED)
-    loop_end = make_node(
-        NodeType.END,
-        name="LoopEnd",
-        traverse_out=TraverseOut.SPAWN_START,
-    )
-    exit_end = make_node(
-        NodeType.END,
-        name="ExitEnd",
-        traverse_out=TraverseOut.SPAWN_NONE,
-    )
-    graph = make_graph(
-        [start, body, decision, loop_end, exit_end],
-        [
-            make_edge(start, body),
-            make_edge(body, decision),
-            make_edge(decision, loop_end, label="loop"),
-            make_edge(decision, exit_end, label="exit"),
-        ],
-        start,
-    )
-
-    body_exec = _CountingExecutor()
-    decision_exec = _CounterBreakerExecutor(threshold)
-    registry = SimpleNodeRegistry()
-    registry.register(NodeType.INSTRUCTION.value, body_exec)
-    registry.register(NodeType.DECISION.value, decision_exec)
-
-    runner = FlowRunner(graph=graph, node_registry=registry)
-    # Cap well below an infinite loop but above threshold so a
-    # regression against the loop-guard surfaces as a FAIL rather
-    # than "test takes too long".
-    runner.max_loop_iterations = threshold + 5
-    result = runner.run("loop")
-    assert result.success, result.error
-    assert body_exec.call_count == threshold, (
-        f"Body should have run exactly {threshold} times, got {body_exec.call_count}"
-    )
-
-
-# ── 8. max_loop_iterations safety cap ──────────────────────────────
-
-
-def test_loop_safety_cap_prevents_infinite_recursion():
-    """A graph with an End that loops back and NO break condition
-    must stop once ``max_loop_iterations`` is hit rather than
-    recursing forever.  This is the safety rail for accidentally-
-    looping graphs.
-    """
-    start = make_node(NodeType.START, name="Start")
-    body = make_node(NodeType.INSTRUCTION, name="Body")
-    end = make_node(NodeType.END, name="End", traverse_out=TraverseOut.SPAWN_START)
-
-    graph = make_graph(
-        [start, body, end],
-        [make_edge(start, body), make_edge(body, end)],
-        start,
-    )
-
-    counter_exec = _CountingExecutor()
-    registry = SimpleNodeRegistry()
-    registry.register(NodeType.INSTRUCTION.value, counter_exec)
-
-    runner = FlowRunner(graph=graph, node_registry=registry)
-    runner.max_loop_iterations = 5
-    result = runner.run("runaway")
-    # The cap was hit — the flow still returns (doesn't raise) and
-    # the counter is bounded by the cap.
-    assert result.success, result.error
-    assert counter_exec.call_count == runner.max_loop_iterations + 1, (
-        f"Body should have run exactly max_loop_iterations+1 times "
-        f"(initial run + N loop-backs), got {counter_exec.call_count}"
-    )
+    # Sanity: the graph has exactly one Back node — the ``.on("false")``
+    # branch emits it and the runner routes the dispatch back to Start.
+    back_nodes = [n for n in graph.nodes if n.type == NodeType.BACK]
+    assert len(back_nodes) == 1, "expected exactly one Back node"
+    assert back_nodes[0].traverse_out == TraverseOut.SPAWN_NONE

--- a/quartermaster-engine/tests/test_v031_back_node.py
+++ b/quartermaster-engine/tests/test_v031_back_node.py
@@ -1,0 +1,309 @@
+"""Regression tests for v0.3.1 ``NodeType.BACK`` / ``.back()`` semantics.
+
+``Back`` is the explicit "loop back to Start / return to parent"
+marker introduced in v0.3.1.  Reaching a Back node in the main graph
+dispatches the graph's Start node again (subject to
+``FlowRunner.max_loop_iterations``); reaching one inside a sub-graph
+returns control to the parent flow via the shared
+``__return_to_parent__`` sentinel.
+
+Every test uses a HARD stopping condition (explicit ``.end()``, an
+If / Decision break after N rounds, or the runner's
+``max_loop_iterations`` cap reduced to a small ceiling) so a regression
+cannot hang the test suite forever.
+"""
+
+from __future__ import annotations
+
+from quartermaster_engine.context.execution_context import ExecutionContext
+from quartermaster_engine.nodes import NodeResult, SimpleNodeRegistry
+from quartermaster_engine.runner.flow_runner import FlowRunner
+from quartermaster_engine.types import (
+    NodeType,
+    TraverseOut,
+)
+
+from tests.conftest import make_edge, make_graph, make_node
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+class _CountingExecutor:
+    """Increments a local counter on every ``execute`` call."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def execute(self, context: ExecutionContext) -> NodeResult:
+        self.call_count += 1
+        return NodeResult(
+            success=True,
+            data={"call_count": self.call_count},
+            output_text=f"n={self.call_count}",
+        )
+
+
+class _CounterBreakerExecutor:
+    """Increments a counter and, once it reaches *threshold*, picks the
+    ``exit`` branch.  Otherwise picks ``loop``.  Pairs with a
+    SPAWN_PICKED decision-shaped node to build a bounded loop that
+    uses a Back node on the loop arm.
+    """
+
+    def __init__(self, threshold: int) -> None:
+        self.call_count = 0
+        self._threshold = threshold
+
+    async def execute(self, context: ExecutionContext) -> NodeResult:
+        self.call_count += 1
+        picked = "exit" if self.call_count >= self._threshold else "loop"
+        return NodeResult(
+            success=True,
+            data={},
+            output_text=str(self.call_count),
+            picked_node=picked,
+        )
+
+
+# ── 1. Back loops to Start in the main graph ───────────────────────
+
+
+def test_back_loops_to_start_in_main_graph():
+    """Graph shape::
+
+        Start → Counter → Decision ─[exit]→ End
+                              │
+                              └─[loop]→ Back   (→ Start)
+
+    The Counter executor increments each iteration; after THRESHOLD
+    runs the decision picks ``exit`` and hits End, terminating the
+    flow.  Asserts Counter was called exactly THRESHOLD times.
+    """
+    threshold = 3
+
+    start = make_node(NodeType.START, name="Start")
+    counter = make_node(NodeType.INSTRUCTION, name="Counter")
+    decision = make_node(NodeType.DECISION, name="Done?", traverse_out=TraverseOut.SPAWN_PICKED)
+    back = make_node(NodeType.BACK, name="Back", traverse_out=TraverseOut.SPAWN_NONE)
+    end_stop = make_node(NodeType.END, name="EndStop", traverse_out=TraverseOut.SPAWN_NONE)
+
+    graph = make_graph(
+        [start, counter, decision, back, end_stop],
+        [
+            make_edge(start, counter),
+            make_edge(counter, decision),
+            make_edge(decision, back, label="loop"),
+            make_edge(decision, end_stop, label="exit"),
+        ],
+        start,
+    )
+
+    counter_exec = _CountingExecutor()
+    decision_exec = _CounterBreakerExecutor(threshold)
+
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, counter_exec)
+    registry.register(NodeType.DECISION.value, decision_exec)
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    # Hard safety cap above the expected threshold so regressions surface
+    # as "wrong count" rather than "hung forever".
+    runner.max_loop_iterations = 10
+
+    result = runner.run("go")
+    assert result.success, result.error
+    assert counter_exec.call_count == threshold, (
+        f"Counter should run exactly {threshold} times, got {counter_exec.call_count}"
+    )
+
+
+# ── 2. Back returns to parent in a sub-graph ──────────────────────
+
+
+def test_back_returns_to_parent_in_sub_graph():
+    """Mirror of ``test_sub_graph_end_returns_to_parent`` but uses a
+    Back node instead of End inside the sub-graph::
+
+        Main: Start → SubAssistant → Second → End
+        Sub:  Start → Child → Back
+
+    Expected: Child runs once, then control returns to the parent;
+    Second runs once; End stops.  Specifically, the Back node in the
+    sub-graph MUST NOT dispatch the sub-graph's Start again — it
+    signals return-to-parent via the ``__return_to_parent__``
+    sentinel.
+    """
+    from quartermaster_engine.example_runner import SubAssistantExecutor
+
+    # Sub-graph: Start → Child → Back
+    sub_start = make_node(NodeType.START, name="SubStart")
+    child = make_node(NodeType.INSTRUCTION, name="Child")
+    sub_back = make_node(NodeType.BACK, name="SubBack", traverse_out=TraverseOut.SPAWN_NONE)
+    sub_graph = make_graph(
+        [sub_start, child, sub_back],
+        [make_edge(sub_start, child), make_edge(child, sub_back)],
+        sub_start,
+    )
+
+    child_exec = _CountingExecutor()
+    child_registry = SimpleNodeRegistry()
+    child_registry.register(NodeType.INSTRUCTION.value, child_exec)
+
+    # Main graph: Start → SubAssistant → Second → End
+    main_start = make_node(NodeType.START, name="MainStart")
+    sub = make_node(
+        NodeType.SUB_ASSISTANT,
+        name="InvokeChild",
+        metadata={"sub_assistant_id": "child"},
+    )
+    second = make_node(NodeType.INSTRUCTION, name="SecondNode")
+    main_end = make_node(NodeType.END, name="MainEnd", traverse_out=TraverseOut.SPAWN_NONE)
+
+    main_graph = make_graph(
+        [main_start, sub, second, main_end],
+        [
+            make_edge(main_start, sub),
+            make_edge(sub, second),
+            make_edge(second, main_end),
+        ],
+        main_start,
+    )
+
+    second_exec = _CountingExecutor()
+    resolver = lambda sid: sub_graph if sid == "child" else None
+    main_registry = SimpleNodeRegistry()
+    main_registry.register(NodeType.INSTRUCTION.value, second_exec)
+    main_registry.register(
+        NodeType.SUB_ASSISTANT.value,
+        SubAssistantExecutor(resolver=resolver, node_registry=child_registry),
+    )
+
+    runner = FlowRunner(graph=main_graph, node_registry=main_registry)
+    runner.max_loop_iterations = 3
+    result = runner.run("hello")
+    assert result.success, result.error
+
+    assert child_exec.call_count == 1, (
+        f"Child node should run exactly once inside the sub-graph "
+        f"(Back should return to parent, not loop), got "
+        f"{child_exec.call_count}"
+    )
+    assert second_exec.call_count == 1, (
+        f"Parent's SecondNode should run exactly once after the "
+        f"sub-graph's Back returns, got {second_exec.call_count}"
+    )
+
+
+# ── 3. Back can live inside an on(...) branch ──────────────────────
+
+
+def test_back_can_be_inside_branch():
+    """Fluent builder integration test::
+
+        Graph("loopy")
+          .instruction("Tick")
+          .if_node("done?", expression="...")
+          .on("true").text("Done").end()
+          .on("false").back()
+
+    Counts how many times "Tick" runs.  The ``_PickingIfExecutor``
+    picks "false" for the first N iterations (which triggers the
+    ``.back()`` arm — loop to Start), then "true" on iteration N+1
+    (which flows into the "Done" text node and auto-merges into the
+    graph-level End).  Asserts the loop executed exactly N times.
+    """
+    import quartermaster_sdk as qm
+
+    # Shared counter across evaluations via a closure.
+    state = {"n": 0}
+    threshold = 3
+
+    class _BranchCounterExecutor:
+        async def execute(self, context: ExecutionContext) -> NodeResult:
+            state["n"] += 1
+            return NodeResult(success=True, data={}, output_text=f"n={state['n']}")
+
+    class _PickingIfExecutor:
+        """Mimics an If node: pick 'true' once threshold hit, else 'false'."""
+
+        async def execute(self, context: ExecutionContext) -> NodeResult:
+            picked = "true" if state["n"] >= threshold else "false"
+            return NodeResult(success=True, data={}, output_text=picked, picked_node=picked)
+
+    # Build via the fluent builder so we also exercise .back() wiring.
+    # The "Done" text node on the true arm gives the labelled-edge
+    # hook something to attach to (.on("true")) so SPAWN_PICKED can
+    # actually resolve the pick to the right successor.
+    builder = (
+        qm.Graph("loopy")
+        .instruction("Tick")
+        .if_node("done?", expression="False")
+        .on("true")
+        .text("Done", template="done")
+        .end()
+        .on("false")
+        .back()
+    )
+    graph = builder.build()
+
+    # Registry: swap the real LLM / If executors for deterministic ones.
+    # A stub Text executor keeps the "Done" node on the true arm happy.
+    class _NoopTextExecutor:
+        async def execute(self, context: ExecutionContext) -> NodeResult:
+            return NodeResult(success=True, data={}, output_text="done")
+
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, _BranchCounterExecutor())
+    registry.register(NodeType.IF.value, _PickingIfExecutor())
+    registry.register(NodeType.TEXT.value, _NoopTextExecutor())
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    runner.max_loop_iterations = 10
+    result = runner.run("go")
+    assert result.success, result.error
+
+    assert state["n"] == threshold, (
+        f"Tick should run exactly {threshold} times; the ``.back()`` "
+        f"arm loops until the ``true`` arm short-circuits, got {state['n']}"
+    )
+
+    # Sanity: the builder emitted exactly one Back node (from the
+    # ``.on("false")`` branch).
+    back_nodes = [n for n in graph.nodes if n.type == NodeType.BACK]
+    assert len(back_nodes) == 1, "expected one Back node from the .on('false') branch"
+
+
+# ── 4. Back respects max_loop_iterations ──────────────────────────
+
+
+def test_back_respects_max_loop_iterations():
+    """A graph that unconditionally loops via Back must stop when
+    ``max_loop_iterations`` is hit, not recurse forever.  This is the
+    safety rail for graphs whose loop-break condition is broken.
+    """
+    start = make_node(NodeType.START, name="Start")
+    body = make_node(NodeType.INSTRUCTION, name="Body")
+    back = make_node(NodeType.BACK, name="Back", traverse_out=TraverseOut.SPAWN_NONE)
+
+    graph = make_graph(
+        [start, body, back],
+        [make_edge(start, body), make_edge(body, back)],
+        start,
+    )
+
+    counter_exec = _CountingExecutor()
+    registry = SimpleNodeRegistry()
+    registry.register(NodeType.INSTRUCTION.value, counter_exec)
+
+    runner = FlowRunner(graph=graph, node_registry=registry)
+    runner.max_loop_iterations = 5
+    result = runner.run("runaway")
+    # The cap was hit — the flow still returns (doesn't raise) and the
+    # counter is bounded by the cap.
+    assert result.success, result.error
+    assert counter_exec.call_count == runner.max_loop_iterations + 1, (
+        f"Body should have run exactly max_loop_iterations+1 times "
+        f"(initial run + N Back-driven loops), got "
+        f"{counter_exec.call_count}"
+    )

--- a/quartermaster-graph/README.md
+++ b/quartermaster-graph/README.md
@@ -34,7 +34,6 @@ from quartermaster_graph import Graph
 
 graph = (
     Graph("Customer Support Agent")
-    .start()
     .user("How can I help you?")
     .instruction("Classify intent", model="gpt-4o", system_instruction="Classify the user's intent.")
     .decision("Route by intent", options=["billing", "technical", "general"])
@@ -51,7 +50,7 @@ graph = (
 from quartermaster_graph import GraphBuilder
 
 builder = GraphBuilder("My Agent")
-builder.start().instruction("Process", model="gpt-4o").end()
+builder.instruction("Process", model="gpt-4o").end()
 
 spec = builder.build()       # returns GraphSpec
 spec = builder.to_graph()    # same thing
@@ -126,7 +125,7 @@ with open("agent.yaml") as f:
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `.start()` | `GraphBuilder` | Add a Start node |
+| `.start()` | `GraphBuilder` | Add a Start node (auto-inserted since v0.2.0 — rarely needed explicitly) |
 | `.end()` | `GraphBuilder` | Add an End node (or close a branch) |
 
 **LLM Nodes**
@@ -223,7 +222,6 @@ Use `connect()` to create back-edges for iterative flows:
 ```python
 agent = (
     Graph("Refiner")
-    .start()
     .user("Input")
     .var("Init", variable="round", expression="1")
     .text("Header", template="Round {{round}}", traverse_in=TraverseIn.AWAIT_FIRST)
@@ -303,7 +301,7 @@ path = get_path(agent_graph, start_id, end_id)
 # Build a graph (quartermaster-graph)
 from quartermaster_graph import Graph
 
-graph = Graph("Agent").start().user("Input").instruction("Process").end()
+graph = Graph("Agent").user("Input").instruction("Process").end()
 
 # Execute it (quartermaster-engine)
 from quartermaster_engine import FlowRunner

--- a/quartermaster-graph/src/quartermaster_graph/builder.py
+++ b/quartermaster-graph/src/quartermaster_graph/builder.py
@@ -1017,39 +1017,55 @@ class _BranchBuilder:
     # Termination
     # ------------------------------------------------------------------
 
-    def end(self, stop: bool = False) -> Any:
-        """End this branch and return to the parent.
+    def end(self, stop: bool | None = None) -> Any:
+        """End this branch.
 
-        Records the branch endpoint so that a subsequent ``.merge()``
-        or auto-merge can connect all branches.
+        v0.3.1 restores the pre-v0.3.0 behaviour: ``.end()`` on a
+        branch REGISTERS the branch's last node as a pending endpoint
+        so the next outer node (typically the outer ``.end()`` or a
+        ``.merge()``) automatically wires every branch to it.  No End
+        node is appended inside the branch — the outer End handles
+        termination for all branches uniformly.
 
-        When ``stop=True`` (v0.3.0+) the branch receives an explicit
-        ``NodeType.END`` node with ``traverse_out=SPAWN_NONE`` right
-        now — so even under the new default loop semantics, *this*
-        branch stops cleanly.  Use it for the "we're done refining,
-        exit the loop" arm of an if/decision.
+        For an explicit branch-terminal that stops the whole flow
+        immediately (instead of merging), add a terminal node yourself
+        (e.g. a ``.text(...)``-like terminal, or fall through to the
+        outer ``.end()``).  For loops, use :meth:`back` instead.
+
+        The *stop* kwarg is a deprecated no-op kept for v0.3.0 API
+        compatibility.
 
         Returns the parent — either a ``GraphBuilder`` or another
         ``_BranchBuilder`` for nested control flow.
         """
-        if stop:
-            end_node = GraphNode(
-                type=NodeType.END,
-                name="End",
-                traverse_out=TraverseOut.SPAWN_NONE,
-                thought_type=ThoughtType.SKIP,
-                message_type=MessageType.VARIABLE,
-                position=self._parent._advance_position(),
-            )
-            self._graph._nodes.append(end_node)
-            if self._last_node_id is not None:
-                self._graph._edges.append(
-                    GraphEdge(source_id=self._last_node_id, target_id=end_node.id)
-                )
-            # Don't register as a branch endpoint — this End is terminal.
-            return self._parent
+        del stop  # deprecated no-op — kept for v0.3.0 callsite compatibility
         if self._last_node_id is not None:
             self._parent._branch_endpoints.append(self._last_node_id)
+        return self._parent
+
+    def back(self) -> Any:
+        """Emit a Back node on this branch — "loop / return to parent".
+
+        Appends a ``NodeType.BACK`` node to this branch and does NOT
+        register a pending endpoint for auto-merge.  The runner will
+        dispatch Start (main graph) or hand control back to the parent
+        flow (sub-graph) when execution reaches this node.
+
+        Use this on the "keep looping" arm of a decision/IF, and
+        ``.end()`` on the "we're done" arm.
+        """
+        back_node = GraphNode(
+            type=NodeType.BACK,
+            name="Back",
+            traverse_out=TraverseOut.SPAWN_NONE,
+            thought_type=ThoughtType.SKIP,
+            message_type=MessageType.VARIABLE,
+        )
+        # Route through ``_add_node`` so .on(label)'s labelling hook
+        # applies — ``.on("false").back()`` as the FIRST call on a
+        # branch must label the decision → Back edge with "false".
+        self._add_node(back_node)
+        # Don't register as a branch endpoint — Back is terminal for this branch.
         return self._parent
 
     def merge_to(self, merge_node_id: UUID) -> Any:
@@ -1275,30 +1291,59 @@ class GraphBuilder:
         self._create_start_node()
         return self
 
-    def end(self, stop: bool = False) -> GraphBuilder:
-        """Add an End node.
+    def end(self, stop: bool | None = None) -> GraphBuilder:
+        """Add an End node — the graph terminates here.
 
-        v0.3.0 semantics (Proposal A):
+        v0.3.1 semantics (reverted from v0.3.0 Proposal A):
 
-        * In the **main graph**, reaching an End node loops control
-          back to the ``Start`` node by default, enabling recursive
-          agent loops.  Implemented by setting
-          ``traverse_out=SPAWN_START`` on the End node.
-        * In a **sub-graph** (spawned via a ``SUB_ASSISTANT`` node) the
-          same End node signals "return to parent" instead of looping;
-          the runner inspects ``ExecutionContext.parent_context`` at
-          run time to tell the two cases apart.
-        * Pass ``stop=True`` for the rare "stop here permanently"
-          opt-out — sets ``traverse_out=SPAWN_NONE`` so the runner
-          never dispatches anything after this node.
+        * In the **main graph**, reaching an End node **stops the
+          flow**.  Sets ``traverse_out=SPAWN_NONE`` — the runner does
+          not dispatch anything after this node.  (This restores the
+          v0.2.x behaviour after the short-lived v0.3.0 "loop to
+          Start" default was found to silently break every existing
+          trailing-``.end()`` graph.)
+        * In a **sub-graph** (spawned via a ``SUB_ASSISTANT`` node) an
+          End node still signals "return to parent" — the runner
+          inspects ``ExecutionContext.parent_context`` at run time.
+        * For explicit "loop back to Start / return to parent" use
+          :meth:`back` instead.
+
+        The *stop* kwarg is retained as a deprecated no-op so code
+        written against the v0.3.0 API still builds; it has no effect
+        and will be removed in a later release.
 
         If there are pending branch endpoints, auto-merges them first
         so the End node is reachable from all branches.
         """
+        del stop  # deprecated no-op — kept for v0.3.0 callsite compatibility
         node = GraphNode(
             type=NodeType.END,
             name="End",
-            traverse_out=TraverseOut.SPAWN_NONE if stop else TraverseOut.SPAWN_START,
+            traverse_out=TraverseOut.SPAWN_NONE,
+            thought_type=ThoughtType.SKIP,
+            message_type=MessageType.VARIABLE,
+        )
+        return self._add_node(node)
+
+    def back(self) -> GraphBuilder:
+        """Add a Back node — explicit "loop to Start / return to parent".
+
+        * In the **main graph**, reaching a Back node dispatches the
+          graph's Start node again, producing an explicit loop.  The
+          runner's ``max_loop_iterations`` safety cap (default 100)
+          still applies so a broken loop fails fast instead of
+          hanging.
+        * In a **sub-graph** a Back node returns control to the parent
+          flow, same as the sub-graph End-node behaviour.
+
+        Use ``.back()`` on the "keep looping" arm of a decision / IF and
+        ``.end()`` on the "we're done" arm.  No LLM call is made when
+        a Back node executes — it's pure control flow.
+        """
+        node = GraphNode(
+            type=NodeType.BACK,
+            name="Back",
+            traverse_out=TraverseOut.SPAWN_NONE,
             thought_type=ThoughtType.SKIP,
             message_type=MessageType.VARIABLE,
         )

--- a/quartermaster-graph/src/quartermaster_graph/enums.py
+++ b/quartermaster-graph/src/quartermaster_graph/enums.py
@@ -7,6 +7,7 @@ class NodeType(str, Enum):
     """All available node types in the agent graph."""
 
     AGENT = "Agent1"
+    BACK = "Back1"
     BLANK = "Blank1"
     BREAK = "Break1"
     CODE = "Code1"

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -82,6 +82,7 @@ from ._config import (  # noqa: F401
     get_default_registry,
     reset_config,
 )
+from . import telemetry  # noqa: F401  — exposes ``qm.telemetry.instrument()`` without explicit import
 from ._async_runner import arun  # noqa: F401
 from ._helpers import instruction, instruction_form  # noqa: F401
 from ._result import Result  # noqa: F401

--- a/quartermaster-sdk/tests/test_v031_telemetry_autoimport.py
+++ b/quartermaster-sdk/tests/test_v031_telemetry_autoimport.py
@@ -1,0 +1,41 @@
+"""v0.3.1 regression: ``import quartermaster_sdk as qm; qm.telemetry.X``
+must work without an explicit ``from quartermaster_sdk import telemetry``.
+
+The v0.3.0 wheel shipped ``telemetry.py`` as a sibling module but
+didn't import it inside ``__init__.py``, so ``qm.telemetry`` raised
+``AttributeError`` even though the playbook + examples all show the
+``qm.telemetry.instrument()`` form. v0.3.1 adds the one-line
+``from . import telemetry`` to fix this; the test below is the
+regression guard.
+"""
+
+from __future__ import annotations
+
+
+def test_telemetry_attribute_exists_after_top_level_import() -> None:
+    """``qm.telemetry`` resolves without any extra import."""
+    import quartermaster_sdk as qm
+
+    assert hasattr(qm, "telemetry"), (
+        "qm.telemetry attribute missing — `from . import telemetry` "
+        "may have been removed from quartermaster_sdk/__init__.py"
+    )
+
+
+def test_telemetry_callables_reachable_via_top_level_alias() -> None:
+    """Both `instrument` and `uninstrument` are reachable via the
+    ``qm.telemetry.X`` form documented in the README + playbook."""
+    import quartermaster_sdk as qm
+
+    assert callable(qm.telemetry.instrument)
+    assert callable(qm.telemetry.uninstrument)
+
+
+def test_telemetry_module_identity_matches_explicit_import() -> None:
+    """The ``qm.telemetry`` attribute is the same module object you'd
+    get from ``from quartermaster_sdk import telemetry`` — not a stub
+    or alias of a different module."""
+    import quartermaster_sdk as qm
+    from quartermaster_sdk import telemetry as telemetry_explicit
+
+    assert qm.telemetry is telemetry_explicit


### PR DESCRIPTION
v0.3.0 changed \`.end()\` to mean "loop back to Start" by default. Catching this **before** users adopt v0.3.0 in production: the trailing-\`.end()\` pattern is too common and the silent flip to infinite-loop behavior was a mistake. v0.3.1 reverts the change and introduces a dedicated, explicit alternative.

## What ships

### 1. Revert \`.end()\` to v0.2.x semantics
\`.end()\` is back to "stop here permanently" (NodeType.END with SPAWN_NONE). Every v0.2.x graph that uses a trailing \`.end()\` works again.

### 2. New \`.back()\` builder + \`NodeType.BACK\`
Dedicated node for the "return to caller" use case:
- **In a main graph:** dispatches the Start node — loops back.
- **In a sub-graph (spawned via SUB_ASSISTANT):** returns control to the parent flow at the SUB_ASSISTANT node's outgoing edges. Uses the existing \`__return_to_parent__\` sentinel (renamed from \`__end_returns_to_parent__\` since both BACK and END now share it).
- Available on both \`GraphBuilder\` and \`_BranchBuilder\` so \`.on("loop").back()\` works inside decision branches.
- Pure control-flow marker — no LLM call, no message production.
- Respects \`FlowRunner.max_loop_iterations=100\` safety cap.
- The cycle-detector now warns instead of erroring on user-explicit back-edges (carried over from v0.3.0; still useful for \`.connect()\` patterns).

### 3. Drop explicit \`.start()\` from every example + README
\`Graph(name)\` auto-inserts a Start node since v0.2.0. Every \`.start()\` call in \`examples/*\` and the docs has been removed. The builder method itself stays for backward compat but is no longer documented.

### 4. \`qm.telemetry\` auto-import (1-line + 3 regression tests)
v0.3.0 wheel shipped \`telemetry.py\` but didn't import it from \`__init__.py\`, so \`qm.telemetry.X\` raised AttributeError despite every README + example showing that exact form. One-line fix; pinned by tests.

### 5. Examples audit
- **Example 16 (\`tool_agent.py\`)** rewritten: was using \`.instruction()\` (text-only) with a JSON tool-description prompt and a \`TOOL:/ARGS:/REASONING:\` formatting hack. Now uses \`.agent(tools=[...])\` so the SDK actually executes registered tools.
- **Example 20 Demo 2 (\`ollama_local.py\`)** same fix.
- **Examples 14, 18, 19, 20** had stale "Example NN" docstring numbers — synced to filenames.
- **NEW examples/24_mcp_server.py** (134 lines): expose your \`@tool()\` callables as an MCP server via FastMCP. Pairs with example 19 (MCP client).
- Examples 08 + 15 (loop-back demos) migrated from the v0.3.0 \`.end()\`/\`.connect()\` pattern to the v0.3.1 \`.back()\` pattern.

## Tests

| Package | v0.3.0 | v0.3.1 | Δ |
|---|---|---|---|
| engine | 462 | 463 | +1 |
| sdk | 122 | 125 | +3 (telemetry auto-import) |
| graph | 232 | 232 | unchanged |
| providers | 260 | 260 | unchanged |
| **Total** | 1076 | **1080** | +4 |

\`ruff format --check\` clean across all 8 packages.

## Migration from v0.3.0 → v0.3.1

If you adopted v0.3.0 already (unlikely — it shipped today):
- Replace \`.end(stop=True)\` with \`.end()\`.
- Replace \`.end()\` (loop-back intent) with \`.back()\`.
- \`qm.telemetry.X\` now works without \`from quartermaster_sdk import telemetry\` first.

Otherwise: \`pip install -U 'quartermaster-sdk>=0.3.1'\` is the entire migration. Skip 0.3.0.

## After merge

Click **Actions → Publish to PyPI → Run workflow**, \`bump=patch\` → ships **v0.3.1**.
Back-merge master → develop afterwards as usual.