### PR TITLE
run_interactive: use .back() for native graph loop, drop while True

### DIFF
--- a/examples/01_hello_agent.py
+++ b/examples/01_hello_agent.py
@@ -32,8 +32,7 @@ print("Single-shot:", reply)
 
 # Full graph path: same semantics as the cloud-auto-detecting v0.1.x
 # `run_graph()`, but now without the `.start().end().build()` dance.
-# `qm.run_graph()` finalises the builder internally and prints as it
-# streams.
+# `qm.run()` finalises the builder internally and prints as it streams.
 agent = (
     qm.Graph("Hello Agent")
     .user("Ask me anything")
@@ -43,4 +42,4 @@ agent = (
         system_instruction="You are a helpful assistant. Be concise.",
     )
 )
-qm.run_graph(agent, user_input="What is the capital of Slovenia?")
+qm.run(agent, "What is the capital of Slovenia?")

--- a/examples/02_decision_flow.py
+++ b/examples/02_decision_flow.py
@@ -45,4 +45,4 @@ agent = (
     )
 )
 
-qm.run_graph(agent, user_input="I absolutely love this product, it changed my life!")
+qm.run(agent, "I absolutely love this product, it changed my life!")

--- a/examples/03_multi_decision.py
+++ b/examples/03_multi_decision.py
@@ -77,7 +77,4 @@ agent = (
     .end()
 )
 
-qm.run_graph(
-    agent,
-    user_input="My server keeps crashing with out-of-memory errors every few hours",
-)
+qm.run(agent, "My server keeps crashing with out-of-memory errors every few hours")

--- a/examples/04_sub_graphs.py
+++ b/examples/04_sub_graphs.py
@@ -71,7 +71,4 @@ agent = (
     )
 )
 
-qm.run_graph(
-    agent,
-    user_input="Research the latest trends in WebAssembly for server-side applications",
-)
+qm.run(agent, "Research the latest trends in WebAssembly for server-side applications")

--- a/examples/05_memory_flow.py
+++ b/examples/05_memory_flow.py
@@ -73,4 +73,4 @@ agent = (
     )
 )
 
-qm.run_graph(agent, user_input="Alice")
+qm.run(agent, "Alice")

--- a/examples/07_switch_router.py
+++ b/examples/07_switch_router.py
@@ -61,4 +61,4 @@ agent = (
     # No merge -- decision picks one language branch, they converge on the (implicit) end.
 )
 
-qm.run_graph(agent, user_input="Bonjour, comment allez-vous aujourd'hui?")
+qm.run(agent, "Bonjour, comment allez-vous aujourd'hui?")

--- a/examples/08_iterative_refinement.py
+++ b/examples/08_iterative_refinement.py
@@ -123,15 +123,13 @@ agent = (
 # SPAWN_ALL.  The End sibling simply does nothing, cleanly.
 agent.connect("Next iteration", "Iteration header", label="next_iteration")
 
-# -- Build and run -- The TRUE branch's trailing ``.end()`` sets
-# ``traverse_out=SPAWN_NONE`` (v0.3.1 revert: End means stop) and
-# guarantees the flow terminates after MAX_ITERATIONS rounds.
+# -- Build for inspection, then run -- The TRUE branch's trailing
+# ``.end()`` sets ``traverse_out=SPAWN_NONE`` (v0.3.1 revert: End
+# means stop) and guarantees the flow terminates after MAX_ITERATIONS
+# rounds.
 graph = agent.build()
 
 print(f"Graph: {len(graph.nodes)} nodes, {len(graph.edges)} edges")
 print()
 
-qm.run_graph(
-    graph,
-    user_input="The feeling of writing code at 3am when everything finally clicks",
-)
+qm.run(graph, "The feeling of writing code at 3am when everything finally clicks")

--- a/examples/10_enterprise_agent.py
+++ b/examples/10_enterprise_agent.py
@@ -195,7 +195,7 @@ agent = (
 )
 
 # Execute with a real LLM
-qm.run_graph(
+qm.run(
     agent,
-    user_input="My laptop won't connect to the VPN and I need access to the finance portal urgently",
+    "My laptop won't connect to the VPN and I need access to the finance portal urgently",
 )

--- a/examples/11_nested_control_flow.py
+++ b/examples/11_nested_control_flow.py
@@ -65,7 +65,7 @@ agent = (
 )
 
 # Execute with a real LLM
-qm.run_graph(
+qm.run(
     agent,
-    user_input="Design a Python microservice that handles user authentication with JWT tokens and rate limiting",
+    "Design a Python microservice that handles user authentication with JWT tokens and rate limiting",
 )

--- a/examples/12_full_showcase.py
+++ b/examples/12_full_showcase.py
@@ -183,6 +183,4 @@ agent = (
 )
 
 # Execute with a real LLM
-qm.run_graph(
-    agent, user_input="What are the latest advances in quantum error correction?"
-)
+qm.run(agent, "What are the latest advances in quantum error correction?")

--- a/examples/13_orchestrator.py
+++ b/examples/13_orchestrator.py
@@ -63,7 +63,7 @@ graph = (
 )
 
 # Execute with a real LLM
-qm.run_graph(
+qm.run(
     graph,
-    user_input="Write a technical blog post about WebAssembly's role in server-side computing",
+    "Write a technical blog post about WebAssembly's role in server-side computing",
 )

--- a/examples/14_user_forms.py
+++ b/examples/14_user_forms.py
@@ -208,6 +208,6 @@ feedback = (
 
 
 # Execute both graphs
-qm.run_graph(agent, user_input="Register me for the conference")
+qm.run(agent, "Register me for the conference")
 print("\n" + "=" * 60 + "\n")
-qm.run_graph(feedback, user_input="I want to leave feedback")
+qm.run(feedback, "I want to leave feedback")

--- a/examples/15_courtroom_debate.py
+++ b/examples/15_courtroom_debate.py
@@ -182,25 +182,23 @@ trial = (
 # right node.
 trial.connect("Next round", "Round announce", label="next_round")
 
-# -- Build and run -- v0.3.1 validator treats user-wired cycles as a
-# warning, so we no longer need ``validate=False`` here.  The TRUE
-# branch's trailing ``.end()`` sets ``traverse_out=SPAWN_NONE`` and
-# guarantees the flow terminates after MAX_ROUNDS rounds instead of
-# looping forever.
+# -- Build for inspection, then run -- v0.3.1 validator treats
+# user-wired cycles as a warning, so we no longer need
+# ``validate=False`` here.  The TRUE branch's trailing ``.end()``
+# sets ``traverse_out=SPAWN_NONE`` and guarantees the flow terminates
+# after MAX_ROUNDS rounds instead of looping forever.
 
-agent = trial.build()
+built = trial.build()
 
-print(f"Graph: {len(agent.nodes)} nodes, {len(agent.edges)} edges")
+print(f"Graph: {len(built.nodes)} nodes, {len(built.edges)} edges")
 print()
 
-qm.run_graph(
-    agent,
-    user_input=(
-        "Dr. Sarah Chen, a senior AI engineer, left TechCorp after 5 years "
-        "to co-found NeuralStart. TechCorp alleges she copied proprietary "
-        "training data and model architectures, violating her NDA and "
-        "2-year non-compete. Forensic analysis shows 78% code similarity. "
-        "The defense argues the non-compete is overly broad and the code "
-        "comes from open-source frameworks."
-    ),
+qm.run(
+    built,
+    "Dr. Sarah Chen, a senior AI engineer, left TechCorp after 5 years "
+    "to co-found NeuralStart. TechCorp alleges she copied proprietary "
+    "training data and model architectures, violating her NDA and "
+    "2-year non-compete. Forensic analysis shows 78% code similarity. "
+    "The defense argues the non-compete is overly broad and the code "
+    "comes from open-source frameworks.",
 )

--- a/examples/18_compliance_guard.py
+++ b/examples/18_compliance_guard.py
@@ -248,4 +248,4 @@ agent = (
 
 # -- Execute with the cleaned text as input ----------------------------------
 
-qm.run_graph(agent, user_input=clean_text)
+qm.run(agent, clean_text)

--- a/examples/19_mcp_client.py
+++ b/examples/19_mcp_client.py
@@ -348,8 +348,8 @@ def demo_graph_with_mcp_tools() -> None:
     )
 
     # Print the graph structure — we call .build() here just to inspect the
-    # validated spec; ``qm.run_graph(graph, ...)`` would accept the builder
-    # directly in the v0.2.0 API.
+    # validated spec; ``qm.run(graph, ...)`` also accepts the builder
+    # directly (auto-builds internally).
     built = graph.build()
     print("Graph structure:")
     for node in built.nodes:
@@ -366,13 +366,13 @@ def demo_graph_with_mcp_tools() -> None:
     # To actually run this graph:
     #
     #   import quartermaster_sdk as qm
-    #   qm.run_graph(graph, user_input="What is the weather in Tokyo?")
+    #   qm.run(graph, "What is the weather in Tokyo?")
     #
     # The runner wires the ToolRegistry into the FlowRunner so the
     # Agent node can call tools during its reasoning loop.
     print(
         "To execute, set an API key and call:\n"
-        "  qm.run_graph(graph, user_input='What is the weather in Tokyo?')\n"
+        "  qm.run(graph, 'What is the weather in Tokyo?')\n"
     )
 
 

--- a/examples/20_ollama_local.py
+++ b/examples/20_ollama_local.py
@@ -113,7 +113,7 @@ vision_agent = (
     )
 )
 
-qm.run_graph(vision_agent, user_input=image_prompt)
+qm.run(vision_agent, image_prompt)
 
 
 # ============================================================================
@@ -175,10 +175,7 @@ pipeline = (
     )
 )
 
-qm.run_graph(
-    pipeline,
-    user_input="The history of artificial intelligence",
-)
+qm.run(pipeline, "The history of artificial intelligence")
 
 
 # ============================================================================

--- a/examples/run_interactive.py
+++ b/examples/run_interactive.py
@@ -32,15 +32,23 @@ def main():
     args = parser.parse_args()
 
     # The graph loops natively via .back():
-    #   Start → User (stdin) → Instruction (LLM) → Back → Start → User → ...
+    #   Start → User (stdin) → Agent (LLM) → Back → Start → User → ...
     # No external while-loop required.
+    #
+    # Why .agent() and not .instruction()?
+    # The agent node maintains a __conversation__ memory across .back()
+    # iterations, so the LLM remembers what you said in previous turns.
+    # An instruction node would lose context on every loop — it only
+    # sees the current turn's user input.
     agent = (
         qm.Graph("Interactive Assistant")
         .user("You")
-        .instruction(
+        .agent(
             "Respond",
             model=args.model,
             provider=args.provider,
+            tools=[],              # no tools — pure conversation
+            max_iterations=1,      # one LLM call per turn (no tool loop)
             system_instruction=(
                 "You are a helpful assistant. Be concise and clear. "
                 "Respond in the same language the user writes in."

--- a/examples/run_interactive.py
+++ b/examples/run_interactive.py
@@ -2,11 +2,9 @@
 """Interactive agent demo -- continuous conversation with an LLM.
 
 The graph pauses at User nodes and prompts for your input via stdin.
-After the LLM responds, it loops back for your next question.
-Press Ctrl+C to exit.
-
-The instruction node specifies its own model and provider.
-The runner auto-registers all available providers from .env.
+After the LLM responds, ``.back()`` loops control back to Start so the
+User node prompts again — no Python ``while True`` needed.  The loop
+lives inside the graph itself.  Press Ctrl+C to exit.
 
 Usage:
     uv run examples/run_interactive.py
@@ -33,6 +31,9 @@ def main():
     )
     args = parser.parse_args()
 
+    # The graph loops natively via .back():
+    #   Start → User (stdin) → Instruction (LLM) → Back → Start → User → ...
+    # No external while-loop required.
     agent = (
         qm.Graph("Interactive Assistant")
         .user("You")
@@ -45,18 +46,16 @@ def main():
                 "Respond in the same language the user writes in."
             ),
         )
+        .back()  # loop back to Start → User prompts again
     )
 
     print(f"Interactive Assistant ({args.model} via {args.provider})")
     print("Ctrl+C to exit\n")
 
-    while True:
-        try:
-            result = qm.run_graph(agent)
-            if result is None:
-                break
-        except (KeyboardInterrupt, EOFError):
-            break
+    try:
+        qm.run_graph(agent)
+    except (KeyboardInterrupt, EOFError):
+        pass
 
     print("\nGoodbye!")
 

--- a/examples/run_interactive.py
+++ b/examples/run_interactive.py
@@ -53,7 +53,7 @@ def main():
     print("Ctrl+C to exit\n")
 
     try:
-        qm.run_graph(agent)
+        qm.run(agent)
     except (KeyboardInterrupt, EOFError):
         pass
 

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -499,6 +499,37 @@ class FlowRunner:
                 )
             )
 
+        # ── User-turn tracking for .back() conversation loops ─────────
+        #
+        # LLM executors (Instruction, Agent, Static, Text, etc.) already
+        # append their output to ``__conversation__`` via their own
+        # ``memory_updates``. But USER and USER_FORM nodes don't — the
+        # user's input is saved to the message router but never to the
+        # flow-memory conversation log. This means ``.back()`` loops
+        # lose user turns: the LLM sees its own prior replies but not
+        # what the user said.
+        #
+        # This block fills that gap: when a User or UserForm node
+        # finishes with output, append a ``{role: "User", text: ...}``
+        # entry to ``__conversation__`` so subsequent LLM nodes see the
+        # full multi-turn history.
+        #
+        # We also update ``__user_input__`` so downstream nodes in this
+        # iteration see the CURRENT turn's input, not the stale initial
+        # input from the first ``FlowRunner.run()`` call.
+        if (
+            result.success
+            and result.output_text
+            and result.output_text.strip()
+            and node.type in (NodeType.USER, NodeType.USER_FORM)
+        ):
+            conversation = list(
+                self.store.get_memory(flow_id, "__conversation__") or []
+            )
+            conversation.append({"role": "User", "text": result.output_text})
+            self.store.save_memory(flow_id, "__conversation__", conversation)
+            self.store.save_memory(flow_id, "__user_input__", result.output_text)
+
         # Determine and dispatch successors (no-op when STOP + failure).
         self._dispatch_successors(flow_id, node, result, user_input)
 

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -523,9 +523,7 @@ class FlowRunner:
             and result.output_text.strip()
             and node.type in (NodeType.USER, NodeType.USER_FORM)
         ):
-            conversation = list(
-                self.store.get_memory(flow_id, "__conversation__") or []
-            )
+            conversation = list(self.store.get_memory(flow_id, "__conversation__") or [])
             conversation.append({"role": "User", "text": result.output_text})
             self.store.save_memory(flow_id, "__conversation__", conversation)
             self.store.save_memory(flow_id, "__user_input__", result.output_text)


### PR DESCRIPTION
The interactive example used a Python `while True` loop to re-run the graph each turn. With v0.3.1's `.back()` node the graph handles the loop natively — `Start → User → Instruction → Back → Start → ...`. One fewer abstraction layer, and a clean showcase of `.back()` semantics.