### PR TITLE
examples: add visible output to all qm.run() calls

### DIFF
--- a/examples/02_decision_flow.py
+++ b/examples/02_decision_flow.py
@@ -45,4 +45,5 @@ agent = (
     )
 )
 
-qm.run(agent, "I absolutely love this product, it changed my life!")
+result = qm.run(agent, "I absolutely love this product, it changed my life!")
+print(result.text)

--- a/examples/03_multi_decision.py
+++ b/examples/03_multi_decision.py
@@ -77,4 +77,5 @@ agent = (
     .end()
 )
 
-qm.run(agent, "My server keeps crashing with out-of-memory errors every few hours")
+result = qm.run(agent, "My server keeps crashing with out-of-memory errors every few hours")
+print(result.text)

--- a/examples/04_sub_graphs.py
+++ b/examples/04_sub_graphs.py
@@ -71,4 +71,5 @@ agent = (
     )
 )
 
-qm.run(agent, "Research the latest trends in WebAssembly for server-side applications")
+result = qm.run(agent, "Research the latest trends in WebAssembly for server-side applications")
+print(result.text)

--- a/examples/05_memory_flow.py
+++ b/examples/05_memory_flow.py
@@ -73,4 +73,5 @@ agent = (
     )
 )
 
-qm.run(agent, "Alice")
+result = qm.run(agent, "Alice")
+print(result.text)

--- a/examples/07_switch_router.py
+++ b/examples/07_switch_router.py
@@ -61,4 +61,5 @@ agent = (
     # No merge -- decision picks one language branch, they converge on the (implicit) end.
 )
 
-qm.run(agent, "Bonjour, comment allez-vous aujourd'hui?")
+result = qm.run(agent, "Bonjour, comment allez-vous aujourd'hui?")
+print(result.text)

--- a/examples/08_iterative_refinement.py
+++ b/examples/08_iterative_refinement.py
@@ -132,4 +132,5 @@ graph = agent.build()
 print(f"Graph: {len(graph.nodes)} nodes, {len(graph.edges)} edges")
 print()
 
-qm.run(graph, "The feeling of writing code at 3am when everything finally clicks")
+result = qm.run(graph, "The feeling of writing code at 3am when everything finally clicks")
+print(result.text)

--- a/examples/10_enterprise_agent.py
+++ b/examples/10_enterprise_agent.py
@@ -195,7 +195,8 @@ agent = (
 )
 
 # Execute with a real LLM
-qm.run(
+result = qm.run(
     agent,
     "My laptop won't connect to the VPN and I need access to the finance portal urgently",
 )
+print(result.text)

--- a/examples/11_nested_control_flow.py
+++ b/examples/11_nested_control_flow.py
@@ -65,7 +65,8 @@ agent = (
 )
 
 # Execute with a real LLM
-qm.run(
+result = qm.run(
     agent,
     "Design a Python microservice that handles user authentication with JWT tokens and rate limiting",
 )
+print(result.text)

--- a/examples/12_full_showcase.py
+++ b/examples/12_full_showcase.py
@@ -183,4 +183,5 @@ agent = (
 )
 
 # Execute with a real LLM
-qm.run(agent, "What are the latest advances in quantum error correction?")
+result = qm.run(agent, "What are the latest advances in quantum error correction?")
+print(result.text)

--- a/examples/13_orchestrator.py
+++ b/examples/13_orchestrator.py
@@ -63,7 +63,8 @@ graph = (
 )
 
 # Execute with a real LLM
-qm.run(
+result = qm.run(
     graph,
     "Write a technical blog post about WebAssembly's role in server-side computing",
 )
+print(result.text)

--- a/examples/14_user_forms.py
+++ b/examples/14_user_forms.py
@@ -208,6 +208,8 @@ feedback = (
 
 
 # Execute both graphs
-qm.run(agent, "Register me for the conference")
+result = qm.run(agent, "Register me for the conference")
+print(result.text)
 print("\n" + "=" * 60 + "\n")
-qm.run(feedback, "I want to leave feedback")
+result = qm.run(feedback, "I want to leave feedback")
+print(result.text)

--- a/examples/15_courtroom_debate.py
+++ b/examples/15_courtroom_debate.py
@@ -193,7 +193,7 @@ built = trial.build()
 print(f"Graph: {len(built.nodes)} nodes, {len(built.edges)} edges")
 print()
 
-qm.run(
+result = qm.run(
     built,
     "Dr. Sarah Chen, a senior AI engineer, left TechCorp after 5 years "
     "to co-found NeuralStart. TechCorp alleges she copied proprietary "
@@ -202,3 +202,4 @@ qm.run(
     "The defense argues the non-compete is overly broad and the code "
     "comes from open-source frameworks.",
 )
+print(result.text)

--- a/examples/18_compliance_guard.py
+++ b/examples/18_compliance_guard.py
@@ -248,4 +248,5 @@ agent = (
 
 # -- Execute with the cleaned text as input ----------------------------------
 
-qm.run(agent, clean_text)
+result = qm.run(agent, clean_text)
+print(result.text)

--- a/examples/run_interactive.py
+++ b/examples/run_interactive.py
@@ -65,7 +65,7 @@ def main():
     print("Ctrl+C to exit\n")
 
     try:
-        qm.run(agent)
+        qm.run_graph(agent)
     except (KeyboardInterrupt, EOFError):
         pass
 


### PR DESCRIPTION
14 examples were silent after the run_graph → qm.run() migration. qm.run() returns a Result without printing; the old run_graph() had verbose=True. Adds print(result.text) to 12 examples, run_interactive.py switches back to run_graph() for live streaming output.