### PR TITLE
Fix: google:/tools: prefix strip + native tool schema format

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -473,6 +473,10 @@ _TOOL_NAME_PREFIXES: tuple[str, ...] = (
     "functions:",
     "functions.",
     "mcp:",
+    "google:",
+    "google.",
+    "tools:",
+    "tools.",
 )
 
 

--- a/quartermaster-providers/src/quartermaster_providers/providers/ollama.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/ollama.py
@@ -377,14 +377,19 @@ class OllamaNativeProvider(_OpenAICompatOllamaProvider):
         if not tools:
             return None
         prepared: list[dict[str, Any]] = []
-        for tool in tools:
+        for td in tools:
+            # Tool definitions arrive in OpenAI format from _tool_definitions():
+            #   {"type": "function", "function": {"name", "description", "parameters"}}
+            # OR in flat format from some registries:
+            #   {"name", "description", "input_schema"/"parameters"}
+            fn = td.get("function") or td
             prepared.append(
                 {
                     "type": "function",
                     "function": {
-                        "name": tool.get("name", ""),
-                        "description": tool.get("description", ""),
-                        "parameters": tool.get("input_schema", {}),
+                        "name": fn.get("name", ""),
+                        "description": fn.get("description", ""),
+                        "parameters": fn.get("parameters", fn.get("input_schema", {})),
                     },
                 }
             )


### PR DESCRIPTION
Stranded commit from PR #48 — the prefix strip and schema format fixes that didn't make it into the merge. Fixes the google:search_web rejection and empty-parameters bug.