### PR TITLE
Docs: v0.5.0 release notes + migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ Modular AI agent orchestration framework. Build agent workflows as directed grap
 
 Built by [MindMade](https://mindmade.io) in Slovenia.
 
-## What's new in v0.4.0
+## What's new in v0.5.0
+
+- **Simplified Ollama provider** -- `OllamaProvider` is now a thin subclass of the OpenAI-compatible client; the separate `OllamaNativeProvider`, the sync `chat()` shim, and the `ollama_tool_protocol` knob are gone. One transport for every local and cloud OpenAI-compatible endpoint. See [Migrating from 0.4 → 0.5](#migrating-from-04--05).
+- **Parallel tool execution** -- when a model emits multiple `tool_calls` in a single turn (common on Claude/GPT-4o, doable on Gemma with explicit prompting), the agent loop dispatches them concurrently via `asyncio.gather(asyncio.to_thread(...))`. Wall-clock latency drops from `O(sum(t))` to `O(max(t))`; event ordering stays deterministic.
+- **`program_runner(program=<callable>)`** -- pass a `@tool()`-decorated function directly instead of its name string; the graph builder auto-registers it into `_inline_tools` (mirrors what `.agent(tools=[...])` already did). No more `get_default_registry().register(...)` plumbing for simple pipelines.
+- **Universal tool-name prefix strip** -- `default_api:foo`, `default_api.foo`, `functions:foo`, `mcp:foo`, etc. all resolve to the bare registry name. Handles every current *and* future namespacing pattern via `rsplit` on `:` or `.` instead of an allow-list.
+- **`duckduckgo_search` UA fix** -- realistic Chrome UA + `Accept`/`Referer` headers. DDG's HTML endpoint no longer serves 202 challenge pages.
+
+### What shipped in v0.4.0
 
 - **Application timeouts** -- `qm.configure(timeout=, connect_timeout=, read_timeout=)` with per-call overrides via `qm.run(..., read_timeout=)`.
 - **Stream cancellation** -- `with qm.run.stream(graph, input) as stream:` context-manager protocol; break/return/exception triggers cooperative cancellation. `qm.Cancelled` exception + `ctx.cancelled` polling flag for tools.
@@ -335,6 +343,21 @@ quartermaster-code-runner   Standalone Docker code execution
 | [Engine](./docs/engine.md) | Execution engine internals |
 | [Security](./docs/security.md) | Safe eval, sandboxing, API key management |
 | [Node Reference](./docs/nodes/README.md) | Detailed node documentation by category |
+
+## Migrating from 0.4 → 0.5
+
+The Ollama transport fork was collapsed. If you were on the v0.4 paths, apply these renames:
+
+| Removed (v0.4) | Replacement (v0.5) |
+|---|---|
+| `OllamaNativeProvider` | `OllamaProvider` (now inherits from `OpenAICompatibleProvider`) |
+| `OllamaProvider.chat(...)` sync shim | `await provider.generate_native_response(...)` |
+| `ChatResult` | `NativeResponse` |
+| `qm.configure(ollama_tool_protocol="auto"/"native"/"openai_compat")` | *removed* — tool-name hallucinations are now handled globally by the universal prefix strip |
+| `from quartermaster_providers import ChatResult` | *removed from `__all__`* |
+| `model_supports_native_tools(...)` | *removed* |
+
+Nothing else is behaviour-breaking. Parallel tool execution is opt-out-free (just emit multiple `tool_calls` from the model). `program_runner(program=<str>)` keeps working — the callable form is an addition.
 
 ## Development
 

--- a/quartermaster-engine/README.md
+++ b/quartermaster-engine/README.md
@@ -17,7 +17,15 @@ Execution engine for AI agent graphs with pluggable storage, dispatching, and me
 - **Flow pause/resume** for user interaction nodes
 - **Sync and async execution** modes with `run()` and `run_async()`
 
-### New in v0.4.0
+### New in v0.5.0
+
+- **Parallel tool execution** -- when a model emits multiple `tool_calls` in a
+  single turn, the agent loop dispatches them concurrently; wall-clock drops
+  from `O(sum(t))` to `O(max(t))`.
+- **Universal tool-name prefix strip** -- `default_api:foo`, `default_api.foo`,
+  `functions:foo`, `mcp:foo` all resolve via `rsplit` on `:` or `.`.
+
+### What shipped in v0.4.0
 
 - **Cooperative cancellation** -- `ctx.cancelled` flag + `Cancelled` exception for clean stream teardown.
 - **Per-node tool scoping** -- `agent(tools=[...])` strictly enforced at the engine level; `tool_scope="permissive"` escape.

--- a/quartermaster-graph/README.md
+++ b/quartermaster-graph/README.md
@@ -17,6 +17,12 @@ Framework-agnostic graph schema for defining AI agent workflows as directed grap
 - **Pre-built templates**: simple chat, decision tree, multi-agent supervisor, and more
 - **Typed metadata schemas** for each node type
 
+### New in v0.5.0
+
+- **`program_runner(program=<callable>)`** -- pass a `@tool()`-decorated function
+  directly instead of its name string; the graph builder auto-registers it.
+  Parity with `.agent(tools=[...])`.
+
 ## Installation
 
 ```bash

--- a/quartermaster-sdk/README.md
+++ b/quartermaster-sdk/README.md
@@ -4,7 +4,24 @@
 
 Quartermaster lets you build AI agent workflows as directed graphs — define nodes (LLM calls, decisions, user input, tools), connect them with edges, and execute them with a pluggable engine.
 
-## What's new in v0.4.0
+## What's new in v0.5.0
+
+- **Simplified Ollama provider** -- `OllamaProvider` is now a thin subclass of the
+  OpenAI-compatible client; the separate `OllamaNativeProvider`, the sync `chat()`
+  shim, and the `ollama_tool_protocol` knob are gone. One transport for every
+  local and cloud OpenAI-compatible endpoint.
+- **Parallel tool execution** -- when a model emits multiple `tool_calls` in a
+  single turn, the agent loop dispatches them concurrently; wall-clock drops
+  from `O(sum(t))` to `O(max(t))`.
+- **`program_runner(program=<callable>)`** -- pass a `@tool()`-decorated function
+  directly instead of its name string; the graph builder auto-registers it.
+  Parity with `.agent(tools=[...])`.
+- **Universal tool-name prefix strip** -- `default_api:foo`, `default_api.foo`,
+  `functions:foo`, `mcp:foo` all resolve via `rsplit` on `:` or `.`.
+- **`duckduckgo_search` UA fix** -- realistic Chrome UA + `Accept`/`Referer`
+  headers.
+
+### What shipped in v0.4.0
 
 - **Application timeouts** -- `qm.configure(timeout=, connect_timeout=, read_timeout=)` + per-call overrides.
 - **Stream cancellation** -- `with qm.run.stream(...) as stream:` context-manager; `qm.Cancelled` + `ctx.cancelled`.

--- a/quartermaster-tools/README.md
+++ b/quartermaster-tools/README.md
@@ -17,7 +17,12 @@ Lightweight tool abstraction framework for AI agent orchestration.
 - **AbstractTool** base class available for advanced use cases
 - **Zero required dependencies** (httpx optional for WebRequestTool)
 
-### New in v0.4.0
+### New in v0.5.0
+
+- **`duckduckgo_search` UA fix** -- realistic Chrome UA + `Accept`/`Referer`
+  headers.
+
+### What shipped in v0.4.0
 
 - **Local-GPU cost tracker** -- `cost_tracker` tool now accepts `duration_seconds` + `local_gpu_cost_per_hour` for self-hosted inference cost accounting.
 


### PR DESCRIPTION
## Summary

Prep docs for v0.5.0 publish. Bullets describe what landed via #51/#52/#53/#54; migration table tells v0.4 integrators what moved.

## Files touched

- \`README.md\` — v0.5.0 \"What's new\", demote 0.4 block, add Migrating 0.4 → 0.5 table.
- \`quartermaster-sdk/README.md\` — v0.5.0 block (all five bullets).
- \`quartermaster-engine/README.md\` — parallel tool execution + prefix strip.
- \`quartermaster-graph/README.md\` — \`program_runner(program=<callable>)\`.
- \`quartermaster-tools/README.md\` — DDG UA fix.

No \`__version__\` or \`pyproject.toml\` bumps — the publish workflow owns those per [RELEASING.md](./RELEASING.md) step 3.