### PR TITLE
Fix: per-event-loop openai client cache; nested qm.run() safe

### DIFF
--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -120,18 +120,66 @@ class OpenAIProvider(AbstractLLMProvider):
         self.api_key = api_key
         self.organization_id = organization_id
         self.base_url = base_url
+        # Legacy single-slot attribute. Kept for back-compat (some downstream
+        # code reads it directly); always mirrors the client for the current
+        # loop. The real cache is ``_clients_by_loop`` below.
         self._client = None
+        # Per-loop client cache. Each ``openai.AsyncOpenAI`` carries an
+        # httpx.AsyncClient whose connection pool and asyncio primitives
+        # (Event/Lock) bind to the loop they are first awaited on. Reusing
+        # that client from a different loop — e.g. when a @tool() body calls
+        # qm.run() which spins its own asyncio.run() — wedges those primitives
+        # and surfaces as "RuntimeError: <Event> is bound to a different event
+        # loop" / "Event loop is closed" from httpcore on the next call from
+        # the original loop. Keeping one client per live loop lets nested
+        # qm.run() from inside a @tool() body coexist with the outer agent's
+        # connection pool. ``id(loop)`` keys rather than the loop object
+        # itself so we can GC-clean dead entries without holding refs.
+        self._clients_by_loop: dict[int, tuple[Any, Any]] = {}
 
     def _get_client(self):
-        if self._client is None:
-            import openai
+        import asyncio
 
-            self._client = openai.AsyncOpenAI(
-                api_key=self.api_key,
-                organization=self.organization_id,
-                base_url=self.base_url,
-            )
-        return self._client
+        # Back-compat: if a caller (test or integrator) has directly
+        # assigned ``provider._client = <fake>``, honour it and skip the
+        # per-loop pool. We detect an external injection as: ``self._client``
+        # is set to an object we haven't registered in ``_clients_by_loop``.
+        if self._client is not None and not any(
+            c is self._client for (_, c) in self._clients_by_loop.values()
+        ):
+            return self._client
+
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        # Prune entries whose loop has closed. ``id()`` can be recycled so
+        # identity via the held ref is what we check here, not the key.
+        dead_keys = [
+            key
+            for key, (loop, _client) in self._clients_by_loop.items()
+            if loop is not None and loop.is_closed()
+        ]
+        for key in dead_keys:
+            self._clients_by_loop.pop(key, None)
+
+        loop_key = id(current_loop) if current_loop is not None else 0
+        entry = self._clients_by_loop.get(loop_key)
+        if entry is not None and entry[0] is current_loop:
+            self._client = entry[1]
+            return self._client
+
+        import openai
+
+        client = openai.AsyncOpenAI(
+            api_key=self.api_key,
+            organization=self.organization_id,
+            base_url=self.base_url,
+        )
+        self._clients_by_loop[loop_key] = (current_loop, client)
+        self._client = client
+        return client
 
     def _handle_api_error(self, e: Exception) -> NoReturn:
         """Translate OpenAI SDK exceptions to quartermaster-providers exceptions."""

--- a/quartermaster-providers/src/quartermaster_providers/providers/openai_compat.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai_compat.py
@@ -51,35 +51,68 @@ class OpenAICompatibleProvider(OpenAIProvider):
             super().__init__(api_key=api_key, base_url=base_url)
 
     def _get_client(self):
-        if self._client is None:
-            import openai
+        # Per-loop client cache — same rationale as OpenAIProvider._get_client,
+        # but this subclass has to build its own httpx.AsyncClient on the same
+        # loop as the wrapping openai.AsyncOpenAI (for basic-auth / extra
+        # headers), so we can't just delegate to super() — we have to
+        # replicate the cache lookup around the extra httpx construction.
+        import asyncio
 
-            kwargs: dict[str, Any] = {
-                "api_key": self.api_key,
-                "base_url": self.base_url,
-            }
+        # Back-compat external injection — see OpenAIProvider._get_client.
+        if self._client is not None and not any(
+            c is self._client for (_, c) in self._clients_by_loop.values()
+        ):
+            return self._client
 
-            extra_headers = getattr(self, "_extra_headers", None)
-            needs_http_client = bool(
-                (self.auth_method == "basic" and self.auth_credentials) or extra_headers
-            )
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
 
-            if needs_http_client:
-                import httpx
+        dead_keys = [
+            key
+            for key, (loop, _client) in self._clients_by_loop.items()
+            if loop is not None and loop.is_closed()
+        ]
+        for key in dead_keys:
+            self._clients_by_loop.pop(key, None)
 
-                client_kwargs: dict[str, Any] = {}
-                if self.auth_method == "basic" and self.auth_credentials:
-                    client_kwargs["auth"] = (
-                        self.auth_credentials[0],
-                        self.auth_credentials[1],
-                    )
-                    kwargs["api_key"] = "unused"
-                if extra_headers:
-                    client_kwargs["headers"] = dict(extra_headers)
-                kwargs["http_client"] = httpx.AsyncClient(**client_kwargs)
+        loop_key = id(current_loop) if current_loop is not None else 0
+        entry = self._clients_by_loop.get(loop_key)
+        if entry is not None and entry[0] is current_loop:
+            self._client = entry[1]
+            return self._client
 
-            self._client = openai.AsyncOpenAI(**kwargs)
-        return self._client
+        import openai
+
+        kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+        }
+
+        extra_headers = getattr(self, "_extra_headers", None)
+        needs_http_client = bool(
+            (self.auth_method == "basic" and self.auth_credentials) or extra_headers
+        )
+
+        if needs_http_client:
+            import httpx
+
+            client_kwargs: dict[str, Any] = {}
+            if self.auth_method == "basic" and self.auth_credentials:
+                client_kwargs["auth"] = (
+                    self.auth_credentials[0],
+                    self.auth_credentials[1],
+                )
+                kwargs["api_key"] = "unused"
+            if extra_headers:
+                client_kwargs["headers"] = dict(extra_headers)
+            kwargs["http_client"] = httpx.AsyncClient(**client_kwargs)
+
+        client = openai.AsyncOpenAI(**kwargs)
+        self._clients_by_loop[loop_key] = (current_loop, client)
+        self._client = client
+        return client
 
     async def list_models(self) -> list[str]:
         """List models from the remote endpoint."""

--- a/quartermaster-providers/tests/test_client_per_loop.py
+++ b/quartermaster-providers/tests/test_client_per_loop.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
-import pytest
-
 from quartermaster_providers.providers.openai import OpenAIProvider
 from quartermaster_providers.providers.openai_compat import OpenAICompatibleProvider
 

--- a/quartermaster-providers/tests/test_client_per_loop.py
+++ b/quartermaster-providers/tests/test_client_per_loop.py
@@ -1,0 +1,132 @@
+"""Regression: OpenAIProvider's cached openai.AsyncOpenAI must not leak
+across asyncio event loops.
+
+The pattern this guards against: an outer ``qm.run()`` spins its own loop,
+an ``@tool()`` body inside that flow calls ``qm.run()`` again which spins
+a *second* loop on a worker thread, both invocations share the same
+ProviderRegistry-cached provider instance. Before this fix, the provider
+kept a single ``self._client`` whose httpx.AsyncClient and asyncio
+primitives bound to whichever loop used it first — leaking
+``RuntimeError: Event loop is closed`` and ``RuntimeError: <Event> is
+bound to a different event loop`` as soon as the original loop tried its
+next LLM call.
+
+The fix: ``_get_client`` now tracks which loop the cached client was
+created on and rebuilds the client when called from a different loop.
+These tests don't hit a real network — they only assert the cache
+behaves loop-locally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from quartermaster_providers.providers.openai import OpenAIProvider
+from quartermaster_providers.providers.openai_compat import OpenAICompatibleProvider
+
+
+class TestOpenAIProviderClientPerLoop:
+    def test_same_loop_returns_same_client(self):
+        """Inside a single loop, repeated _get_client() calls return the
+        same cached instance — the fix must not kill connection-pool reuse
+        within one run."""
+        provider = OpenAIProvider(api_key="sk-test")
+
+        async def _inner():
+            return provider._get_client(), provider._get_client()
+
+        a, b = asyncio.run(_inner())
+        assert a is b, "client cache must be reused within the same loop"
+
+    def test_new_loop_rebuilds_client(self):
+        """Two consecutive ``asyncio.run()`` invocations should get
+        distinct clients — the first loop is closed by the time the
+        second call happens."""
+        provider = OpenAIProvider(api_key="sk-test")
+
+        async def _probe():
+            return provider._get_client()
+
+        first = asyncio.run(_probe())
+        second = asyncio.run(_probe())
+
+        assert first is not second, (
+            "_get_client must rebuild the client when the previous loop "
+            "has closed — otherwise asyncio primitives wedge"
+        )
+
+    def test_nested_loop_in_worker_thread_rebuilds_and_preserves_outer(self):
+        """Simulates the real bug: outer agent's loop A holds a client;
+        a tool on a ThreadPoolExecutor worker spins its own loop B and
+        calls _get_client() inside; outer loop A then calls _get_client()
+        again. The outer client must NOT have been replaced by the inner
+        call — per-loop caching lets both coexist."""
+        provider = OpenAIProvider(api_key="sk-test")
+
+        async def _outer():
+            outer_client = provider._get_client()
+
+            def _tool_body():
+                async def _inner_loop():
+                    return provider._get_client()
+
+                return asyncio.run(_inner_loop())
+
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                inner_client = await asyncio.wrap_future(pool.submit(_tool_body))
+
+            # Outer loop is still alive here; second call from loop A
+            # must return the SAME object as the first outer call.
+            outer_client_again = provider._get_client()
+            return outer_client, inner_client, outer_client_again
+
+        outer, inner, outer_again = asyncio.run(_outer())
+
+        assert inner is not outer, (
+            "nested loop's client must not be the outer loop's client — "
+            "reusing one AsyncClient across loops wedges httpcore primitives"
+        )
+        assert outer_again is outer, (
+            "outer loop's cached client must survive a nested qm.run() on a "
+            "different loop — otherwise every tool invocation trashes the "
+            "outer agent's connection pool"
+        )
+
+
+class TestOpenAICompatibleProviderClientPerLoop:
+    """Same guarantees for the OpenAI-compatible subclass — it has its own
+    ``_get_client`` override to build the inner httpx.AsyncClient for
+    basic auth / extra headers, and must also respect loop changes."""
+
+    def test_new_loop_rebuilds_client(self):
+        provider = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1",
+            api_key="no-key",
+            auth_method="none",
+        )
+
+        async def _probe():
+            return provider._get_client()
+
+        first = asyncio.run(_probe())
+        second = asyncio.run(_probe())
+        assert first is not second
+
+    def test_basic_auth_rebuilds_on_loop_change(self):
+        """Basic-auth path also goes through a fresh httpx.AsyncClient
+        hand-off; confirm that path doesn't leak across loops either."""
+        provider = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1",
+            auth_method="basic",
+            auth_credentials=("user", "pass"),
+        )
+
+        async def _probe():
+            return provider._get_client()
+
+        first = asyncio.run(_probe())
+        second = asyncio.run(_probe())
+        assert first is not second

--- a/quartermaster-providers/tests/test_v040_circuit_breaker.py
+++ b/quartermaster-providers/tests/test_v040_circuit_breaker.py
@@ -191,7 +191,7 @@ class TestCircuitBreakerWrapper:
         breaker = _make_state(failure_threshold=3)
         wrapper = CircuitBreakerWrapper(mock_provider, breaker)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             wrapper.generate_text_response("hello", config)
         )
 
@@ -212,7 +212,7 @@ class TestCircuitBreakerWrapper:
         assert breaker.state == "open"
 
         with pytest.raises(CircuitOpenError):
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 wrapper.generate_text_response("hello", config)
             )
 
@@ -235,7 +235,7 @@ class TestCircuitBreakerWrapper:
 
         for _ in range(3):
             with pytest.raises(RuntimeError):
-                asyncio.get_event_loop().run_until_complete(
+                asyncio.run(
                     wrapper.generate_text_response("hello", config)
                 )
 
@@ -251,7 +251,7 @@ class TestCircuitBreakerWrapper:
         wrapper = CircuitBreakerWrapper(mock_provider, breaker)
 
         # These should still work even with an open circuit.
-        models = asyncio.get_event_loop().run_until_complete(wrapper.list_models())
+        models = asyncio.run(wrapper.list_models())
         assert "mock-model-1" in models
 
         count = wrapper.estimate_token_count("hello world", "mock-model-1")

--- a/quartermaster-providers/tests/test_v040_circuit_breaker.py
+++ b/quartermaster-providers/tests/test_v040_circuit_breaker.py
@@ -191,9 +191,7 @@ class TestCircuitBreakerWrapper:
         breaker = _make_state(failure_threshold=3)
         wrapper = CircuitBreakerWrapper(mock_provider, breaker)
 
-        result = asyncio.run(
-            wrapper.generate_text_response("hello", config)
-        )
+        result = asyncio.run(wrapper.generate_text_response("hello", config))
 
         assert result.content == "ok"
         assert mock_provider.call_count == 1
@@ -212,9 +210,7 @@ class TestCircuitBreakerWrapper:
         assert breaker.state == "open"
 
         with pytest.raises(CircuitOpenError):
-            asyncio.run(
-                wrapper.generate_text_response("hello", config)
-            )
+            asyncio.run(wrapper.generate_text_response("hello", config))
 
         # Inner provider was never called.
         assert mock_provider.call_count == 0
@@ -235,9 +231,7 @@ class TestCircuitBreakerWrapper:
 
         for _ in range(3):
             with pytest.raises(RuntimeError):
-                asyncio.run(
-                    wrapper.generate_text_response("hello", config)
-                )
+                asyncio.run(wrapper.generate_text_response("hello", config))
 
         assert breaker.state == "open"
 


### PR DESCRIPTION
## The bug

Calling \`qm.run(sub_graph)\` from inside a \`@tool()\` body surfaces as:

\`\`\`
RuntimeError: <asyncio.locks.Event [unset]> is bound to a different event loop
RuntimeError: Event loop is closed
\`\`\`

…on the outer agent's **next** LLM iteration, after a parallel tool-call batch has returned. openai-SDK retries 3× and fails with \`Graph failed: Connection error.\` The remote server never sees the failure — it's entirely in the client's asyncio state.

## Root cause

\`OpenAIProvider\` / \`OpenAICompatibleProvider\` cached a single \`openai.AsyncOpenAI\`. That client's \`httpx.AsyncClient\` (and its asyncio Event/Lock primitives) bind to whichever loop first awaits it. A \`@tool()\` body dispatched via [PR #53](https://github.com/MindMadeLab/quartermaster-sdk-py/pull/53)'s \`asyncio.to_thread(...)\` then calling \`qm.run()\` does its own \`asyncio.run()\` on the worker thread — which reuses the **same** cached provider instance on a **new** loop. The inner loop closes; pool primitives wedge. The outer loop's next \`/chat/completions\` call raises.

## The fix

Replace the single-slot \`_client\` cache with a per-loop dict keyed by \`id(loop)\`. Each live loop gets its own \`AsyncOpenAI\`; dead loops get pruned on the next \`_get_client()\` call.

Back-compat preserved: tests that inject \`provider._client = fake\` still work — we detect an externally-set client (not tracked in our per-loop dict) and honour it.

Bonus: modernised 4 circuit-breaker tests that used the deprecated \`asyncio.get_event_loop().run_until_complete(...)\` pattern. They passed by accident on some orderings; now they pass deterministically regardless of what ran before them.

## Regression tests

\`quartermaster-providers/tests/test_client_per_loop.py\` — 5 cases:
- same loop returns cached client (connection-pool reuse within a run)
- consecutive \`asyncio.run\` calls get distinct clients
- nested loop on worker thread gets its own client AND outer loop's client survives
- OpenAI-compatible subclass (basic auth + no auth paths) both rebuild on loop change

## Test plan

- [x] \`quartermaster-providers\` — 248/248
- [x] \`quartermaster-sdk\` — 186/186 (+ 2 skipped)
- [x] \`quartermaster-engine\` — 470/470
- [ ] CI

## Release note

Target: **v0.5.1** (patch). Fixes a user-reported high-severity regression in v0.5.0's parallel-tool-dispatch path.