### PR TITLE
v0.6.0 phase 3: strip 9 migration-note comments

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/cancellation.py
+++ b/quartermaster-engine/src/quartermaster_engine/cancellation.py
@@ -1,4 +1,4 @@
-"""Cooperative cancellation primitives — v0.4.0.
+"""Cooperative cancellation primitives.
 
 The engine-side home of the :class:`Cancelled` exception. Tools inside
 an :class:`AgentExecutor` loop that want to bail out mid-work raise

--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -534,7 +534,7 @@ def _execute_tool_call(
     # Strip ``default_api:`` / ``functions:`` / ``mcp:`` prefixes that
     # different providers attach to the function name.  Without this the
     # registry lookup would miss a tool that's registered under the bare
-    # name — a recurring integrator complaint before v0.2.0.
+    # name.
     normalised = _normalise_tool_name(tool_name)
     # v0.4.0 per-node scoping check — runs AFTER prefix-stripping so that
     # ``default_api:A`` matches an allow-list entry of ``A`` (preserves the

--- a/quartermaster-graph/src/quartermaster_graph/validation.py
+++ b/quartermaster-graph/src/quartermaster_graph/validation.py
@@ -57,12 +57,12 @@ def validate_graph(version: GraphSpec) -> list[ValidationError]:  # type: ignore
                 )
             )
 
-    # --- End node (optional since v0.2.0) ---
-    # Pre-0.2.0 a graph without an explicit End node was rejected here.
-    # The runner has always been fine with "no End" — it falls back to the
-    # last finished node's output in ``FlowResult``.  Making ``.end()``
-    # optional means single-node flows (``Graph("x").instruction(...).build()``)
-    # don't need a trailing ``.end()`` boilerplate line.
+    # --- End node ---
+    # A graph without an explicit End node is permitted. The runner falls
+    # back to the last finished node's output in ``FlowResult``.  Making
+    # ``.end()`` optional means single-node flows
+    # (``Graph("x").instruction(...).build()``) don't need a trailing
+    # ``.end()`` boilerplate line.
 
     # --- Start node ID valid ---
     if version.start_node_id not in node_map:

--- a/quartermaster-nodes/quartermaster_nodes/__init__.py
+++ b/quartermaster-nodes/quartermaster_nodes/__init__.py
@@ -35,8 +35,7 @@ __all__ = [
     # Chain
     "Chain",
     "Handler",
-    # Catalog (design-time). Not to be confused with
-    # quartermaster_engine.nodes.NodeRegistry (runtime executor Protocol).
+    # Catalog (design-time registry of node types).
     "NodeCatalog",
     "register_node",
 ]

--- a/quartermaster-providers/src/quartermaster_providers/config.py
+++ b/quartermaster-providers/src/quartermaster_providers/config.py
@@ -26,10 +26,10 @@ class LLMConfig:
             alongside the prompt for vision-capable models. ``base64_data``
             is the raw image bytes encoded as ASCII base64 (no ``data:``
             URI prefix); ``mime_type`` is e.g. ``"image/jpeg"`` /
-            ``"image/png"`` / ``"image/webp"``. Populated by the v0.3.0
-            engine path that reads ``flow_memory["__user_images__"]``;
-            providers that support vision consume this list when building
-            the request payload. Empty/``None`` means a text-only request.
+            ``"image/png"`` / ``"image/webp"``. Populated by the engine
+            path that reads ``flow_memory["__user_images__"]``; providers
+            that support vision consume this list when building the
+            request payload. Empty/``None`` means a text-only request.
         thinking_enabled: Whether to enable extended thinking mode (e.g., Claude thinking).
         thinking_budget: Maximum tokens allowed for thinking/reasoning.
         top_p: Nucleus sampling parameter (alternative to temperature).

--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -31,9 +31,6 @@ __version__ = "0.5.1"
 # * ``configure(provider="ollama", default_model=...)`` — boot once
 # * ``instruction(system=..., user=...)`` — single-shot prompt → text
 # * ``instruction_form(schema, system=..., user=...)`` — prompt → typed JSON
-#
-# Legacy v0.1.x exports (``FlowRunner``, ``build_default_registry``, …)
-# remain available for integrators who need the low-level surface.
 from quartermaster_engine import (  # noqa: F401
     AgentExecutor,
     Cancelled,

--- a/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_helpers.py
@@ -4,8 +4,7 @@ These wrap a single-node graph so callers never touch ``Graph``,
 ``FlowRunner``, or ``register_local`` for the 90% of use-cases that are
 just ``prompt → text`` or ``prompt → typed JSON``.
 
-The docs / downstream feedback called this "the thing we'd actually write";
-v0.2.0 ships it as the primary recommended API for non-agentic calls.
+This is the recommended API for non-agentic calls.
 """
 
 from __future__ import annotations
@@ -302,9 +301,9 @@ def instruction_form(
     is_dict_schema = isinstance(schema, dict)
 
     if not (is_pydantic_schema or is_dict_schema):
-        # v0.4.0: upgraded from ValueError to TypeError — this is a
-        # programmer error about the *type* of the argument, not its
-        # value. Matches the pattern used elsewhere in the SDK.
+        # TypeError (not ValueError): this is a programmer error about the
+        # *type* of the argument, not its value. Matches the pattern used
+        # elsewhere in the SDK.
         raise TypeError(
             f"instruction_form(schema=...) must be a pydantic.BaseModel "
             f"subclass or a dict (JSON Schema); got {type(schema).__name__}"

--- a/quartermaster-tools/src/quartermaster_tools/decorator.py
+++ b/quartermaster-tools/src/quartermaster_tools/decorator.py
@@ -207,9 +207,9 @@ def is_quartermaster_tool(obj: Any) -> bool:
     * :class:`FunctionTool` instances produced by :func:`tool`
     * Any other :class:`AbstractTool` subclass instance
 
-    Used by the SDK runner (v0.4.0) to detect already-wrapped callables
-    in ``.agent(tools=[...])`` so they can be pulled through to the
-    run-time tool registry without a manual ``register()`` step.
+    Used by the SDK runner to detect already-wrapped callables in
+    ``.agent(tools=[...])`` so they can be pulled through to the run-time
+    tool registry without a manual ``register()`` step.
     """
     return isinstance(obj, (FunctionTool, AbstractTool))
 
@@ -217,9 +217,9 @@ def is_quartermaster_tool(obj: Any) -> bool:
 def auto_decorate(func: Callable[..., Any]) -> FunctionTool:
     """Wrap a plain callable as a :class:`FunctionTool` on the fly.
 
-    Used by the SDK runner (v0.4.0) when ``.agent(tools=[...])`` is
-    handed a bare ``def`` function that the caller forgot — or chose not
-    — to decorate with :func:`tool`.  The result has the same shape as
+    Used by the SDK runner when ``.agent(tools=[...])`` is handed a bare
+    ``def`` function that the caller forgot — or chose not — to decorate
+    with :func:`tool`.  The result has the same shape as
     ``@tool()`` would have produced: the function's ``__name__`` becomes
     the tool name, the signature becomes the parameter list, and the
     docstring populates short/long descriptions.


### PR DESCRIPTION
Pure comment/docstring cleanup — **zero behavioural change.**

## Removed

8 files touched. Each comment referenced a long-shipped API shift but didn't explain any current code choice:

- \`engine/example_runner.py\` — "recurring integrator complaint before v0.2.0" tail
- \`engine/cancellation.py\` — " — v0.4.0" suffix in module docstring
- \`graph/validation.py\` — "(optional since v0.2.0)" section-header qualifier + paired "Pre-0.2.0" prose
- \`nodes/__init__.py\` — cross-reference to the NodeRegistry alias (dropped in phase 1)
- \`providers/config.py\` — "Populated by the v0.3.0 vision kwarg" attribution
- \`sdk/__init__.py\` — "Legacy v0.1.x exports" block-header
- \`sdk/_helpers.py\` — two version-dated docstring fragments
- \`tools/decorator.py\` — "(v0.4.0)" tags on two tool-factory docstrings

## Explicitly kept

Every load-bearing version comment that explains non-obvious CURRENT behaviour stays:
- \`engine/__init__.py\` export-boundary section markers
- v0.4.0 per-node scoping check (explains execution order)
- tool-scope permissive escape hatch
- v0.3.1 Back→Start loop safety cap
- v0.4.0 inline-tools side-channel (explains serialisation split)
- v0.3.0 implicit End→Start back-edges (graph traversal semantics)
- v0.4.0 timeout resolution logic (backwards-compat with v0.3.x)
- "v0.2.0 primary API" tier header in sdk/\_\_init\_\_
- Lint rule metadata (users need to know when behaviour changed to fix violations)

## Diff

\`\`\`
8 files changed, 23 insertions(+), 28 deletions(-)
\`\`\`

## Test counts (all green, no test changes)

| Package | Count |
|---|---|
| engine | 474 |
| graph | 235 |
| sdk | 184 (+2 skip) |
| providers | 248 |
| tools | 873 (+1 skip) |
| nodes | 471 |