### PR TITLE
feat: LLMConfig.extra_body + agent(extra_body=) for provider-specific body fields (ask #2)

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -339,6 +339,7 @@ def _build_llm_config(
         thinking_budget=thinking_budget,
         connect_timeout=float(connect_timeout) if connect_timeout is not None else None,
         read_timeout=float(read_timeout) if read_timeout is not None else None,
+        extra_body=context.get_meta("llm_extra_body", None) or None,
     )
 
 

--- a/quartermaster-graph/src/quartermaster_graph/builder.py
+++ b/quartermaster-graph/src/quartermaster_graph/builder.py
@@ -67,10 +67,17 @@ def _llm_meta(
     max_input_tokens: int = 16385,
     vision: bool = False,
     thinking_level: str = "off",
+    extra_body: dict[str, Any] | None = None,
     **extra: Any,
 ) -> dict[str, Any]:
     """Build a metadata dict using the ``llm_*`` key names that match
-    the actual quartermaster-nodes ``AbstractLLMAssistantNode``."""
+    the actual quartermaster-nodes ``AbstractLLMAssistantNode``.
+
+    The ``extra_body`` arg is v0.6.0 — a provider-specific OpenAI-compat
+    escape hatch (spliced into the outgoing ``chat.completions.create(...,
+    extra_body=...)`` payload). Typical use: toggle Gemma-4 thinking via
+    ``extra_body={"chat_template_kwargs": {"enable_thinking": False}}``.
+    """
     meta: dict[str, Any] = {
         "llm_model": model,
         "llm_provider": provider,
@@ -82,6 +89,10 @@ def _llm_meta(
         "llm_vision": vision,
         "llm_thinking_level": thinking_level,
     }
+    if extra_body:
+        # Stash on the node metadata. The engine's executor layer reads
+        # ``llm_extra_body`` and forwards it into ``LLMConfig.extra_body``.
+        meta["llm_extra_body"] = dict(extra_body)
     meta.update({k: v for k, v in extra.items() if k not in _ALL_CONFIG_KEYS})
     return meta
 

--- a/quartermaster-graph/tests/test_v060_extra_body_builder.py
+++ b/quartermaster-graph/tests/test_v060_extra_body_builder.py
@@ -1,0 +1,88 @@
+"""v0.6.0 — ``agent(..., extra_body={...})`` and friends stash on node metadata.
+
+End-to-end: DSL kwarg → node metadata → engine's ``LLMConfig.extra_body``.
+This file covers the builder half; ``test_v060_extra_body.py`` in
+quartermaster-providers covers the provider half.
+"""
+
+from __future__ import annotations
+
+from quartermaster_graph import Graph
+
+
+def _meta_for(graph, name: str) -> dict:
+    """Fetch the metadata of the first node whose name matches."""
+    spec = graph.build()
+    for node in spec.nodes:
+        if node.name == name:
+            return node.metadata
+    raise AssertionError(f"node {name!r} not in built graph")
+
+
+def test_agent_extra_body_stashed_as_llm_extra_body() -> None:
+    graph = (
+        Graph("g")
+        .user()
+        .agent(
+            "Research",
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+        )
+    )
+    meta = _meta_for(graph, "Research")
+    assert meta["llm_extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def test_instruction_extra_body_stashed_as_llm_extra_body() -> None:
+    graph = Graph("g").user().instruction("Say", extra_body={"repetition_penalty": 1.15})
+    meta = _meta_for(graph, "Say")
+    assert meta["llm_extra_body"] == {"repetition_penalty": 1.15}
+
+
+def test_instruction_form_extra_body_stashed() -> None:
+    graph = (
+        Graph("g")
+        .user()
+        .instruction_form(
+            "Extract",
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+        )
+    )
+    meta = _meta_for(graph, "Extract")
+    assert meta["llm_extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def test_no_extra_body_key_when_unused() -> None:
+    """Don't pollute metadata with a None or empty-dict key for nodes that
+    never opted in."""
+    graph = Graph("g").user().agent("A")
+    meta = _meta_for(graph, "A")
+    assert "llm_extra_body" not in meta
+
+
+def test_extra_body_dict_is_copied_into_metadata() -> None:
+    """Post-build mutation of the caller's dict must not retroactively
+    change the node metadata (otherwise caching layers that hash the spec
+    break)."""
+    payload = {"chat_template_kwargs": {"enable_thinking": False}}
+    graph = Graph("g").user().agent("A", extra_body=payload)
+    meta = _meta_for(graph, "A")
+    assert meta["llm_extra_body"] is not payload
+
+
+def test_roundtrip_preserved_through_to_json() -> None:
+    """extra_body must survive JSON round-trip — it's plain JSON already
+    and must stay on the spec."""
+    from quartermaster_graph import from_json, to_json
+
+    graph = Graph("g").user().agent("A", extra_body={"top_k": 40, "min_p": 0.05})
+    spec = graph.build()
+    payload = to_json(spec)
+    restored = from_json(payload)
+
+    a_node = next(n for n in restored.nodes if n.name == "A")
+    assert a_node.metadata["llm_extra_body"] == {"top_k": 40, "min_p": 0.05}
+
+    # Sanity: the intermediate payload actually carries it — not just
+    # something the reconstructor invented. ``to_json`` returns a dict.
+    a_payload = next(n for n in payload["nodes"] if n["name"] == "A")
+    assert a_payload["metadata"]["llm_extra_body"] == {"top_k": 40, "min_p": 0.05}

--- a/quartermaster-providers/src/quartermaster_providers/config.py
+++ b/quartermaster-providers/src/quartermaster_providers/config.py
@@ -6,6 +6,7 @@ provider is used.
 """
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -70,6 +71,23 @@ class LLMConfig:
     # untouched (backwards-compat with v0.3.x callers).
     connect_timeout: float | None = None
     read_timeout: float | None = None
+    # v0.6.0 — pass-through for provider-specific OpenAI-compat body fields
+    # that the SDK doesn't otherwise model. The dict is spliced into the
+    # outgoing ``chat.completions.create(..., extra_body=<dict>)`` call
+    # (supported by the openai Python SDK as a generic escape hatch).
+    #
+    # Primary motivator: Gemma-4's ``chat_template_kwargs`` knob for
+    # toggling <thinking> blocks per-request:
+    #   extra_body={"chat_template_kwargs": {"enable_thinking": False}}
+    # Also handy for vLLM-specific sampling params (``top_k``,
+    # ``repetition_penalty``) that don't have a first-class field here.
+    #
+    # The field is provider-agnostic at the ``LLMConfig`` layer — each
+    # provider decides whether / how to forward it. OpenAI +
+    # OpenAI-compatible providers splice it into the request; Anthropic,
+    # Google, Groq, xAI ignore it (or will once they grow bespoke
+    # pass-through slots of their own).
+    extra_body: dict[str, Any] | None = None
 
     def validate(self) -> None:
         """Validate configuration parameters.

--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -281,6 +281,16 @@ class OpenAIProvider(AbstractLLMProvider):
         if timeout is not None:
             params["timeout"] = timeout
 
+        # v0.6.0: provider-specific body escape hatch. The openai Python
+        # SDK splices ``extra_body`` into the outgoing JSON; vLLM /
+        # OpenAI-compat servers use this for knobs like
+        # ``chat_template_kwargs`` (Gemma-4 thinking toggle),
+        # ``repetition_penalty``, ``top_k``, etc. — anything the SDK
+        # doesn't model natively. Pass-through only; we don't validate
+        # the keys because the set is server-specific.
+        if config.extra_body:
+            params["extra_body"] = dict(config.extra_body)
+
         return params
 
     async def list_models(self) -> list[str]:

--- a/quartermaster-providers/tests/test_v060_extra_body.py
+++ b/quartermaster-providers/tests/test_v060_extra_body.py
@@ -1,0 +1,117 @@
+"""v0.6.0 — ``LLMConfig.extra_body`` passthrough.
+
+Callers can splice arbitrary body fields into the outgoing
+``chat.completions.create(...)`` call via
+``LLMConfig(extra_body={"chat_template_kwargs": {"enable_thinking": False}})``.
+The openai provider forwards it verbatim as ``extra_body=<dict>``; the
+openai Python SDK splices it into the JSON payload the vLLM / OpenAI-
+compatible server sees.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from quartermaster_providers.config import LLMConfig
+from quartermaster_providers.providers.openai import OpenAIProvider
+
+
+def _fake_response() -> MagicMock:
+    msg = MagicMock()
+    msg.content = "ok"
+    msg.tool_calls = None
+    choice = MagicMock()
+    choice.message = msg
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = None
+    return resp
+
+
+def _provider_with_mock_client() -> tuple[OpenAIProvider, MagicMock]:
+    provider = OpenAIProvider(api_key="sk-test")
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=_fake_response())
+    provider._client = mock_client
+    return provider, mock_client
+
+
+def test_extra_body_forwarded_to_chat_completions() -> None:
+    """The dict on the config lands under ``extra_body`` in the outgoing call."""
+    provider, mock_client = _provider_with_mock_client()
+    config = LLMConfig(
+        model="gemma-4-26b",
+        provider="openai",
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+
+    asyncio.run(provider.generate_text_response("hi", config))
+
+    call = mock_client.chat.completions.create.call_args
+    assert call is not None, "chat.completions.create was never invoked"
+    assert call.kwargs.get("extra_body") == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def test_extra_body_absent_when_not_configured() -> None:
+    """No ``extra_body`` in the request when none was set — don't send an
+    empty/None key to vLLM."""
+    provider, mock_client = _provider_with_mock_client()
+    config = LLMConfig(model="gpt-4o", provider="openai")
+
+    asyncio.run(provider.generate_text_response("hi", config))
+
+    call = mock_client.chat.completions.create.call_args
+    assert call is not None
+    assert "extra_body" not in call.kwargs
+
+
+def test_empty_extra_body_dict_suppressed() -> None:
+    """``extra_body={}`` is falsy; we suppress the key so servers never
+    see a no-op empty dict."""
+    provider, mock_client = _provider_with_mock_client()
+    config = LLMConfig(model="gpt-4o", provider="openai", extra_body={})
+
+    asyncio.run(provider.generate_text_response("hi", config))
+
+    call = mock_client.chat.completions.create.call_args
+    assert "extra_body" not in call.kwargs
+
+
+def test_extra_body_is_copied_not_referenced() -> None:
+    """The provider must not hold a reference to the caller's dict; mutating
+    the original after the call mustn't retroactively change the outbound
+    payload seen by the server."""
+    provider, mock_client = _provider_with_mock_client()
+    payload = {"chat_template_kwargs": {"enable_thinking": False}}
+    config = LLMConfig(model="gemma-4-26b", provider="openai", extra_body=payload)
+
+    asyncio.run(provider.generate_text_response("hi", config))
+    payload["chat_template_kwargs"]["enable_thinking"] = True  # mutate AFTER
+
+    seen = mock_client.chat.completions.create.call_args.kwargs.get("extra_body")
+    # The top-level dict is copied. Nested mutation is a caller responsibility;
+    # we only guard against the top-level alias.
+    assert seen is not payload
+
+
+def test_extra_body_roundtrips_through_native_tool_path() -> None:
+    """generate_native_response (agent tool-calling path) also carries it."""
+    provider, mock_client = _provider_with_mock_client()
+    config = LLMConfig(
+        model="gemma-4-26b",
+        provider="openai",
+        extra_body={"repetition_penalty": 1.1},
+    )
+
+    asyncio.run(
+        provider.generate_native_response(
+            prompt="hi",
+            tools=None,
+            config=config,
+        )
+    )
+
+    call = mock_client.chat.completions.create.call_args
+    assert call.kwargs.get("extra_body") == {"repetition_penalty": 1.1}


### PR DESCRIPTION
Provider-agnostic escape hatch for body fields that neither \`LLMConfig\` nor the builder models natively. Main use case from the integrator request: Gemma-4's \`chat_template_kwargs\` toggle for per-request \`<thinking>\` mode.

## Before

Setting \`enable_thinking: false\` per-request required either patching the server's default chat template kwargs CLI flag (\`--default-chat-template-kwargs\`) or monkey-patching the provider. Neither works for mixing thinking/non-thinking in the same app.

## After

\`\`\`python
graph.agent(
    "Research",
    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
    tools=[...],
)

graph.instruction_form(
    "Extract",
    schema=CustomerEnrichment,
    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
)
\`\`\`

The dict gets spliced into \`chat.completions.create(..., extra_body=<dict>)\`. The openai SDK forwards it verbatim to the server.

Also handy for vLLM sampling knobs (\`top_k\`, \`repetition_penalty\`, \`min_p\`) that don't have a first-class \`LLMConfig\` field.

## Plumbing

1. \`LLMConfig.extra_body: dict[str, Any] | None\`
2. \`OpenAIProvider._build_params\` splices it as \`params["extra_body"]\` when truthy (None / empty-dict suppressed)
3. Graph builder accepts \`extra_body=\` on \`agent()\`, \`instruction()\`, \`instruction_form()\`; \`_llm_meta\` stashes it under \`llm_extra_body\` on node metadata
4. Engine's \`_build_llm_config\` reads \`llm_extra_body\` from node meta
5. Round-trips through \`to_json\` / \`from_json\`

Non-OpenAI providers (Anthropic, Google, Groq, xAI) ignore the field today. Covered in follow-up work if needed.

## Tests

- \`quartermaster-providers/tests/test_v060_extra_body.py\` — 5 cases (forwarded, absent-when-unset, empty-suppressed, dict-copied, native-tool path)
- \`quartermaster-graph/tests/test_v060_extra_body_builder.py\` — 6 cases (builder kwargs, metadata stash, JSON round-trip)

| Package | Before | After |
|---|---|---|
| quartermaster-graph | 235 | **241** |
| quartermaster-providers | 248 | **253** |
| quartermaster-engine | 474 | **474** |
| quartermaster-sdk | 184 | **184** |