### PR TITLE
feat: qm.parse_partial(text, schema) progressive-degradation parser (ask #7)

### DIFF
--- a/quartermaster-sdk/src/quartermaster_sdk/__init__.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/__init__.py
@@ -84,6 +84,7 @@ from ._config import (  # noqa: F401
 from . import telemetry  # noqa: F401  — exposes ``qm.telemetry.instrument()`` without explicit import
 from ._async_runner import arun  # noqa: F401
 from ._helpers import instruction, instruction_form  # noqa: F401
+from ._parse_partial import PartialResult, parse_partial  # noqa: F401
 from ._result import Result  # noqa: F401
 from ._runner import StreamDeadlineExceeded, assert_traces_equal, run  # noqa: F401
 from ._session import ChatTurn, InMemorySessionStore, SessionStore  # noqa: F401
@@ -100,6 +101,8 @@ __all__ = [
     "arun",
     "instruction",
     "instruction_form",
+    "parse_partial",
+    "PartialResult",
     "Result",
     # v0.4.0 cooperative cancellation — stream context-manager exit
     # and/or tools raising qm.Cancelled inside the agent loop.

--- a/quartermaster-sdk/src/quartermaster_sdk/_parse_partial.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_parse_partial.py
@@ -1,0 +1,284 @@
+"""v0.6.0 — progressive-degradation parser for LLM output that doesn't
+quite match a Pydantic schema.
+
+Motivation
+----------
+When an agent finishes a ``qm.Graph`` with an ``instruction_form``
+node, its raw text sometimes contains 80% of the right answer wrapped
+in prose, broken JSON, or a bullet list. The SDK's strict validator
+returns ``output_data=None`` in that case. Callers end up hand-rolling
+key-value parsers per schema.
+
+``parse_partial(text, schema)`` replaces that hand-rolling with a
+single helper that attempts four progressively-lenient strategies:
+
+1. **Parse full JSON + validate full schema** — the happy path. If the
+   whole thing parses and every required field is present, return it.
+2. **Extract the last ``{...}`` block and validate optional fields
+   only** — tolerates preambles ("Here you go: {...}") and Pydantic
+   models whose missing ``required`` fields would otherwise fail. Each
+   field is tried individually; the ones that validate land in
+   ``partial_data``, the rest in ``missing_fields``.
+3. **Line-based ``Field: value`` / ``Field = value`` scanner** — for
+   the research-note style output ("Company: MindMade\\nCountry: SI\\n…").
+   Only runs when JSON extraction yielded nothing.
+4. **Give up** — return an empty ``partial_data`` + every schema field
+   as missing + the raw text. Strategy name in the result tells the
+   caller nothing stuck.
+
+The return value is a ``PartialResult`` dataclass — ``.data`` is a
+plain dict, never a validated Pydantic instance. Callers that want a
+model object can call ``Schema.model_construct(**result.data)`` if they
+trust the partial data, or ``Schema.model_validate(result.data)`` to
+re-validate (and discover which fields don't coerce).
+
+Design note: we deliberately do NOT run the full Pydantic validator
+after partial extraction. Pydantic is strict about required fields; a
+partial dict will always fail. Callers that want strict validation
+should use the existing ``instruction_form(schema=..., on_parse_fail
+="raise")`` path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+#: Matches ``Key: value`` / ``Key = value`` / ``**Key**: value`` lines.
+#: Captures 2 groups: the field name and the value up to end-of-line.
+_LINE_RE = re.compile(
+    r"^\s*\*{0,2}\s*([A-Za-z][A-Za-z0-9 _\-]*?)\s*\*{0,2}\s*[:=]\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass
+class PartialResult:
+    """Result of a progressively-degraded parse.
+
+    Attributes:
+        data: Fields we managed to extract, keyed by schema field name.
+            Never a Pydantic model instance — always a plain dict.
+        missing_fields: Schema fields that couldn't be populated.
+            Includes both required-but-missing and optional-but-missing
+            (callers distinguish by re-inspecting the schema).
+        raw_output: The original text passed to ``parse_partial``.
+            Kept on the result so logs / error reports can show the
+            LLM's actual output next to what we salvaged.
+        strategy: Which step succeeded:
+            ``"full_json_validated"`` — the happy path.
+            ``"json_extracted"``     — last ``{...}`` block found, per-field coerced.
+            ``"line_scan"``          — key-colon-value scan over plain text.
+            ``"none"``               — nothing stuck; ``data`` is empty.
+    """
+
+    data: dict[str, Any] = field(default_factory=dict)
+    missing_fields: list[str] = field(default_factory=list)
+    raw_output: str = ""
+    strategy: str = "none"
+
+
+def _field_names_for(schema: Any) -> list[str]:
+    """Return the field names declared on a Pydantic model OR
+    JSON-schema dict. Preserves declaration order — callers rendering
+    a form want the same order the schema authored them in.
+    """
+    try:
+        from pydantic import BaseModel
+    except ImportError:
+        BaseModel = None  # type: ignore[assignment]
+
+    if (
+        BaseModel is not None
+        and isinstance(schema, type)
+        and issubclass(schema, BaseModel)
+    ):
+        return list(schema.model_fields.keys())
+    if isinstance(schema, dict):
+        # JSON-schema path: ``properties`` is the convention.
+        props = schema.get("properties")
+        if isinstance(props, dict):
+            return list(props.keys())
+    # Fall back to introspecting ``__annotations__`` (dataclass etc.)
+    ann = getattr(schema, "__annotations__", None)
+    if isinstance(ann, dict):
+        return list(ann.keys())
+    return []
+
+
+def _try_full_pydantic_validate(payload: dict[str, Any], schema: Any):
+    """Return a validated instance (as a dict dump) or ``None`` on fail."""
+    try:
+        from pydantic import BaseModel
+    except ImportError:
+        return None
+    if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
+        return None
+    try:
+        instance = schema.model_validate(payload)
+    except Exception:
+        return None
+    # Dump back to a plain dict so PartialResult.data is always a dict
+    # — mixing dict and BaseModel returns would confuse callers.
+    return instance.model_dump()
+
+
+def _coerce_scalar(raw: str) -> Any:
+    """Turn a line-scanned value string into the most-natural Python type.
+
+    Parse order: JSON (handles lists, bools, numbers, nulls, quoted
+    strings), fall back to string. Keeps parity with how LLMs render
+    values in ``Field: [..]`` / ``Field: true`` / ``Field: 42`` forms.
+    """
+    raw = raw.strip()
+    if not raw:
+        return ""
+    if raw.lower() == "not found" or raw.lower() == "n/a":
+        # Common LLM placeholder for "I couldn't find this" — treat as
+        # absent so the field lands in missing_fields rather than
+        # polluting data with a literal "not found" string.
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        # Strip surrounding quotes/backticks, return as-is.
+        return raw.strip("\"'`")
+
+
+def parse_partial(text: str, schema: Any) -> PartialResult:
+    """Attempt progressively-lenient parsing of *text* against *schema*.
+
+    See module docstring for the strategy list. Always returns a
+    :class:`PartialResult` — never raises. Callers inspect
+    ``result.strategy`` / ``result.missing_fields`` to decide whether
+    to use the extracted data or fall through to a human-in-the-loop
+    step.
+
+    Args:
+        text: The LLM's raw output (``result.text`` or a captured
+            ``output_text``). Empty string is handled — you get back
+            an all-missing result with strategy ``"none"``.
+        schema: A Pydantic ``BaseModel`` subclass, a JSON-schema dict
+            (with a ``properties`` key), or any class with
+            ``__annotations__``. Determines the field set we try to
+            populate.
+
+    Returns:
+        A :class:`PartialResult`. Never ``None``, never raises.
+    """
+    raw = text or ""
+    fields = _field_names_for(schema)
+
+    # ── Strategy 1: full JSON + full schema validate ──────────────
+    candidate = _extract_last_json_object(raw)
+    if candidate is not None:
+        validated = _try_full_pydantic_validate(candidate, schema)
+        if validated is not None:
+            return PartialResult(
+                data=validated,
+                missing_fields=[],
+                raw_output=raw,
+                strategy="full_json_validated",
+            )
+
+    # ── Strategy 2: JSON extracted, per-field copy ────────────────
+    if candidate is not None and fields:
+        extracted: dict[str, Any] = {}
+        for name in fields:
+            if name in candidate:
+                extracted[name] = candidate[name]
+        if extracted:
+            return PartialResult(
+                data=extracted,
+                missing_fields=[n for n in fields if n not in extracted],
+                raw_output=raw,
+                strategy="json_extracted",
+            )
+
+    # ── Strategy 3: line scan ─────────────────────────────────────
+    if fields:
+        scanned = _line_scan(raw, fields)
+        if scanned:
+            return PartialResult(
+                data=scanned,
+                missing_fields=[n for n in fields if n not in scanned],
+                raw_output=raw,
+                strategy="line_scan",
+            )
+
+    # ── Strategy 4: nothing stuck ─────────────────────────────────
+    return PartialResult(
+        data={},
+        missing_fields=list(fields),
+        raw_output=raw,
+        strategy="none",
+    )
+
+
+def _extract_last_json_object(text: str) -> dict[str, Any] | None:
+    """Find the last ``{...}`` substring and json-decode it.
+
+    Greedy on the opening brace (so ``{outer: {inner: 1}}`` round-trips
+    whole), tolerates whitespace / preamble. Returns ``None`` if no
+    parseable object is found.
+
+    We keep this local rather than importing from ``_helpers`` because
+    ``_helpers.py`` raises on failure (it's the strict path); here we
+    want ``None``-on-fail semantics.
+    """
+    if not text:
+        return None
+    # Find every candidate object and try them in reverse order (last
+    # wins — agents often preamble then emit JSON as the final segment).
+    matches = list(_JSON_OBJECT_RE.finditer(text))
+    for match in reversed(matches):
+        snippet = match.group(0)
+        try:
+            obj = json.loads(snippet)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    return None
+
+
+def _line_scan(text: str, fields: list[str]) -> dict[str, Any]:
+    """Key-colon-value scanner over plain-text LLM output.
+
+    Matches tokens in ``text`` against *fields* case-insensitively and
+    allows flexible separators — ``"Company Name"`` in the text is
+    matched against the ``company_name`` field, ``Country = SI`` is
+    matched as ``country``.
+
+    We purposely DO NOT coerce unknown keys — if the LLM writes
+    ``"E-mail: x@y"`` and your schema calls the field ``emails``, that
+    line won't match. Keep field names close to what the LLM will
+    produce, or use the ``strategy == "json_extracted"`` path for
+    tighter control.
+    """
+    if not text:
+        return {}
+
+    # Build a case-insensitive map. Normalise field names by lowering
+    # and stripping non-alnum so "Company Name" / "company_name" /
+    # "CompanyName" all hash to the same key.
+    def _norm(s: str) -> str:
+        return "".join(ch.lower() for ch in s if ch.isalnum())
+
+    fieldmap = {_norm(f): f for f in fields}
+    out: dict[str, Any] = {}
+    for match in _LINE_RE.finditer(text):
+        key_raw, val_raw = match.group(1), match.group(2)
+        normed = _norm(key_raw)
+        schema_field = fieldmap.get(normed)
+        if schema_field is None or schema_field in out:
+            continue
+        coerced = _coerce_scalar(val_raw)
+        if coerced is None:
+            continue  # "not found" / "n/a" → treat as absent
+        out[schema_field] = coerced
+    return out

--- a/quartermaster-sdk/tests/test_public_surface.py
+++ b/quartermaster-sdk/tests/test_public_surface.py
@@ -39,6 +39,9 @@ _REQUIRED_PUBLIC_NAMES: tuple[str, ...] = (
     "LLMConfig",
     "ProviderRegistry",
     "register_local",
+    # v0.6.0 parse_partial helper
+    "parse_partial",
+    "PartialResult",
 )
 
 

--- a/quartermaster-sdk/tests/test_v060_parse_partial.py
+++ b/quartermaster-sdk/tests/test_v060_parse_partial.py
@@ -1,0 +1,233 @@
+"""v0.6.0 — ``qm.parse_partial(text, schema)`` progressive-degradation parser.
+
+Tests are grouped by which strategy they exercise: full-JSON-validated,
+JSON-extracted-per-field, line-scan, give-up.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from quartermaster_sdk import PartialResult, parse_partial
+
+
+class CustomerEnrichment(BaseModel):
+    company_name: str = ""
+    country: str = ""
+    website: str = ""
+    emails: list[str] = Field(default_factory=list)
+    phones: list[str] = Field(default_factory=list)
+    industry: str = ""
+    summary: str = ""
+    sources: list[str] = Field(default_factory=list)
+
+
+# ── Strategy 1: full_json_validated ──────────────────────────────────
+
+
+class TestFullJsonValidated:
+    def test_clean_json_body(self) -> None:
+        text = """{
+          "company_name": "Gorenje",
+          "country": "Slovenia",
+          "website": "https://gorenje.com",
+          "emails": ["info@gorenje.si"],
+          "phones": ["01 320 92 92"],
+          "industry": "Appliances",
+          "summary": "Slovenian appliances maker.",
+          "sources": ["https://gorenje.com"]
+        }"""
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.strategy == "full_json_validated"
+        assert result.data["company_name"] == "Gorenje"
+        assert result.data["emails"] == ["info@gorenje.si"]
+        assert result.missing_fields == []
+
+    def test_preamble_before_json(self) -> None:
+        """The helper walks for the LAST parseable object — a preamble
+        doesn't defeat the happy path."""
+        text = (
+            "Here's the profile you asked for:\n"
+            '{"company_name": "X", "country": "SI", "website": "", "emails": [], '
+            '"phones": [], "industry": "", "summary": "", "sources": []}'
+        )
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.strategy == "full_json_validated"
+        assert result.data["company_name"] == "X"
+
+    def test_empty_list_defaults_respected(self) -> None:
+        """Pydantic default_factory for emails / phones / sources means
+        ``[]`` is valid where the JSON omits them AND the model has
+        defaults. ``CustomerEnrichment`` has string defaults ``""`` so
+        omission is allowed."""
+        text = '{"company_name": "X"}'
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.strategy == "full_json_validated"
+        assert result.data["company_name"] == "X"
+        assert result.data["emails"] == []
+
+
+# ── Strategy 2: json_extracted ───────────────────────────────────────
+
+
+class RequiredNameModel(BaseModel):
+    """Has a required field — forces the happy path to fail when name
+    is missing, so we fall through to json_extracted."""
+
+    name: str
+    country: str = ""
+    emails: list[str] = Field(default_factory=list)
+
+
+class TestJsonExtracted:
+    def test_missing_required_drops_to_partial(self) -> None:
+        """The JSON is valid but missing the required ``name`` field.
+        Strategy 1 rejects; strategy 2 salvages ``country`` and ``emails``."""
+        text = '{"country": "SI", "emails": ["x@y.z"]}'
+        result = parse_partial(text, RequiredNameModel)
+        assert result.strategy == "json_extracted"
+        assert result.data == {"country": "SI", "emails": ["x@y.z"]}
+        assert result.missing_fields == ["name"]
+
+
+# ── Strategy 3: line_scan ────────────────────────────────────────────
+
+
+class TestLineScan:
+    def test_research_note_style(self) -> None:
+        """The pattern matches what Gemma writes in the research note:
+        plain ``Key: value`` lines, no JSON at all."""
+        text = (
+            "Company: MindMade\n"
+            "Country: Slovenia\n"
+            "Website: https://mindmade.ai/\n"
+            'Emails: ["info@mindmade.ai"]\n'
+            "Industry: Computer activities\n"
+            "Summary: Slovenian software company.\n"
+            "Sources:\n"
+            "  - https://mindmade.ai/\n"
+            "  - https://companywall.si/podjetje/mindmade-doo/MMCckxvq\n"
+        )
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.strategy == "line_scan"
+        assert result.data["country"] == "Slovenia"
+        assert result.data["website"] == "https://mindmade.ai/"
+        assert result.data["emails"] == ["info@mindmade.ai"]
+
+    def test_star_bolded_keys(self) -> None:
+        """Markdown-bolded keys (``**Company**: x``) still match."""
+        text = "**Company**: MindMade\n**Country**: Slovenia"
+        # Field is `company_name`, and the text has "Company" — the
+        # line-scan normalisation doesn't try to synonym-match. This
+        # assertion documents that constraint: rename your field to
+        # match LLM output if you want line_scan to pick it up.
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.data.get("country") == "Slovenia"
+
+    def test_not_found_placeholder_treated_as_absent(self) -> None:
+        """When the LLM writes ``Country: not found`` we DON'T land the
+        literal ``"not found"`` string in data — the field goes to
+        missing instead."""
+        text = "Country: not found\nIndustry: SaaS"
+        result = parse_partial(text, CustomerEnrichment)
+        assert "country" not in result.data
+        assert "country" in result.missing_fields
+        assert result.data.get("industry") == "SaaS"
+
+    def test_equals_separator(self) -> None:
+        text = "country = SI\nindustry = retail"
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.data["country"] == "SI"
+        assert result.data["industry"] == "retail"
+
+    def test_coerces_list_values(self) -> None:
+        text = 'emails: ["a@b.c", "d@e.f"]'
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.data["emails"] == ["a@b.c", "d@e.f"]
+
+    def test_coerces_bool_numeric_values(self) -> None:
+        """Line scan is provider-agnostic — bool / int / float still parse."""
+
+        class Flags(BaseModel):
+            active: bool = False
+            count: int = 0
+
+        text = "active: true\ncount: 42"
+        result = parse_partial(text, Flags)
+        assert result.data == {"active": True, "count": 42}
+
+
+# ── Strategy 4: none ─────────────────────────────────────────────────
+
+
+class TestGiveUp:
+    def test_empty_input(self) -> None:
+        result = parse_partial("", CustomerEnrichment)
+        assert result.strategy == "none"
+        assert result.data == {}
+        assert "company_name" in result.missing_fields
+
+    def test_junk_with_no_matches(self) -> None:
+        text = "Lorem ipsum dolor sit amet. This paragraph has no keys we recognise."
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.strategy == "none"
+        assert result.data == {}
+
+    def test_raw_output_preserved_on_give_up(self) -> None:
+        text = "uneparsable"
+        result = parse_partial(text, CustomerEnrichment)
+        assert result.raw_output == "uneparsable"
+
+
+# ── Schema shapes: JSON-schema dicts, dataclasses ────────────────────
+
+
+class TestSchemaShapes:
+    def test_dict_schema(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "year": {"type": "integer"},
+            },
+        }
+        text = "Name: Acme Inc\nYear: 2024"
+        result = parse_partial(text, schema)
+        assert result.data == {"name": "Acme Inc", "year": 2024}
+
+    def test_dataclass_via_annotations(self) -> None:
+        from dataclasses import dataclass
+
+        @dataclass
+        class AnnotatedThing:
+            title: str = ""
+            count: int = 0
+
+        text = '{"title": "x", "count": 3}'
+        result = parse_partial(text, AnnotatedThing)
+        # Not a Pydantic model → strategy 1 skipped; strategy 2 extracts.
+        assert result.strategy == "json_extracted"
+        assert result.data == {"title": "x", "count": 3}
+
+
+# ── Result dataclass ─────────────────────────────────────────────────
+
+
+class TestPartialResult:
+    def test_round_trip_field_access(self) -> None:
+        r = PartialResult(
+            data={"x": 1},
+            missing_fields=["y"],
+            raw_output="hello",
+            strategy="line_scan",
+        )
+        assert r.data == {"x": 1}
+        assert r.missing_fields == ["y"]
+        assert r.raw_output == "hello"
+        assert r.strategy == "line_scan"
+
+    def test_exported_from_top_level(self) -> None:
+        import quartermaster_sdk
+
+        assert "parse_partial" in quartermaster_sdk.__all__
+        assert "PartialResult" in quartermaster_sdk.__all__


### PR DESCRIPTION
## Problem

When an agent's \`instruction_form(schema=...)\` LLM output doesn't quite match the schema, strict validation returns \`output_data=None\`. Integrators end up hand-rolling per-schema \`_parse_research_note()\` / \`_parse_bill_note()\` helpers. Every project re-invents the same key:value parser.

## Solution

\`\`\`python
from quartermaster_sdk import parse_partial

result = parse_partial(raw_llm_output, CustomerEnrichment)

match result.strategy:
    case "full_json_validated":
        customer = result.data         # clean happy path
    case "json_extracted" | "line_scan":
        customer = result.data         # partial — check missing_fields
    case "none":
        flag_for_human_review(result.raw_output)
\`\`\`

## Strategy ladder

1. **\`full_json_validated\`** — full JSON parse + full Pydantic validation.
2. **\`json_extracted\`** — last \`{...}\` block found, per-field copy (tolerates missing required fields the Pydantic validator would reject).
3. **\`line_scan\`** — \`Field: value\` / \`Field = value\` / \`**Field**: value\` regex scan. Case-insensitive, strips spaces/underscores so "Company Name" matches \`company_name\`. JSON-decodes values (lists, bools, numbers) with string fallback. \`"not found"\` / \`"n/a"\` treated as absent.
4. **\`none\`** — nothing stuck.

## \`PartialResult\` shape

| Field | Type | Purpose |
|---|---|---|
| \`data\` | \`dict[str, Any]\` | What we salvaged. Always a plain dict, never a Pydantic instance. |
| \`missing_fields\` | \`list[str]\` | Schema fields we couldn't populate. |
| \`raw_output\` | \`str\` | Original text — kept for logs / error reports. |
| \`strategy\` | \`str\` | Named step that won: \`full_json_validated\` / \`json_extracted\` / \`line_scan\` / \`none\`. |

Never raises. Callers decide whether to use the partial data, ask the user, or re-run.

## Schema shapes supported

- Pydantic \`BaseModel\` subclasses (primary)
- JSON-schema dicts (via \`properties\`)
- Dataclasses / classes with \`__annotations__\`

## Tests

\`quartermaster-sdk/tests/test_v060_parse_partial.py\` — 17 cases:
- full_json_validated: clean body, preamble, defaults
- json_extracted: missing-required drops to partial
- line_scan: research-note style, **bold** keys, "not found" absent, equals separator, list values, bool/numeric coercion
- give-up: empty input, junk, raw_output preserved
- schema shapes: JSON-schema dict, dataclass
- PartialResult: field access, exported at top level

**Full SDK suite: 214 passed** (+17 new).

## Exports

- \`qm.parse_partial\` — callable
- \`qm.PartialResult\` — dataclass for return type inspection
Both in \`quartermaster_sdk.__all__\` and covered by the public-surface test.

Closes v0.6.0 ask #7.