### PR TITLE
feat: node-level retry primitive for instruction / agent / instruction_form (ask #6)

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -65,6 +65,25 @@ from quartermaster_engine.types import (
 logger = logging.getLogger(__name__)
 
 
+# v0.7.0: node types eligible for graph-level retry.  Mirrors the surface
+# the builder exposes — ``instruction() / instruction_form() / agent()``.
+# Other node types ignore the ``retry_max_attempts`` metadata key (it's
+# only populated by the three builders that accept ``retry=``).
+_RETRYABLE_NODE_TYPES: frozenset[NodeType] = frozenset(
+    {NodeType.INSTRUCTION, NodeType.INSTRUCTION_FORM, NodeType.AGENT}
+)
+
+
+def _default_retry_predicate(result: NodeResult) -> bool:
+    """Default v0.7.0 retry predicate — fire only when the node failed.
+
+    Used when ``retry={"max_attempts": N}`` is passed without an ``on=``
+    predicate. Matches the documented semantics: "retry fires on the
+    exception path".
+    """
+    return not result.success
+
+
 @dataclass
 class FlowResult:
     """The final result of a flow execution.
@@ -132,6 +151,7 @@ class FlowRunner:
         provider_registry: Any | None = None,
         tool_registry: Any | None = None,
         parent_context: ExecutionContext | None = None,
+        retry_predicates: dict[str, Callable[[NodeResult], bool]] | None = None,
     ) -> None:
         """Construct a runner.
 
@@ -191,6 +211,16 @@ class FlowRunner:
         # v0.3.0: pointer back at the parent flow's ExecutionContext when
         # this runner is driving a sub-graph (spawned via SUB_ASSISTANT).
         self.parent_context = parent_context
+        # v0.7.0: per-node-name retry predicates. The builder's
+        # ``retry={"on": ...}`` kwarg stashes the callable here (via the
+        # SDK runner's pass-through) so the engine can resolve it by
+        # node name at run time.  Predicates can't live in node metadata
+        # because callables aren't JSON/YAML-serialisable — we follow
+        # the same in-memory side-channel pattern that ``_inline_tools``
+        # uses for tool callables.
+        self.retry_predicates: dict[str, Callable[[NodeResult], bool]] = dict(
+            retry_predicates or {}
+        )
 
         self._traverse_in = TraverseInGate()
         self._traverse_out = TraverseOutGate()
@@ -670,9 +700,17 @@ class FlowRunner:
             _cancelled_event=self._get_cancel_event(flow_id),
         )
 
-        # Execute with error handling
+        # Execute with error handling — wrapped in the v0.7.0 node-level
+        # retry loop for INSTRUCTION / INSTRUCTION_FORM / AGENT nodes when
+        # their metadata carries ``retry_max_attempts`` (set by
+        # ``.agent(retry={...})`` et al on the builder).  The loop
+        # re-invokes ``_run_executor`` up to ``max_attempts`` times,
+        # gated by the (optional) per-node predicate; both the happy
+        # path and the exception path are covered.  Non-retryable node
+        # types (or retryable nodes with no retry spec) execute exactly
+        # once, preserving pre-v0.7.0 behaviour.
         try:
-            result = self._run_executor(executor, context, node)
+            result = self._run_with_retry(executor, context, node, flow_id)
         except Exception as e:
             return self._handle_node_error(flow_id, node, execution, str(e))
 
@@ -688,6 +726,124 @@ class FlowRunner:
                 self.store.save_memory(flow_id, key, value)
 
         return result
+
+    def _run_with_retry(
+        self,
+        executor: NodeExecutor,
+        context: ExecutionContext,
+        node: GraphNode,
+        flow_id: UUID,
+    ) -> NodeResult:
+        """Invoke *executor* under the v0.7.0 node-level retry policy.
+
+        Scope is the SINGLE node — retries re-run ``executor.execute(...)``
+        with the same context; the rest of the graph is untouched (separate
+        design from a graph-level retry).  The counter is per-call, so a
+        sub-graph visited twice gets a fresh budget each time.
+
+        Semantics:
+
+        * Only :class:`NodeType.INSTRUCTION`, ``INSTRUCTION_FORM`` and
+          ``AGENT`` participate — the surface the builder exposes.  Other
+          node types short-circuit to a single ``_run_executor`` call.
+        * ``retry_max_attempts`` on node metadata is the TOTAL attempt
+          budget (initial attempt + retries).  Missing / non-int / ``<= 0``
+          → 1 (normalised upstream, but we defensively clamp again).
+        * The predicate (resolved by node name against
+          ``self.retry_predicates``) is called with the ``NodeResult`` of
+          the just-completed attempt.  If it returns True AND the budget
+          allows, we retry.  If no predicate is registered, the default
+          ``success is False`` check fires (exception path).
+        * Exceptions inside the executor are caught, converted into a
+          synthetic ``NodeResult(success=False, error=...)`` so the
+          predicate can inspect them, and the loop re-invokes the
+          executor.  After the final attempt the caught exception is
+          re-raised so the outer ``_execute_logic_node`` can funnel it
+          through ``_handle_node_error``.
+        * Every retry emits a ``CustomEvent(name="node.retried", ...)``
+          so observability tooling (``stream.custom(name="node.retried")``)
+          can see when and why a retry fired.
+        """
+        # Fast path — not a retryable node type, run once and done.
+        if node.type not in _RETRYABLE_NODE_TYPES:
+            return self._run_executor(executor, context, node)
+
+        raw_budget = node.metadata.get("retry_max_attempts", 1)
+        try:
+            max_attempts = int(raw_budget)
+        except (TypeError, ValueError):
+            max_attempts = 1
+        if max_attempts <= 0:
+            max_attempts = 1
+
+        predicate = self.retry_predicates.get(node.name)
+
+        attempt = 0
+        last_exc: Exception | None = None
+        while True:
+            attempt += 1
+            last_exc = None
+            try:
+                result = self._run_executor(executor, context, node)
+            except Exception as exc:
+                last_exc = exc
+                # Build a synthetic failure result so the predicate (if any)
+                # gets a uniform NodeResult shape to inspect.  We never
+                # expose this result outside the retry loop — on success
+                # we return ``result``; on budget exhaustion we re-raise
+                # the original exception.
+                result = NodeResult(success=False, data={}, error=str(exc))
+
+            if attempt >= max_attempts:
+                # Out of budget — if the last attempt raised, re-raise so
+                # the outer error handler runs.  Otherwise return the
+                # final result (success or failure) as-is.
+                if last_exc is not None:
+                    raise last_exc
+                return result
+
+            # Decide whether to retry based on the predicate.  ``last_exc``
+            # forces the retry path regardless of the predicate — an
+            # exception is always considered a retry trigger (the "default
+            # behaviour" for specs without ``on=``) because otherwise a
+            # caller-supplied predicate that only inspects ``output_text``
+            # would silently swallow transient errors.
+            if last_exc is not None:
+                should_retry = True
+                reason = "exception"
+            else:
+                pred = predicate if predicate is not None else _default_retry_predicate
+                try:
+                    should_retry = bool(pred(result))
+                except Exception:
+                    logger.exception(
+                        "retry predicate for node %r raised; treating as "
+                        "no-retry and surfacing the current result",
+                        node.name,
+                    )
+                    should_retry = False
+                reason = "predicate"
+
+            if not should_retry:
+                return result
+
+            # Emit the retry event BEFORE the next attempt so the retried
+            # attempt's NodeStarted/finished events sit alongside it in
+            # arrival order.  ``attempt`` here counts the retry itself,
+            # starting at 1 for the first re-run (matches the spec's
+            # "attempt counter starting at 1 (first retry)" wording).
+            self._emit(
+                CustomEvent(
+                    flow_id=flow_id,
+                    node_id=node.id,
+                    name="node.retried",
+                    payload={
+                        "node": node.name,
+                        "attempt": attempt,
+                        "reason": reason,
+                    },
+                )
+            )
 
     def _run_executor(
         self, executor: NodeExecutor, context: ExecutionContext, node: GraphNode

--- a/quartermaster-engine/tests/test_v070_node_retry.py
+++ b/quartermaster-engine/tests/test_v070_node_retry.py
@@ -1,0 +1,347 @@
+"""v0.7.0 — graph-level per-node retry primitive (engine side).
+
+The builder puts ``retry_max_attempts`` on node metadata and (optionally)
+stashes an ``on=`` predicate in a side-channel dict that the SDK runner
+forwards to :class:`FlowRunner` as ``retry_predicates={name: callable}``.
+The engine wraps the executor invocation in a loop:
+
+* Up to ``max_attempts`` total attempts per node execution.
+* Predicate ``(NodeResult) -> bool`` gates the retry. When absent the
+  default "retry on failure" kicks in (``NodeResult.success is False``).
+* Exceptions count as a retry trigger regardless of predicate.
+* Emits ``CustomEvent(name="node.retried")`` for each re-attempt.
+* Counter is per-node-execution — not shared across sub-graph invocations.
+* Non-retryable node types (e.g. ``START``) ignore the metadata.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from quartermaster_engine import FlowRunner
+from quartermaster_engine.context.execution_context import ExecutionContext
+from quartermaster_engine.events import CustomEvent, FlowEvent
+from quartermaster_engine.nodes import NodeResult, SimpleNodeRegistry
+from quartermaster_engine.types import (
+    GraphSpec,
+    GraphEdge,
+    GraphNode,
+    NodeType,
+    ThoughtType,
+    MessageType,
+    TraverseOut,
+)
+
+
+# ── Test doubles ────────────────────────────────────────────────────
+
+
+class _ScriptedExecutor:
+    """Executor whose ``execute()`` returns / raises from a scripted list.
+
+    Each call pops the next element:
+
+    * A :class:`NodeResult` is returned as-is.
+    * An :class:`Exception` instance is raised.
+    * A bare string is converted to a successful ``NodeResult(output_text=...)``.
+
+    Tracks ``call_count`` for assertions.
+    """
+
+    def __init__(self, script: list[Any]) -> None:
+        self._script = list(script)
+        self.call_count = 0
+
+    async def execute(self, context: ExecutionContext) -> NodeResult:
+        self.call_count += 1
+        if not self._script:
+            # Shouldn't happen in tests — surface loudly rather than looping.
+            raise AssertionError("scripted executor ran out of responses")
+        next_item = self._script.pop(0)
+        if isinstance(next_item, Exception):
+            raise next_item
+        if isinstance(next_item, NodeResult):
+            return next_item
+        return NodeResult(success=True, data={}, output_text=str(next_item))
+
+
+def _build_graph(
+    node_type: NodeType = NodeType.INSTRUCTION,
+    node_name: str = "Target",
+    retry_max_attempts: int | None = None,
+) -> tuple[GraphSpec, GraphNode]:
+    """Tiny graph: Start → Target → End.  Only the ``Target`` node is
+    interesting; the Start / End nodes pass through unchanged.
+
+    Returns ``(spec, target_node)`` so tests can reference the node's
+    UUID when scripting registries / asserting captures.
+    """
+    start = GraphNode(
+        id=uuid4(),
+        type=NodeType.START,
+        name="Start",
+        thought_type=ThoughtType.SKIP,
+        message_type=MessageType.VARIABLE,
+    )
+    metadata: dict[str, Any] = {}
+    if retry_max_attempts is not None:
+        metadata["retry_max_attempts"] = retry_max_attempts
+    target = GraphNode(
+        id=uuid4(),
+        type=node_type,
+        name=node_name,
+        metadata=metadata,
+        message_type=MessageType.ASSISTANT,
+    )
+    end = GraphNode(
+        id=uuid4(),
+        type=NodeType.END,
+        name="End",
+        traverse_out=TraverseOut.SPAWN_NONE,
+        thought_type=ThoughtType.SKIP,
+        message_type=MessageType.VARIABLE,
+    )
+    edges = [
+        GraphEdge(source_id=start.id, target_id=target.id),
+        GraphEdge(source_id=target.id, target_id=end.id),
+    ]
+    spec = GraphSpec(
+        id=uuid4(),
+        agent_id=uuid4(),
+        start_node_id=start.id,
+        nodes=[start, target, end],
+        edges=edges,
+    )
+    return spec, target
+
+
+def _make_runner(
+    spec: GraphSpec,
+    executor: _ScriptedExecutor,
+    target_type: NodeType,
+    events: list[FlowEvent] | None = None,
+    retry_predicates: dict[str, Any] | None = None,
+) -> FlowRunner:
+    """Build a runner with just the executor we care about + passthroughs
+    for the non-interesting node types."""
+    from quartermaster_engine.example_runner import PassthroughExecutor
+
+    reg = SimpleNodeRegistry()
+    reg.register(target_type.value, executor)
+    # Cover the other node types the test graph uses so the runner
+    # doesn't bail on "no executor registered" before reaching Target.
+    reg.register(NodeType.START.value, PassthroughExecutor())
+    reg.register(NodeType.END.value, PassthroughExecutor())
+
+    on_event = None
+    if events is not None:
+
+        def _capture(ev: FlowEvent) -> None:
+            events.append(ev)
+
+        on_event = _capture
+
+    return FlowRunner(
+        graph=spec,
+        node_registry=reg,
+        on_event=on_event,
+        retry_predicates=retry_predicates,
+    )
+
+
+# ── Default predicate: retry on success=False ────────────────────────
+
+
+def test_failing_then_succeeding_produces_success_on_second_attempt() -> None:
+    """``retry_max_attempts=3`` + fail, then succeed → success, 2 calls."""
+    spec, target = _build_graph(retry_max_attempts=3)
+    executor = _ScriptedExecutor(
+        [
+            NodeResult(success=False, data={}, error="transient"),
+            NodeResult(success=True, data={}, output_text="recovered"),
+        ]
+    )
+    runner = _make_runner(spec, executor, NodeType.INSTRUCTION)
+    fr = runner.run("go")
+    assert fr.success is True, fr.error
+    assert executor.call_count == 2
+    # The successful attempt's output flows to the End node.
+    assert "recovered" in fr.final_output
+
+
+def test_always_failing_exhausts_budget_exactly_max_attempts_times() -> None:
+    """Always-failing executor with budget=3 → 3 calls, final NodeResult.success=False."""
+    spec, target = _build_graph(retry_max_attempts=3)
+    executor = _ScriptedExecutor(
+        [
+            NodeResult(success=False, data={}, error="boom-1"),
+            NodeResult(success=False, data={}, error="boom-2"),
+            NodeResult(success=False, data={}, error="boom-3"),
+        ]
+    )
+    runner = _make_runner(spec, executor, NodeType.INSTRUCTION)
+    fr = runner.run("go")
+    assert executor.call_count == 3
+    assert fr.success is False
+    # The final error surfaces via the flow-level error string.
+    assert fr.error is not None
+    assert "boom-3" in fr.error
+
+
+def test_no_retry_spec_runs_node_exactly_once() -> None:
+    """No ``retry_max_attempts`` metadata → legacy single-call behaviour."""
+    spec, target = _build_graph(retry_max_attempts=None)
+    executor = _ScriptedExecutor([NodeResult(success=True, data={}, output_text="once")])
+    runner = _make_runner(spec, executor, NodeType.INSTRUCTION)
+    fr = runner.run("go")
+    assert fr.success is True, fr.error
+    assert executor.call_count == 1
+
+
+def test_retry_emits_node_retried_custom_event_with_attempt_and_reason() -> None:
+    """Each retry fires a CustomEvent(name='node.retried') with ``attempt`` and ``reason``."""
+    spec, target = _build_graph(retry_max_attempts=3)
+    executor = _ScriptedExecutor(
+        [
+            NodeResult(success=False, data={}, error="first"),
+            NodeResult(success=False, data={}, error="second"),
+            NodeResult(success=True, data={}, output_text="ok"),
+        ]
+    )
+    events: list[FlowEvent] = []
+    runner = _make_runner(spec, executor, NodeType.INSTRUCTION, events=events)
+    fr = runner.run("go")
+    assert fr.success is True, fr.error
+
+    retries = [ev for ev in events if isinstance(ev, CustomEvent) and ev.name == "node.retried"]
+    # 3 attempts → 2 retries.
+    assert len(retries) == 2
+    # Attempt counter starts at 1 for the first retry, 2 for the second.
+    assert retries[0].payload["attempt"] == 1
+    assert retries[1].payload["attempt"] == 2
+    # All retries reference the target node by name.
+    for ev in retries:
+        assert ev.payload["node"] == "Target"
+        assert ev.payload["reason"] == "predicate"
+        assert ev.node_id == target.id
+
+
+# ── Custom predicate ─────────────────────────────────────────────────
+
+
+def test_predicate_based_retry_runs_once_then_stops() -> None:
+    """Predicate ``on=lambda r: "retry me" in r.output_text`` re-runs when
+    the first result has that text and stops when the second doesn't."""
+    spec, target = _build_graph(retry_max_attempts=5)
+    executor = _ScriptedExecutor(
+        [
+            NodeResult(success=True, data={}, output_text="please retry me"),
+            NodeResult(success=True, data={}, output_text="final answer"),
+        ]
+    )
+
+    def _predicate(capture: NodeResult) -> bool:
+        return "retry me" in (capture.output_text or "")
+
+    runner = _make_runner(
+        spec,
+        executor,
+        NodeType.INSTRUCTION,
+        retry_predicates={"Target": _predicate},
+    )
+    fr = runner.run("go")
+    assert fr.success is True, fr.error
+    assert executor.call_count == 2
+    assert "final answer" in fr.final_output
+
+
+def test_predicate_never_triggers_runs_once() -> None:
+    """Predicate that never returns True → single call even with budget=5."""
+    spec, target = _build_graph(retry_max_attempts=5)
+    executor = _ScriptedExecutor([NodeResult(success=True, data={}, output_text="done")])
+    runner = _make_runner(
+        spec,
+        executor,
+        NodeType.INSTRUCTION,
+        retry_predicates={"Target": lambda r: False},
+    )
+    fr = runner.run("go")
+    assert fr.success is True, fr.error
+    assert executor.call_count == 1
+
+
+def test_exception_path_retries_with_reason_exception() -> None:
+    """An executor exception counts as a retry trigger; reason='exception'."""
+    spec, target = _build_graph(retry_max_attempts=3)
+    executor = _ScriptedExecutor(
+        [
+            RuntimeError("network glitch"),
+            NodeResult(success=True, data={}, output_text="recovered"),
+        ]
+    )
+    events: list[FlowEvent] = []
+    runner = _make_runner(spec, executor, NodeType.INSTRUCTION, events=events)
+    fr = runner.run("go")
+    assert fr.success is True, fr.error
+    assert executor.call_count == 2
+
+    retries = [ev for ev in events if isinstance(ev, CustomEvent) and ev.name == "node.retried"]
+    assert len(retries) == 1
+    assert retries[0].payload["reason"] == "exception"
+
+
+# ── Agent node ───────────────────────────────────────────────────────
+
+
+def test_agent_node_retries_on_predicate_match() -> None:
+    """Same contract applies to ``NodeType.AGENT``."""
+    spec, target = _build_graph(node_type=NodeType.AGENT, retry_max_attempts=2)
+    executor = _ScriptedExecutor(
+        [
+            NodeResult(success=True, data={}, output_text="bad <|tool_call>"),
+            NodeResult(success=True, data={}, output_text="clean"),
+        ]
+    )
+
+    def _predicate(r: NodeResult) -> bool:
+        return "<|tool_call>" in (r.output_text or "")
+
+    runner = _make_runner(
+        spec,
+        executor,
+        NodeType.AGENT,
+        retry_predicates={"Target": _predicate},
+    )
+    fr = runner.run("go")
+    assert fr.success is True, fr.error
+    assert executor.call_count == 2
+
+
+# ── Non-retryable node types ─────────────────────────────────────────
+
+
+def test_retry_metadata_ignored_on_non_retryable_types() -> None:
+    """A node type outside {INSTRUCTION, INSTRUCTION_FORM, AGENT} must
+    ignore ``retry_max_attempts``; the loop is intentionally limited to
+    the builder's ``retry=`` surface."""
+    from quartermaster_engine.types import NodeType as NT
+
+    # DECISION is logic but not part of the retry surface.
+    spec, target = _build_graph(node_type=NT.STATIC, retry_max_attempts=5)
+    executor = _ScriptedExecutor([NodeResult(success=False, data={}, error="one-shot")])
+    runner = _make_runner(spec, executor, NT.STATIC)
+    runner.run("go")
+    # One call only — metadata was present but the type wasn't eligible.
+    assert executor.call_count == 1
+
+
+# ── Zero / negative budget is normalised ─────────────────────────────
+
+
+def test_zero_max_attempts_runs_exactly_once() -> None:
+    spec, target = _build_graph(retry_max_attempts=0)
+    executor = _ScriptedExecutor([NodeResult(success=False, data={}, error="boom")])
+    runner = _make_runner(spec, executor, NodeType.INSTRUCTION)
+    runner.run("go")
+    assert executor.call_count == 1

--- a/quartermaster-graph/src/quartermaster_graph/builder.py
+++ b/quartermaster-graph/src/quartermaster_graph/builder.py
@@ -38,6 +38,11 @@ _META_CONFIG_KEYS = {"show_output", "capture_as"}
 # string (see ``quartermaster_engine.runner.flow_runner``).
 CAPTURE_AS_METADATA_KEY = "capture_as"
 
+# v0.7.0: node-metadata key under which the ``retry_max_attempts`` integer
+# (normalised budget for node-level retries) is stored.  Kept as a named
+# constant so the engine side can import it rather than hard-coding.
+RETRY_MAX_ATTEMPTS_METADATA_KEY = "retry_max_attempts"
+
 # Combined set for extraction from kwargs
 _ALL_CONFIG_KEYS = _FLOW_CONFIG_KEYS | _META_CONFIG_KEYS
 
@@ -95,6 +100,55 @@ def _llm_meta(
         meta["llm_extra_body"] = dict(extra_body)
     meta.update({k: v for k, v in extra.items() if k not in _ALL_CONFIG_KEYS})
     return meta
+
+
+def _apply_retry_spec(
+    node: GraphNode,
+    retry: dict[str, Any] | None,
+    predicate_registry: dict[str, Any],
+) -> None:
+    """Apply a v0.7.0 retry spec to *node* metadata and *predicate_registry*.
+
+    The retry spec is a dict with shape::
+
+        {"max_attempts": int, "on": Callable[[NodeResult], bool] | None}
+
+    Only the integer budget lands on ``node.metadata[RETRY_MAX_ATTEMPTS_METADATA_KEY]``
+    because node metadata must survive JSON / YAML round-trips.  The ``on``
+    predicate (if any) is stashed in *predicate_registry* keyed by node name
+    so the engine can look it up at run time via the same inline-tools-style
+    side-channel — it does NOT survive serialisation.
+
+    ``max_attempts`` values ``<= 0`` are normalised to ``1`` (no retries,
+    just the initial attempt).  The spec is a no-op when ``retry`` is
+    ``None`` or an empty dict — metadata stays clean so round-trips don't
+    acquire stale keys.
+    """
+    if not retry:
+        return
+    max_attempts = retry.get("max_attempts", 1)
+    try:
+        max_attempts_int = int(max_attempts)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"retry=: 'max_attempts' must be int-coercible, got {max_attempts!r}"
+        ) from exc
+    if max_attempts_int <= 0:
+        max_attempts_int = 1
+    node.metadata[RETRY_MAX_ATTEMPTS_METADATA_KEY] = max_attempts_int
+
+    predicate = retry.get("on")
+    if predicate is not None:
+        if not callable(predicate):
+            raise TypeError(
+                f"retry={{'on': ...}}: expected a callable predicate, got "
+                f"{type(predicate).__name__}"
+            )
+        # Keyed by node NAME — the engine resolves predicates by looking
+        # the node's name up in ``FlowRunner.retry_predicates`` at run time.
+        # Callable objects can't survive JSON/YAML so they live only in
+        # this in-memory registry (mirrors the inline-tools design).
+        predicate_registry[node.name] = predicate
 
 
 def _normalise_agent_tools(
@@ -382,11 +436,20 @@ class _BranchBuilder:
         provider: str = "",
         temperature: float = 0.5,
         system_instruction: str = "",
+        retry: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> _BranchBuilder:
         """Add an Instruction node — pure LLM text generation, NO tools.
 
         Streams the LLM response. Use ``agent()`` instead if you need tool use.
+
+        Args:
+            retry: Optional v0.7.0 node-level retry spec. A dict with
+                ``max_attempts`` (int) and optional ``on`` (predicate
+                ``(NodeResult) -> bool``). Only the int budget survives
+                ``to_json``/``from_json`` round-trips — the predicate is
+                held in memory on the builder and re-attached to the
+                engine by the SDK runner.
         """
         flow_cfg = {k: kwargs.pop(k) for k in list(kwargs) if k in _ALL_CONFIG_KEYS}
         meta = _llm_meta(
@@ -400,6 +463,7 @@ class _BranchBuilder:
             type=NodeType.INSTRUCTION, name=name, metadata=meta, message_type=MessageType.ASSISTANT
         )
         _apply_flow_config(node, flow_cfg)
+        _apply_retry_spec(node, retry, self._graph._retry_predicates)
         return self._add_node(node)
 
     def instruction_form(
@@ -410,6 +474,7 @@ class _BranchBuilder:
         provider: str = "",
         temperature: float = 0.1,
         system_instruction: str = "",
+        retry: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> _BranchBuilder:
         """Add an InstructionForm node — LLM returns typed JSON.
@@ -420,6 +485,8 @@ class _BranchBuilder:
 
         Args:
             schema: Pydantic BaseModel subclass or dict JSON Schema.
+            retry: Optional v0.7.0 node-level retry spec — see
+                :meth:`instruction` for the exact shape.
         """
         import json as _json
 
@@ -451,6 +518,7 @@ class _BranchBuilder:
             message_type=MessageType.ASSISTANT,
         )
         _apply_flow_config(node, flow_cfg)
+        _apply_retry_spec(node, retry, self._graph._retry_predicates)
         return self._add_node(node)
 
     def summarize(
@@ -486,6 +554,7 @@ class _BranchBuilder:
         tools: list[Any] | None = None,
         max_iterations: int = 25,
         tool_scope: str = "strict",
+        retry: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> _BranchBuilder:
         """Add an Agent node — autonomous agentic loop with optional tools.
@@ -509,6 +578,8 @@ class _BranchBuilder:
                 ``"permissive"`` — the legacy pre-v0.4.0 behaviour where
                 every tool registered on the shared registry is reachable
                 from this node; intended as a migration escape hatch.
+            retry: Optional v0.7.0 node-level retry spec — see
+                :meth:`instruction` for the exact shape.
         """
         flow_cfg = {k: kwargs.pop(k) for k in list(kwargs) if k in _ALL_CONFIG_KEYS}
         meta = _llm_meta(
@@ -524,6 +595,7 @@ class _BranchBuilder:
             type=NodeType.AGENT, name=name, metadata=meta, message_type=MessageType.ASSISTANT
         )
         _apply_flow_config(node, flow_cfg)
+        _apply_retry_spec(node, retry, self._graph._retry_predicates)
         return self._add_node(node)
 
     def instruction_program(
@@ -1434,6 +1506,13 @@ class GraphBuilder:
         # in the serialisable GraphSpec (they can't survive JSON/YAML
         # round-trips), only the resolved tool NAMES do.
         self._inline_tools: dict[str, Any] = {}
+        # v0.7.0: side-channel dict of {node_name: retry-predicate callable}
+        # populated by ``.instruction(retry=...)`` / ``.agent(retry=...)`` /
+        # ``.instruction_form(retry=...)``.  The engine resolves predicates
+        # by name at run time.  Callable objects can't survive JSON/YAML
+        # so they live only in this in-memory registry (mirrors
+        # ``_inline_tools``).
+        self._retry_predicates: dict[str, Any] = {}
         if auto_start:
             self._create_start_node()
 
@@ -1655,11 +1734,19 @@ class GraphBuilder:
         provider: str = "",
         temperature: float = 0.5,
         system_instruction: str = "",
+        retry: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> GraphBuilder:
         """Add an Instruction node — pure LLM text generation, NO tools.
 
         Streams the LLM response. Use ``agent()`` instead if you need tool use.
+
+        Args:
+            retry: Optional v0.7.0 node-level retry spec. Shape:
+                ``{"max_attempts": int, "on": (NodeResult) -> bool}``.
+                Only the integer budget survives ``to_json``/``from_json``
+                round-trips — the predicate is in-memory only (builder
+                side-channel, re-attached by the SDK runner).
         """
         flow_cfg = {k: kwargs.pop(k) for k in list(kwargs) if k in _ALL_CONFIG_KEYS}
         meta = _llm_meta(
@@ -1673,6 +1760,7 @@ class GraphBuilder:
             type=NodeType.INSTRUCTION, name=name, metadata=meta, message_type=MessageType.ASSISTANT
         )
         _apply_flow_config(node, flow_cfg)
+        _apply_retry_spec(node, retry, self._retry_predicates)
         return self._add_node(node)
 
     def instruction_form(
@@ -1683,11 +1771,13 @@ class GraphBuilder:
         provider: str = "",
         temperature: float = 0.1,
         system_instruction: str = "",
+        retry: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> GraphBuilder:
         """Add an InstructionForm node — LLM returns typed JSON.
 
-        See :meth:`_BranchBuilder.instruction_form`.
+        See :meth:`_BranchBuilder.instruction_form`. Accepts the v0.7.0
+        ``retry=`` spec; see :meth:`instruction` for the exact shape.
         """
         import json as _json
 
@@ -1719,6 +1809,7 @@ class GraphBuilder:
             message_type=MessageType.ASSISTANT,
         )
         _apply_flow_config(node, flow_cfg)
+        _apply_retry_spec(node, retry, self._retry_predicates)
         return self._add_node(node)
 
     def summarize(
@@ -1754,6 +1845,7 @@ class GraphBuilder:
         tools: list[Any] | None = None,
         max_iterations: int = 25,
         tool_scope: str = "strict",
+        retry: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> GraphBuilder:
         """Add an Agent node — autonomous agentic loop with optional tools.
@@ -1796,6 +1888,7 @@ class GraphBuilder:
             type=NodeType.AGENT, name=name, metadata=meta, message_type=MessageType.ASSISTANT
         )
         _apply_flow_config(node, flow_cfg)
+        _apply_retry_spec(node, retry, self._retry_predicates)
         return self._add_node(node)
 
     def instruction_program(
@@ -2605,6 +2698,11 @@ class GraphBuilder:
         # yet accessible to the SDK runner via ``getattr(spec, "_inline_tools")``.
         if self._inline_tools:
             object.__setattr__(ver, "_inline_tools", dict(self._inline_tools))
+        # v0.7.0: retry predicates follow the same side-channel pattern as
+        # inline tools — callables can't survive JSON/YAML, so they live as
+        # a non-declared attribute on the spec for the SDK runner to read.
+        if self._retry_predicates:
+            object.__setattr__(ver, "_retry_predicates", dict(self._retry_predicates))
         return ver
 
     def build(self, validate: bool = True) -> GraphSpec:

--- a/quartermaster-graph/tests/test_v070_retry_kwarg.py
+++ b/quartermaster-graph/tests/test_v070_retry_kwarg.py
@@ -1,0 +1,167 @@
+"""v0.7.0 — ``retry={"max_attempts": N, "on": <callable>}`` on the builder.
+
+Covers the builder half of the graph-level node-retry primitive:
+
+* ``.agent(retry=...)`` / ``.instruction(retry=...)`` / ``.instruction_form(retry=...)``
+  stash ``retry_max_attempts`` on node metadata (integer, serialisable).
+* The ``on`` predicate (optional) is stashed in the builder's
+  ``_retry_predicates`` side-channel keyed by node name — NOT on node
+  metadata, because callables can't survive JSON / YAML round-trips.
+* Zero / negative ``max_attempts`` is normalised to 1 (no retries, just
+  the initial attempt).
+* Omitting ``retry=`` leaves metadata clean — no stale
+  ``retry_max_attempts`` key.
+* JSON / YAML round-trips preserve the integer; the callable is lost
+  because it lives only in the in-memory registry.
+
+Engine wiring is covered separately in
+``quartermaster-engine/tests/test_v070_node_retry.py``.
+"""
+
+from __future__ import annotations
+
+from quartermaster_graph import Graph
+from quartermaster_graph.serialization import from_json, to_json
+
+
+def _node(graph, name: str):
+    spec = graph.build()
+    for n in spec.nodes:
+        if n.name == name:
+            return n
+    raise AssertionError(f"node {name!r} not in built graph")
+
+
+def test_agent_retry_stashes_max_attempts_on_metadata() -> None:
+    graph = Graph("g").user().agent("Research", retry={"max_attempts": 3})
+    meta = _node(graph, "Research").metadata
+    assert meta["retry_max_attempts"] == 3
+
+
+def test_instruction_retry_stashes_max_attempts_on_metadata() -> None:
+    graph = Graph("g").user().instruction("Say", retry={"max_attempts": 4})
+    meta = _node(graph, "Say").metadata
+    assert meta["retry_max_attempts"] == 4
+
+
+def test_instruction_form_retry_stashes_max_attempts_on_metadata() -> None:
+    graph = (
+        Graph("g")
+        .user()
+        .instruction_form("Form", schema={"type": "object"}, retry={"max_attempts": 2})
+    )
+    meta = _node(graph, "Form").metadata
+    assert meta["retry_max_attempts"] == 2
+
+
+def test_no_retry_leaves_metadata_clean() -> None:
+    """Omitting ``retry=`` must NOT leave a ``retry_max_attempts`` key."""
+    graph = Graph("g").user().agent("Plain").instruction("Follow-up")
+    for name in ("Plain", "Follow-up"):
+        meta = _node(graph, name).metadata
+        assert "retry_max_attempts" not in meta, (
+            f"node {name!r} acquired retry_max_attempts without retry=; metadata={meta}"
+        )
+
+
+def test_predicate_stashed_in_retry_predicates_side_channel() -> None:
+    def _on(capture):
+        return "boom" in (capture.output_text or "")
+
+    builder = Graph("g").user().agent("Research", retry={"max_attempts": 3, "on": _on})
+
+    # The builder instance itself holds the side-channel dict (the
+    # :class:`GraphBuilder` the ``.agent()`` call returned is the same
+    # object we started from — chainable API).
+    assert isinstance(builder._retry_predicates, dict)
+    assert builder._retry_predicates["Research"] is _on
+
+    # Building propagates the predicates onto the spec for the SDK
+    # runner to pick up.  Attribute access — it's NOT a declared
+    # Pydantic field (callables can't survive model_dump).
+    spec = builder.build()
+    assert getattr(spec, "_retry_predicates")["Research"] is _on
+
+
+def test_predicate_keyed_by_node_name_across_multiple_nodes() -> None:
+    def _on_a(capture):
+        return False
+
+    def _on_b(capture):
+        return False
+
+    builder = (
+        Graph("g")
+        .user()
+        .instruction("A", retry={"max_attempts": 2, "on": _on_a})
+        .agent("B", retry={"max_attempts": 3, "on": _on_b})
+    )
+    assert builder._retry_predicates == {"A": _on_a, "B": _on_b}
+
+
+def test_retry_without_on_leaves_predicate_registry_empty() -> None:
+    builder = Graph("g").user().agent("Research", retry={"max_attempts": 3})
+    assert builder._retry_predicates == {}
+
+
+def test_max_attempts_zero_is_normalised_to_one() -> None:
+    graph = Graph("g").user().agent("R", retry={"max_attempts": 0})
+    assert _node(graph, "R").metadata["retry_max_attempts"] == 1
+
+
+def test_max_attempts_negative_is_normalised_to_one() -> None:
+    graph = Graph("g").user().agent("R", retry={"max_attempts": -5})
+    assert _node(graph, "R").metadata["retry_max_attempts"] == 1
+
+
+def test_max_attempts_default_when_key_missing_is_one() -> None:
+    """If the caller passes an otherwise-empty dict, treat it as no-retry."""
+    graph = Graph("g").user().agent("R", retry={})
+    # Empty dict is falsy → _apply_retry_spec returns early, leaving
+    # metadata untouched (same as retry=None).
+    assert "retry_max_attempts" not in _node(graph, "R").metadata
+
+
+def test_json_round_trip_preserves_max_attempts() -> None:
+    """The integer budget survives to_json / from_json; the callable does not.
+
+    Node metadata is JSON-serialisable by contract, so the integer
+    ``retry_max_attempts`` key round-trips cleanly.  The ``on=`` predicate
+    lives in a builder-side registry and is intentionally lost across
+    JSON transport — downstream integrators must re-attach predicates on
+    the consumer side via a fresh builder.
+    """
+
+    def _on(capture):
+        return False
+
+    builder = Graph("g").user().agent("Research", retry={"max_attempts": 3, "on": _on})
+    spec = builder.build()
+    payload = to_json(spec)
+    # ``to_json`` produces a JSON-compatible dict — verify the integer
+    # survives into the dump (otherwise a silent drop would still
+    # "round trip" to the same missing value).
+    agent_node = next(n for n in payload["nodes"] if n["name"] == "Research")
+    assert agent_node["metadata"]["retry_max_attempts"] == 3
+
+    restored = from_json(payload)
+    restored_meta = next(n for n in restored.nodes if n.name == "Research").metadata
+    assert restored_meta["retry_max_attempts"] == 3
+
+    # The callable is NOT on the restored spec (private side-channel was
+    # never serialised to begin with).
+    assert getattr(restored, "_retry_predicates", None) in (None, {})
+
+
+def test_non_callable_predicate_raises_type_error() -> None:
+    import pytest
+
+    with pytest.raises(TypeError, match="callable predicate"):
+        Graph("g").user().agent("R", retry={"max_attempts": 2, "on": "not a callable"})
+
+
+def test_non_int_max_attempts_raises_value_error() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="int-coercible"):
+        Graph("g").user().agent("R", retry={"max_attempts": "three"})

--- a/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_async_runner.py
@@ -43,6 +43,7 @@ from ._runner import (
     StreamDeadlineExceeded,
     _event_to_chunk,
     _extract_inline_tools,
+    _extract_retry_predicates,
     _merge_inline_tools,
     _resolve_call_timeouts,
     _resolve_graph,
@@ -104,6 +105,7 @@ class _ARunCallable:
         their current LLM/tool call but no new work is scheduled.
         """
         inline_tools = _extract_inline_tools(graph)
+        retry_predicates = _extract_retry_predicates(graph)
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
         prepared_images = prepare_images(image=image, images=images)
@@ -130,6 +132,7 @@ class _ARunCallable:
             graph=spec,
             provider_registry=registry,
             tool_registry=effective_tool_registry,
+            retry_predicates=retry_predicates or None,
             # Forward every event to the global listener registry so
             # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
             # observes the same FlowEvent stream the streaming runner
@@ -298,6 +301,7 @@ class _ARunCallable:
                 f"arun.stream(): deadline_seconds must be > 0, got {deadline_seconds!r}"
             )
         inline_tools = _extract_inline_tools(graph)
+        retry_predicates = _extract_retry_predicates(graph)
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
         prepared_images = prepare_images(image=image, images=images)
@@ -338,6 +342,7 @@ class _ARunCallable:
             graph=spec,
             provider_registry=registry,
             tool_registry=effective_tool_registry,
+            retry_predicates=retry_predicates or None,
             on_event=on_event,
         )
 

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -154,6 +154,27 @@ def _extract_inline_tools(graph: GraphBuilder | GraphSpec) -> dict[str, Any]:
     return dict(raw)
 
 
+def _extract_retry_predicates(graph: GraphBuilder | GraphSpec) -> dict[str, Any]:
+    """Return the builder-side ``_retry_predicates`` dict if present.
+
+    v0.7.0: ``.agent(retry={"on": <callable>})`` (and the analogous
+    ``instruction()`` / ``instruction_form()`` forms) stashes the
+    predicate on the builder's ``_retry_predicates`` side-channel so the
+    engine can resolve it by node name at run time. Callables cannot
+    survive JSON/YAML so they do NOT round-trip through a rebuilt
+    :class:`GraphSpec` — callers who transport graphs across process
+    boundaries must re-attach their predicates via a freshly-invoked
+    builder on the consumer side.
+
+    Returns an empty dict when the graph carries no predicates (mirrors
+    :func:`_extract_inline_tools`).
+    """
+    raw = getattr(graph, "_retry_predicates", None)
+    if not isinstance(raw, dict):
+        return {}
+    return dict(raw)
+
+
 def _merge_inline_tools(
     tool_registry: Any | None,
     inline_tools: dict[str, Any],
@@ -429,6 +450,7 @@ class _RunCallable:
             user_input = _apply_pii_redaction(user_input, redact_policy)
 
         inline_tools = _extract_inline_tools(graph)
+        retry_predicates = _extract_retry_predicates(graph)
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
         prepared_images = prepare_images(image=image, images=images)
@@ -453,6 +475,7 @@ class _RunCallable:
             graph=spec,
             provider_registry=registry,
             tool_registry=effective_tool_registry,
+            retry_predicates=retry_predicates or None,
             # Forward every event to the global listener registry so
             # bolt-on instrumentation (e.g. ``qm.telemetry.instrument()``)
             # observes the same FlowEvent stream the streaming runner
@@ -614,6 +637,7 @@ class _RunCallable:
                 f"run.stream(): deadline_seconds must be > 0, got {deadline_seconds!r}"
             )
         inline_tools = _extract_inline_tools(graph)
+        retry_predicates = _extract_retry_predicates(graph)
         spec = _resolve_graph(graph)
         registry = provider_registry or get_default_registry()
         prepared_images = prepare_images(image=image, images=images)
@@ -653,6 +677,7 @@ class _RunCallable:
             graph=spec,
             provider_registry=registry,
             tool_registry=effective_tool_registry,
+            retry_predicates=retry_predicates or None,
             on_event=on_event,
         )
 

--- a/quartermaster-sdk/tests/test_v070_retry_integration.py
+++ b/quartermaster-sdk/tests/test_v070_retry_integration.py
@@ -1,0 +1,144 @@
+"""v0.7.0 — end-to-end ``.agent(retry={...})`` through ``qm.run``.
+
+Exercises the full surface: builder stashes ``retry_max_attempts`` on
+node metadata + the ``on=`` predicate in the ``_retry_predicates``
+side-channel; the SDK runner forwards both to :class:`FlowRunner`; the
+engine re-runs the node until the predicate returns False or the budget
+is exhausted.
+
+The MockProvider scripts two distinct answers — the first should trip
+the predicate (``"bad" in output_text``), the second should clear it.
+End state: 2 provider calls, final capture text == "good".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import quartermaster_sdk as qm
+from quartermaster_providers import ProviderRegistry
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+from quartermaster_tools import get_default_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_sdk_state():
+    """Reset SDK config + the default tool registry between tests."""
+    qm.reset_config()
+    get_default_registry().clear()
+    yield
+    qm.reset_config()
+    get_default_registry().clear()
+
+
+def _scripted_registry(texts: list[str]) -> tuple[ProviderRegistry, MockProvider]:
+    """Build a ``ProviderRegistry`` whose ``MockProvider`` replays the
+    given completion texts in order.
+
+    Each text drives ONE ``generate_native_response`` call — perfect for
+    agent nodes that degenerate to single-shot completions when no tools
+    are attached.
+    """
+    mock = MockProvider(
+        responses=[TokenResponse(content=t, stop_reason="stop") for t in texts],
+        native_responses=[
+            NativeResponse(
+                text_content=t,
+                thinking=[],
+                tool_calls=[],
+                stop_reason="stop",
+            )
+            for t in texts
+        ],
+    )
+    reg = ProviderRegistry(auto_configure=False)
+    reg.register_instance("mock", mock)
+    reg.set_default_provider("mock")
+    reg.set_default_model("mock", "test-model")
+    return reg, mock
+
+
+def test_retry_on_predicate_reruns_then_stops() -> None:
+    """First answer ``"bad"`` → predicate True → retry; second answer
+    ``"good"`` → predicate False → done.  Exactly 2 provider calls."""
+    reg, mock = _scripted_registry(["bad", "good"])
+    qm.configure(registry=reg)
+
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent(
+            "Research",
+            capture_as="Research",
+            retry={
+                "max_attempts": 2,
+                "on": lambda r: "bad" in (r.output_text or ""),
+            },
+        )
+    )
+
+    result = qm.run(graph, "go")
+    assert result.success, result.error
+    # The second attempt's "good" output should be the surviving capture.
+    assert result.captures["Research"].output_text == "good"
+    # And the mock was called exactly twice (no more, no fewer).
+    native_calls = [c for c in mock.calls if c["method"] == "generate_native_response"]
+    assert len(native_calls) == 2
+
+
+def test_retry_budget_not_exceeded_when_predicate_keeps_firing() -> None:
+    """Predicate stays True through every attempt — the runner must stop
+    at ``max_attempts`` calls, NOT loop forever."""
+    reg, mock = _scripted_registry(["bad", "still bad", "always bad"])
+    qm.configure(registry=reg)
+
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent(
+            "Research",
+            capture_as="Research",
+            retry={
+                "max_attempts": 2,
+                "on": lambda r: "bad" in (r.output_text or ""),
+            },
+        )
+    )
+
+    qm.run(graph, "go")
+    # max_attempts=2 → exactly 2 provider calls, never 3.
+    native_calls = [c for c in mock.calls if c["method"] == "generate_native_response"]
+    assert len(native_calls) == 2
+
+
+def test_retry_emits_node_retried_custom_chunk_on_stream() -> None:
+    """The ``node.retried`` engine event surfaces as a ``CustomChunk``
+    on the streaming surface — integrators can filter it via
+    ``stream.custom(name="node.retried")``."""
+    reg, _mock = _scripted_registry(["bad", "good"])
+    qm.configure(registry=reg)
+
+    graph = (
+        qm.Graph("chat")
+        .user()
+        .agent(
+            "Research",
+            capture_as="Research",
+            retry={
+                "max_attempts": 2,
+                "on": lambda r: "bad" in (r.output_text or ""),
+            },
+        )
+    )
+
+    retried_chunks: list[dict] = []
+    with qm.run.stream(graph, "go") as s:
+        for chunk in s:
+            if getattr(chunk, "name", None) == "node.retried":
+                retried_chunks.append(dict(chunk.payload))
+
+    assert len(retried_chunks) == 1
+    assert retried_chunks[0]["node"] == "Research"
+    assert retried_chunks[0]["attempt"] == 1
+    assert retried_chunks[0]["reason"] == "predicate"


### PR DESCRIPTION
## Shape

\`\`\`python
graph.agent(
    "Research",
    retry={
        "max_attempts": 2,
        "on": lambda capture: "<|tool_call>" in (capture.output_text or ""),
    },
    tools=[...],
)
\`\`\`

Works on \`.instruction()\`, \`.instruction_form()\`, and \`.agent()\`. Scope is the single node — no whole-graph rewind.

## Semantics

| Behaviour | Value |
|---|---|
| Predicate signature | \`(capture: NodeResult) -> bool\` |
| Default predicate | \`capture.success is False\` (exception path) |
| \`max_attempts ≤ 0\` | normalised to 1 (no retries) |
| Counter | per-node-execution (sub-graphs visited twice get fresh budgets) |
| Exception during attempt | always retries (until budget) — \`reason="exception"\` |
| Predicate returned True | retries — \`reason="predicate"\` |
| Retry event | \`CustomEvent(name="node.retried", payload={"node", "attempt", "reason"})\` |

## Plumbing

- **Builder**: \`retry=\` kwarg on \`.instruction()\` / \`.instruction_form()\` / \`.agent()\`. Stashes \`retry_max_attempts\` int on node metadata, keyed-by-node-name callables on \`self._retry_predicates\` (side-channel like \`_inline_tools\`).
- **Engine**: \`FlowRunner.retry_predicates=\` kwarg; \`_run_with_retry\` wraps LLM node execution. Decision / user / static nodes unchanged.
- **SDK runner**: \`_extract_retry_predicates\` mirrors \`_extract_inline_tools\`; threaded through both sync and async call paths.

## Serialisation

Round-trips cleanly: only \`retry_max_attempts\` survives \`to_json\` / \`from_json\`. The \`on\` predicate is callable and in-memory only (declared via \`object.__setattr__\`, invisible to \`model_dump\`). Callers who reconstruct a graph from JSON will have max-attempts but no predicate — default exception-only predicate then applies.

## Tests

- \`quartermaster-graph/tests/test_v070_retry_kwarg.py\` — 13 cases (stashing, normalisation, predicate registry, JSON round-trip)
- \`quartermaster-engine/tests/test_v070_node_retry.py\` — 10 cases (retry-success, budget-exhausted, predicate, default, event emission, call_count assertions)
- \`quartermaster-sdk/tests/test_v070_retry_integration.py\` — 3 cases (end-to-end, predicate fires on text pattern, captures carry successful output)

| Package | Before | After |
|---|---|---|
| quartermaster-graph | 248 | **261** |
| quartermaster-engine | 474 | **484** |
| quartermaster-sdk | 214 | **217** (+2 skip) |

No new public exports — \`retry=\` on the builder methods is the entire user-facing surface.

Closes v0.7 ask #6.