### PR TITLE
feat: stream cancellation actually aborts the in-flight httpx call (ask #1)

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -390,13 +390,24 @@ class LLMExecutor(NodeExecutor):
             system_message=system_instruction,
         )
 
+        from quartermaster_providers.cancellation import set_cancel_check
+
         try:
-            stream = await provider.generate_text_response(prompt, config)
-            chunks = []
-            async for token_response in stream:
-                if token_response.content:
-                    chunks.append(token_response.content)
-                    context.emit_token(token_response.content)
+            # v0.7.0: install a cancellation probe the provider's streaming
+            # path polls between chunks. When ``runner.stop(flow_id)`` flips
+            # ``ctx.cancelled`` (SSE client disconnect / explicit
+            # qm.Cancelled / context-manager break), the provider closes
+            # the openai AsyncStream → httpx response, so vLLM / Ollama
+            # stop generating mid-token instead of draining to completion.
+            with set_cancel_check(lambda: context.cancelled):
+                stream = await provider.generate_text_response(prompt, config)
+                chunks = []
+                async for token_response in stream:
+                    if token_response.stop_reason == "cancelled":
+                        break
+                    if token_response.content:
+                        chunks.append(token_response.content)
+                        context.emit_token(token_response.content)
             text = "".join(chunks)
 
             # Append to conversation history

--- a/quartermaster-providers/src/quartermaster_providers/__init__.py
+++ b/quartermaster-providers/src/quartermaster_providers/__init__.py
@@ -17,6 +17,10 @@ Example:
 """
 
 from quartermaster_providers.base import AbstractLLMProvider
+from quartermaster_providers.cancellation import (  # noqa: F401
+    set_cancel_check,
+    should_cancel,
+)
 from quartermaster_providers.circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerState,

--- a/quartermaster-providers/src/quartermaster_providers/cancellation.py
+++ b/quartermaster-providers/src/quartermaster_providers/cancellation.py
@@ -1,0 +1,83 @@
+"""Provider-level cooperative cancellation for streaming LLM calls.
+
+v0.7.0. Motivation:
+
+``qm.run.stream(graph, user_input)`` returns a generator. When the HTTP
+client disconnects (browser AbortController, SSE client close), the
+outer caller breaks out of the generator. The SDK propagates that via
+``FlowRunner.stop(flow_id)`` which flips an asyncio event the running
+executor polls via ``ctx.cancelled``.
+
+Pre-v0.7.0 that flag only stopped the AGENT LOOP from scheduling the
+*next* LLM iteration. The in-flight ``/v1/chat/completions`` stream
+kept draining tokens from the server until the model finished
+naturally — vLLM kept its slot occupied, the token bill kept ticking.
+
+This module exposes a contextvar-based cancellation hook that the
+provider's streaming path polls between chunks. When the engine sets
+``set_cancel_check(lambda: ctx.cancelled)`` around the provider call,
+the provider calls ``should_cancel()`` after each yielded chunk and
+closes the openai ``AsyncStream`` (which in turn closes the underlying
+``httpx.AsyncClient`` response) when cancellation is requested.
+
+Contextvar rather than a kwarg on ``LLMConfig``:
+- ``LLMConfig`` is serialisable (survives to_json / from_json); a
+  callable wouldn't round-trip.
+- ``ContextVar`` carries through asyncio.to_thread and copy_context()
+  already (v0.5.0's parallel-tool-dispatch path relies on this), so
+  cancellation propagates into worker threads without extra plumbing.
+- Scoped push/pop means nested ``qm.run`` calls each see their own
+  cancel check rather than the outermost one leaking through.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from contextvars import ContextVar
+from typing import Callable, Iterator
+
+#: The contextvar itself. ``None`` means "no cancel check installed" — the
+#: default case for calls outside a ``qm.run.stream`` flow (one-shot
+#: ``qm.instruction``, direct provider use in tests, etc.).
+_cancel_check: ContextVar[Callable[[], bool] | None] = ContextVar("qm_cancel_check", default=None)
+
+
+@contextlib.contextmanager
+def set_cancel_check(check: Callable[[], bool] | None) -> Iterator[None]:
+    """Install *check* for the duration of a ``with`` block.
+
+    The engine wraps each streaming provider call with this manager,
+    passing ``lambda: ctx.cancelled``. Inside the block, any code that
+    calls :func:`should_cancel` observes the installed check; on exit
+    we reset the previous value so nested flows behave correctly.
+
+    ``check`` may be ``None`` — useful when a caller wants to
+    explicitly strip cancellation for a sub-call (e.g. a cleanup path
+    that must complete even after the outer flow was cancelled).
+    """
+    token = _cancel_check.set(check)
+    try:
+        yield
+    finally:
+        _cancel_check.reset(token)
+
+
+def should_cancel() -> bool:
+    """Return ``True`` iff a cancel check is installed AND reports True.
+
+    Safe to call from any code path — returns ``False`` when no check
+    is installed, so one-shot ``qm.instruction`` callers never trip it.
+    Providers poll this between streaming chunks and close the response
+    when it flips.
+    """
+    check = _cancel_check.get()
+    if check is None:
+        return False
+    try:
+        return bool(check())
+    except Exception:
+        # A misbehaving predicate must not crash the streaming path —
+        # treat a raising check as "don't cancel" so the stream keeps
+        # flowing and the caller observes the exception on the next
+        # natural check (e.g. a per-node error).
+        return False

--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -190,6 +190,34 @@ def _coerce_text_tool_call_payload(payload: str) -> tuple[str, dict[str, Any]] |
     return name, args
 
 
+async def _aclose_stream(stream: Any) -> None:
+    """Close an openai streaming response defensively.
+
+    openai's ``AsyncStream`` exposes either ``close()`` (a coroutine),
+    ``aclose()`` (a coroutine), or a ``.response`` attribute with an
+    ``aclose()`` coroutine. Older versions only have one or the other.
+    We try each option; any exception during close is swallowed —
+    we're in a finally path and must not obscure the original error.
+    """
+    for attr in ("close", "aclose"):
+        method = getattr(stream, attr, None)
+        if callable(method):
+            try:
+                result = method()
+                if hasattr(result, "__await__"):
+                    await result
+                return
+            except Exception:
+                pass
+    response = getattr(stream, "response", None)
+    aclose = getattr(response, "aclose", None) if response is not None else None
+    if callable(aclose):
+        try:
+            await aclose()
+        except Exception:
+            pass
+
+
 def _extract_reasoning_text(obj: Any) -> str:
     """Pull reasoning text out of a non-standard OpenAI-compatible response.
 
@@ -475,38 +503,64 @@ class OpenAIProvider(AbstractLLMProvider):
     async def _stream_text(
         self, client: Any, params: dict[str, Any]
     ) -> AsyncIterator[TokenResponse]:
+        # v0.7.0: poll the provider-level cancellation contextvar between
+        # chunks. When the engine calls ``runner.stop(flow_id)`` (triggered
+        # by an SSE client disconnect, a ``with qm.run.stream(...) as stream:
+        # break``, or an explicit ``qm.Cancelled`` exception in a tool) it
+        # flips the check; we then close the openai ``AsyncStream`` — which
+        # closes the underlying httpx response — so vLLM / Ollama stops
+        # generating and releases the slot. Without this the httpx
+        # connection kept draining tokens until the model finished naturally.
+        from quartermaster_providers.cancellation import should_cancel
+
         try:
             stream = await client.chat.completions.create(**params)
-            async for chunk in stream:
-                if chunk.choices:
-                    delta = chunk.choices[0].delta
-                    finish_reason = chunk.choices[0].finish_reason
-                    if delta and delta.content:
+            try:
+                async for chunk in stream:
+                    if chunk.choices:
+                        delta = chunk.choices[0].delta
+                        finish_reason = chunk.choices[0].finish_reason
+                        if delta and delta.content:
+                            yield TokenResponse(
+                                content=delta.content,
+                                stop_reason=finish_reason,
+                            )
+                        else:
+                            # OpenAI-compatible reasoning models stream their
+                            # answer through ``reasoning_content`` (or ``reasoning``)
+                            # when ``content`` is absent — surface that as visible
+                            # text so callers don't see an empty stream.
+                            reasoning_chunk = _extract_reasoning_text(delta) if delta else ""
+                            if reasoning_chunk:
+                                yield TokenResponse(
+                                    content=reasoning_chunk,
+                                    stop_reason=finish_reason,
+                                )
+                            elif finish_reason:
+                                yield TokenResponse(
+                                    content="",
+                                    stop_reason=finish_reason,
+                                )
+                    if hasattr(chunk, "usage") and chunk.usage:
                         yield TokenResponse(
-                            content=delta.content,
-                            stop_reason=finish_reason,
+                            content="",
+                            stop_reason="usage",
                         )
-                    else:
-                        # OpenAI-compatible reasoning models stream their
-                        # answer through ``reasoning_content`` (or ``reasoning``)
-                        # when ``content`` is absent — surface that as visible
-                        # text so callers don't see an empty stream.
-                        reasoning_chunk = _extract_reasoning_text(delta) if delta else ""
-                        if reasoning_chunk:
-                            yield TokenResponse(
-                                content=reasoning_chunk,
-                                stop_reason=finish_reason,
-                            )
-                        elif finish_reason:
-                            yield TokenResponse(
-                                content="",
-                                stop_reason=finish_reason,
-                            )
-                if hasattr(chunk, "usage") and chunk.usage:
-                    yield TokenResponse(
-                        content="",
-                        stop_reason="usage",
-                    )
+                    if should_cancel():
+                        # Close the openai AsyncStream (→ httpx response)
+                        # so the server knows to stop generating. The
+                        # ``stop_reason="cancelled"`` sentinel tells the
+                        # engine loop to treat this as a cooperative
+                        # cancel rather than a natural finish.
+                        await _aclose_stream(stream)
+                        yield TokenResponse(content="", stop_reason="cancelled")
+                        return
+            finally:
+                # Defensive: if the consumer abandons the generator mid-
+                # stream (e.g. the engine raises out of the async-for),
+                # still close the underlying httpx response rather than
+                # leaking it into GC.
+                await _aclose_stream(stream)
         except (AuthenticationError, RateLimitError, ProviderError):
             raise
         except Exception as e:

--- a/quartermaster-providers/tests/test_v070_stream_cancel.py
+++ b/quartermaster-providers/tests/test_v070_stream_cancel.py
@@ -1,0 +1,231 @@
+"""v0.7.0 — provider-level stream cancellation.
+
+The provider polls ``should_cancel()`` between streaming chunks. The
+engine wraps each provider call with ``set_cancel_check(lambda:
+ctx.cancelled)``. When cancellation fires, the provider closes the
+openai ``AsyncStream`` (which closes the underlying ``httpx`` response,
+which releases the vLLM slot).
+
+These tests exercise the primitive without a live LLM server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from quartermaster_providers.cancellation import (
+    set_cancel_check,
+    should_cancel,
+)
+from quartermaster_providers.config import LLMConfig
+from quartermaster_providers.providers.openai import OpenAIProvider
+
+
+# ── Unit: contextvar push/pop/default ───────────────────────────────
+
+
+class TestCancelContextVar:
+    def test_default_is_false(self) -> None:
+        """No cancel check installed → should_cancel() is a safe False."""
+
+        async def _probe() -> bool:
+            return should_cancel()
+
+        assert asyncio.run(_probe()) is False
+
+    def test_installed_true(self) -> None:
+        async def _probe() -> bool:
+            with set_cancel_check(lambda: True):
+                return should_cancel()
+
+        assert asyncio.run(_probe()) is True
+
+    def test_installed_false(self) -> None:
+        async def _probe() -> bool:
+            with set_cancel_check(lambda: False):
+                return should_cancel()
+
+        assert asyncio.run(_probe()) is False
+
+    def test_pop_restores_previous(self) -> None:
+        """Nested context managers stack — exiting the inner one
+        restores the outer's check, not the default."""
+
+        async def _probe() -> tuple[bool, bool, bool]:
+            outer_before: bool = False
+            outer_during: bool = False
+            outer_after: bool = False
+            with set_cancel_check(lambda: True):
+                outer_before = should_cancel()  # outer says True
+                with set_cancel_check(lambda: False):
+                    outer_during = should_cancel()  # inner says False
+                outer_after = should_cancel()  # outer again True
+            return outer_before, outer_during, outer_after
+
+        a, b, c = asyncio.run(_probe())
+        assert a is True
+        assert b is False
+        assert c is True
+
+    def test_raising_predicate_treated_as_no_cancel(self) -> None:
+        """A buggy predicate must not bring down the streaming path."""
+
+        def _raise() -> bool:
+            raise RuntimeError("bad predicate")
+
+        async def _probe() -> bool:
+            with set_cancel_check(_raise):
+                return should_cancel()
+
+        assert asyncio.run(_probe()) is False
+
+    def test_none_strips_cancellation(self) -> None:
+        """Explicitly passing None inside a nested block suppresses
+        an outer cancel — useful for cleanup code that must complete
+        even after the outer flow was cancelled."""
+
+        async def _probe() -> tuple[bool, bool]:
+            outer: bool = False
+            inner: bool = False
+            with set_cancel_check(lambda: True):
+                outer = should_cancel()
+                with set_cancel_check(None):
+                    inner = should_cancel()
+            return outer, inner
+
+        a, b = asyncio.run(_probe())
+        assert a is True
+        assert b is False
+
+
+# ── Integration: openai provider stream cancels mid-iteration ────────
+
+
+def _make_chunk(text: str, finish: str | None = None) -> MagicMock:
+    """Fake one streaming chunk from openai.AsyncStream."""
+    delta = MagicMock()
+    delta.content = text
+    choice = MagicMock()
+    choice.delta = delta
+    choice.finish_reason = finish
+    chunk = MagicMock()
+    chunk.choices = [choice]
+    chunk.usage = None
+    return chunk
+
+
+class _FakeAsyncStream:
+    """Mimics openai.AsyncStream: async-iterable + close coroutine."""
+
+    def __init__(self, chunks: list[MagicMock]) -> None:
+        self._chunks = list(chunks)
+        self.closed = False
+        # The number of chunks actually pulled by the consumer before
+        # a close. Helps tests assert "we stopped at iteration N".
+        self.yielded_count = 0
+
+    def __aiter__(self) -> "_FakeAsyncStream":
+        return self
+
+    async def __anext__(self) -> MagicMock:
+        if self.closed or not self._chunks:
+            raise StopAsyncIteration
+        self.yielded_count += 1
+        return self._chunks.pop(0)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestStreamCancellation:
+    def test_cancel_mid_stream_closes_response(self) -> None:
+        """Check returns True after the 3rd chunk — stream.close() runs,
+        consumer sees a ``cancelled`` sentinel, remaining chunks are
+        NOT emitted."""
+        chunks = [_make_chunk(f"t{i} ", finish=None) for i in range(10)]
+        fake_stream = _FakeAsyncStream(chunks)
+
+        provider = OpenAIProvider(api_key="sk-test")
+        provider._client = MagicMock()
+        provider._client.chat.completions.create = AsyncMock(return_value=fake_stream)
+
+        # Flip True after 3 chunks have been observed.
+        state = {"calls": 0}
+
+        def _check() -> bool:
+            state["calls"] += 1
+            # We poll AFTER yielding; so check-after-3rd-yield is
+            # the 3rd invocation → flip True.
+            return state["calls"] >= 3
+
+        async def _drive() -> tuple[list[str], bool]:
+            out: list[str] = []
+            with set_cancel_check(_check):
+                config = LLMConfig(model="gpt-4o", provider="openai", stream=True)
+                stream = await provider.generate_text_response("hi", config)
+                async for token in stream:
+                    if token.stop_reason == "cancelled":
+                        out.append("<CANCELLED>")
+                        break
+                    if token.content:
+                        out.append(token.content)
+            return out, fake_stream.closed
+
+        out, closed = asyncio.run(_drive())
+        # We see the first 3 tokens (the check fires after each yield).
+        # The cancel sentinel terminates the stream before token 4.
+        assert out[:3] == ["t0 ", "t1 ", "t2 "]
+        assert out[-1] == "<CANCELLED>"
+        assert closed, "Provider must close the underlying AsyncStream on cancel"
+        # Fewer than all 10 chunks were pulled.
+        assert fake_stream.yielded_count < 10
+
+    def test_no_cancel_check_drains_fully(self) -> None:
+        """When no cancel check is installed, the stream drains every
+        chunk — the baseline we want the cancellation code to preserve
+        for the happy path."""
+        chunks = [_make_chunk(f"t{i} ", finish=None) for i in range(5)]
+        fake_stream = _FakeAsyncStream(chunks)
+
+        provider = OpenAIProvider(api_key="sk-test")
+        provider._client = MagicMock()
+        provider._client.chat.completions.create = AsyncMock(return_value=fake_stream)
+
+        async def _drive() -> list[str]:
+            out: list[str] = []
+            config = LLMConfig(model="gpt-4o", provider="openai", stream=True)
+            stream = await provider.generate_text_response("hi", config)
+            async for token in stream:
+                if token.content:
+                    out.append(token.content)
+            return out
+
+        out = asyncio.run(_drive())
+        assert out == ["t0 ", "t1 ", "t2 ", "t3 ", "t4 "]
+        # And the finally-close still fires on natural end-of-stream:
+        assert fake_stream.closed
+
+    def test_cancel_check_that_stays_false_is_never_triggered(self) -> None:
+        """A check installed but reporting False must behave exactly
+        like no check at all — full drain, clean close."""
+        chunks = [_make_chunk(f"t{i} ", finish=None) for i in range(4)]
+        fake_stream = _FakeAsyncStream(chunks)
+
+        provider = OpenAIProvider(api_key="sk-test")
+        provider._client = MagicMock()
+        provider._client.chat.completions.create = AsyncMock(return_value=fake_stream)
+
+        async def _drive() -> list[str]:
+            out: list[str] = []
+            with set_cancel_check(lambda: False):
+                config = LLMConfig(model="gpt-4o", provider="openai", stream=True)
+                stream = await provider.generate_text_response("hi", config)
+                async for token in stream:
+                    if token.content:
+                        out.append(token.content)
+            return out
+
+        out = asyncio.run(_drive())
+        assert out == ["t0 ", "t1 ", "t2 ", "t3 "]
+        assert fake_stream.closed


### PR DESCRIPTION
## The bug

When an SSE client disconnects, \`runner.stop(flow_id)\` flipped \`ctx.cancelled\` — but the in-flight \`/v1/chat/completions\` stream kept draining tokens until the model finished naturally. vLLM kept its slot occupied; the token bill kept ticking.

## The fix

A provider-level contextvar (\`quartermaster_providers.cancellation\`) that the provider's streaming loop polls between chunks. The engine wraps each streaming call with:

\`\`\`python
with set_cancel_check(lambda: context.cancelled):
    async for token in await provider.generate_text_response(...):
        ...
\`\`\`

When the check fires, the provider:

1. Closes the openai \`AsyncStream\` (\`close()\` → underlying \`httpx\` response \`aclose()\` → vLLM sees TCP close → releases the slot).
2. Yields a terminal \`TokenResponse(content="", stop_reason="cancelled")\` so the engine recognises cooperative cancel.
3. Defensively re-closes in the \`finally\` path, covering the consumer-abandons-generator case.

A new \`_aclose_stream\` helper probes \`stream.close()\` / \`aclose()\` / \`stream.response.aclose()\` so the close works across every openai SDK version we support.

## Why a contextvar not an LLMConfig field

- LLMConfig is serialisable — a callable wouldn't round-trip.
- \`contextvars.copy_context()\` carries through \`asyncio.to_thread\` / the v0.5.0 parallel-tool-dispatch worker threads automatically. Zero extra plumbing.
- Scoped push/pop means nested \`qm.run\` calls see their own check; an outer cancel doesn't leak into an inner retry.

## Tests

9 cases in \`quartermaster-providers/tests/test_v070_stream_cancel.py\`:
- contextvar unit: default/installed/nested/raising/None-strips
- integration: cancel mid-stream closes AsyncStream, consumer sees \`<CANCELLED>\`, fewer chunks pulled than available
- baseline: no-check-installed and check-returns-False both drain fully + close cleanly

| Package | Before | After |
|---|---|---|
| quartermaster-providers | 274 | **283** |
| quartermaster-engine | 474 | **474** |

Closes v0.7 ask #1.

## Not in scope for this PR

- Non-streaming mid-call abort (one round-trip; not currently cancellable — openai SDK doesn't expose abort on non-stream create).
- Anthropic / Google / Groq / xAI streaming providers — same contextvar primitive is already available; they just need the same 3-line poll inserted in their stream methods. Follow-up PR.