### PR TITLE
fix: salvage Gemma-4's asymmetric-pipe + Python-call tool-call form

### DIFF
--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -75,7 +75,15 @@ def _is_o_series(model: str) -> bool:
 #: entry is ``(open_marker, close_marker)``. Order-matters: we try the
 #: most specific marker set first.
 _TEXT_TOOL_CALL_MARKERS: tuple[tuple[str, str], ...] = (
-    # Gemma-style markers
+    # Gemma-4's actual production form — asymmetric pipes. Open marker
+    # is ``<|tool_call>`` (pipe AFTER the ``<``), close marker is
+    # ``<tool_call|>`` (pipe BEFORE the ``>``). A production reproducer:
+    #   <|tool_call>call:list_orders(status='odprto')<tool_call|>
+    # Tried FIRST because it's more specific — the symmetric form
+    # below would accidentally match half of the asymmetric markers.
+    ("<|tool_call>", "<tool_call|>"),
+    # Symmetric Gemma variant — appears in some fine-tunes and in the
+    # upstream vLLM chat template when the stop tokens are collapsed.
     ("<|tool_call|>", "<|tool_call|>"),
     # Qwen / some Llama fine-tunes
     ("<tool_call>", "</tool_call>"),
@@ -154,20 +162,45 @@ def _parse_text_form_tool_calls(content: str) -> tuple[list[ToolCall], str]:
 
 
 def _coerce_text_tool_call_payload(payload: str) -> tuple[str, dict[str, Any]] | None:
-    """Parse ``{name, arguments}`` / ``{tool_name, parameters}`` /
-    ``{function: {name, arguments}}`` out of one JSON block.
+    """Parse one tool-call block into ``(name, arguments_dict)``.
 
-    Returns ``(name, arguments_dict)`` on success, ``None`` if the block
-    isn't parseable as any recognised shape.
+    Two payload flavours supported:
+
+    1. **JSON** — ``{"name": ..., "arguments": {...}}`` /
+       ``{"tool_name": ..., "parameters": {...}}`` /
+       ``{"function": {"name": ..., "arguments": {...}}}``, plus
+       double-encoded arguments strings.
+    2. **Python-call syntax** — ``call:list_orders(status='active')``.
+       Gemma-4 emits this form inside ``<|tool_call>...<tool_call|>``
+       blocks when the server lacks ``--tool-call-parser gemma4``.
+       Keyword args supported (``key='value'`` / ``key=42`` / ``key=None``
+       / ``key=True``). Positional-only calls are NOT supported —
+       downstream tool registries expect keyword arguments; a
+       positional call would need per-tool signature introspection
+       we don't have at this layer.
+
+    Returns ``None`` when neither form parses.
     """
+    payload = payload.strip()
+    if not payload:
+        return None
+
+    # JSON path first — it's strict, so if it doesn't parse we know
+    # to try the Python-call form. Parsing-unit has no ambiguity.
     try:
         obj = json.loads(payload)
+        if isinstance(obj, dict):
+            return _coerce_json_payload(obj)
     except json.JSONDecodeError:
-        return None
-    if not isinstance(obj, dict):
-        return None
+        pass
 
-    # Handle ``{"function": {...}}`` nesting
+    # Python-call path — ``call:name(key='val', key2=42, ...)``.
+    return _coerce_python_call_payload(payload)
+
+
+def _coerce_json_payload(obj: dict[str, Any]) -> tuple[str, dict[str, Any]] | None:
+    """JSON-shape extraction — factored out so the JSON and
+    Python-call paths stay easy to read independently."""
     fn = obj.get("function") if "function" in obj else obj
     if not isinstance(fn, dict):
         return None
@@ -188,6 +221,102 @@ def _coerce_text_tool_call_payload(payload: str) -> tuple[str, dict[str, Any]] |
     if not isinstance(args, dict):
         args = {"raw": args}
     return name, args
+
+
+#: Matches ``call:foo(args...)`` and ``foo(args...)`` with optional
+#: ``call:`` prefix. Captures the function name and the raw argument
+#: string. ``DOTALL`` so arg strings spanning newlines (rare, but
+#: Gemma-4 occasionally wraps them) still match.
+_PYTHON_CALL_RE = None
+
+
+def _python_call_regex():
+    global _PYTHON_CALL_RE
+    if _PYTHON_CALL_RE is None:
+        import re
+
+        _PYTHON_CALL_RE = re.compile(
+            r"""
+            (?:call\s*:\s*)?           # optional ``call:`` prefix
+            ([A-Za-z_][A-Za-z0-9_]*)   # tool name — Python identifier
+            \s*\(                      # opening paren
+            (.*?)                      # arg body (lazy, stops at the matching close)
+            \)\s*$                     # closing paren + optional trailing whitespace
+            """,
+            re.DOTALL | re.VERBOSE,
+        )
+    return _PYTHON_CALL_RE
+
+
+def _coerce_python_call_payload(payload: str) -> tuple[str, dict[str, Any]] | None:
+    """Parse ``call:list_orders(status='active', limit=5)`` into
+    ``("list_orders", {"status": "active", "limit": 5})``.
+
+    Uses :mod:`ast` to evaluate argument values so we get real Python
+    scalars (ints, floats, bools, ``None``, strings, lists, dicts).
+    ``ast.literal_eval`` rejects arbitrary expressions — no
+    ``eval()`` risk, no ``__import__``-style escapes.
+    """
+    import ast
+
+    match = _python_call_regex().fullmatch(payload)
+    if match is None:
+        return None
+    name, raw_args = match.group(1), match.group(2).strip()
+    if not name:
+        return None
+
+    if not raw_args:
+        # ``call:list_orders()`` — no arguments.
+        return name, {}
+
+    # Wrap the arg body in a synthetic call so ast can parse the
+    # keyword arguments for us — this is strictly-speaking easier
+    # than splitting on commas (which gets ugly inside nested dicts,
+    # quoted commas, etc.).
+    try:
+        expr = ast.parse(f"_({raw_args})", mode="eval")
+    except SyntaxError:
+        return None
+
+    call = expr.body
+    if not isinstance(call, ast.Call):
+        return None
+
+    args: dict[str, Any] = {}
+    for kw in call.keywords:
+        if kw.arg is None:
+            # ``**kwargs`` splat — nothing useful to extract; skip.
+            continue
+        try:
+            args[kw.arg] = ast.literal_eval(kw.value)
+        except (ValueError, SyntaxError):
+            # Value wasn't a literal (e.g. a bare identifier the model
+            # invented); stash the source form so the tool registry can
+            # at least log it meaningfully.
+            args[kw.arg] = ast.unparse(kw.value)
+
+    # Positional args: we expose them as ``__positional__`` so downstream
+    # tools can see them if they really want to, but most tools in
+    # quartermaster expect kwargs only. Left in as a diagnostic, not a
+    # promise.
+    if call.args:
+        args["__positional__"] = [
+            (ast.literal_eval(a) if _is_literal(a) else ast.unparse(a)) for a in call.args
+        ]
+
+    return name, args
+
+
+def _is_literal(node: Any) -> bool:
+    """``True`` when ``ast.literal_eval`` would accept *node*."""
+    import ast
+
+    try:
+        ast.literal_eval(node)
+    except (ValueError, SyntaxError):
+        return False
+    return True
 
 
 async def _aclose_stream(stream: Any) -> None:

--- a/quartermaster-providers/tests/test_v061_gemma4_asymmetric_markers.py
+++ b/quartermaster-providers/tests/test_v061_gemma4_asymmetric_markers.py
@@ -1,0 +1,262 @@
+"""v0.6.1 — Gemma-4 production emits asymmetric-pipe markers and
+Python-call syntax, not the symmetric-JSON form PR #63 originally
+covered.
+
+Observed in production when vLLM is launched without
+``--tool-call-parser gemma4``:
+
+    <|tool_call>call:list_orders(status='odprto')<tool_call|>
+    ^pipe-after-<                          ^pipe-before->
+
+Both the marker asymmetry and the Python-call payload format are new
+relative to PR #63. This file exercises both, plus the "multiple
+concatenated calls in one response" pattern that produces Gemma-4's
+retry-loop wedge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from quartermaster_providers.config import LLMConfig
+from quartermaster_providers.providers.openai import (
+    OpenAIProvider,
+    _coerce_python_call_payload,
+    _coerce_text_tool_call_payload,
+    _parse_text_form_tool_calls,
+)
+
+
+# ── Unit: the asymmetric marker pair is recognised ───────────────────
+
+
+class TestAsymmetricMarkers:
+    """The Gemma-4 production form ``<|tool_call>...<tool_call|>`` must
+    match — the whole reason this patch exists."""
+
+    def test_single_asymmetric_call_with_python_syntax(self) -> None:
+        content = "<|tool_call>call:list_orders(status='active')<tool_call|>"
+        calls, residual = _parse_text_form_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].tool_name == "list_orders"
+        assert calls[0].parameters == {"status": "active"}
+        assert residual == ""  # markers fully stripped
+
+    def test_symmetric_form_still_works(self) -> None:
+        """Don't regress the symmetric form — PR #63's original case."""
+        content = '<|tool_call|>{"name": "f", "arguments": {}}<|tool_call|>'
+        calls, _ = _parse_text_form_tool_calls(content)
+        assert len(calls) == 1
+        assert calls[0].tool_name == "f"
+
+    def test_asymmetric_takes_precedence_over_symmetric(self) -> None:
+        """When a string only contains asymmetric markers, we must NOT
+        accidentally match half of them as symmetric ``<|tool_call|>``
+        blocks. The asymmetric regex is listed first for this reason."""
+        content = "<|tool_call>call:a(x=1)<tool_call|><|tool_call>call:b(x=2)<tool_call|>"
+        calls, residual = _parse_text_form_tool_calls(content)
+        assert [c.tool_name for c in calls] == ["a", "b"]
+        assert residual == ""
+
+
+# ── Unit: the production reproducer (4 concatenated calls) ──────────
+
+
+class TestProductionReproducer:
+    """The exact string that triggered Gemma-4's retry loop on chat. All
+    four calls must salvage; no single call lost to the next call's
+    marker boundary."""
+
+    PRODUCTION_STRING = (
+        "<|tool_call>call:list_orders(status='odprto')<tool_call|>"
+        "<|tool_call>call:list_orders(status='poprokan')<tool_call|>"
+        "<|tool_call>call:list_orders(status='odprto')<tool_call|>"
+        "<|tool_call>call:list_orders(status='poprokan')<tool_call|>"
+    )
+
+    def test_four_calls_extracted(self) -> None:
+        calls, residual = _parse_text_form_tool_calls(self.PRODUCTION_STRING)
+        assert len(calls) == 4
+        assert [c.tool_name for c in calls] == ["list_orders"] * 4
+        assert [c.parameters["status"] for c in calls] == [
+            "odprto",
+            "poprokan",
+            "odprto",
+            "poprokan",
+        ]
+        assert residual == "", (
+            "Residual must be empty when every call was salvaged — "
+            "otherwise the assistant's visible text still shows the "
+            "literal <|tool_call> / <tool_call|> junk."
+        )
+
+    def test_four_calls_have_unique_tool_ids(self) -> None:
+        """Agent dispatch loops key by ``tool_id`` — duplicates would
+        collapse concurrent calls into one card and misorder results."""
+        calls, _ = _parse_text_form_tool_calls(self.PRODUCTION_STRING)
+        ids = [c.tool_id for c in calls]
+        assert len(ids) == len(set(ids))
+
+    def test_four_calls_preserve_order(self) -> None:
+        """The status params alternate odprto/poprokan — we must preserve
+        that order so the engine's ``tool_history`` reflects what the
+        model actually requested."""
+        calls, _ = _parse_text_form_tool_calls(self.PRODUCTION_STRING)
+        seen_order = [c.parameters["status"] for c in calls]
+        assert seen_order == ["odprto", "poprokan", "odprto", "poprokan"]
+
+
+# ── Unit: Python-call-syntax payload parser ──────────────────────────
+
+
+class TestPythonCallCoercer:
+    def test_single_string_kwarg(self) -> None:
+        assert _coerce_python_call_payload("call:list_orders(status='active')") == (
+            "list_orders",
+            {"status": "active"},
+        )
+
+    def test_without_call_prefix(self) -> None:
+        """The ``call:`` prefix is optional — some servers emit it, some
+        don't. Both must parse."""
+        assert _coerce_python_call_payload("list_orders(status='active')") == (
+            "list_orders",
+            {"status": "active"},
+        )
+
+    def test_multiple_kwargs_mixed_types(self) -> None:
+        name, args = _coerce_python_call_payload(
+            "call:search(query='foo', limit=5, strict=True, page=None)"
+        )
+        assert name == "search"
+        assert args == {"query": "foo", "limit": 5, "strict": True, "page": None}
+
+    def test_double_quoted_strings(self) -> None:
+        name, args = _coerce_python_call_payload('call:f(x="hello world")')
+        assert name == "f"
+        assert args == {"x": "hello world"}
+
+    def test_list_value(self) -> None:
+        name, args = _coerce_python_call_payload("call:f(ids=[1, 2, 3])")
+        assert name == "f"
+        assert args == {"ids": [1, 2, 3]}
+
+    def test_nested_dict_value(self) -> None:
+        name, args = _coerce_python_call_payload("call:f(cfg={'a': 1, 'b': [2, 3]})")
+        assert name == "f"
+        assert args == {"cfg": {"a": 1, "b": [2, 3]}}
+
+    def test_no_args(self) -> None:
+        assert _coerce_python_call_payload("call:ping()") == ("ping", {})
+
+    def test_positional_args_preserved_under_sentinel(self) -> None:
+        """Positional args are NOT promoted to kwargs (we don't know the
+        tool's signature here). They land under ``__positional__`` so
+        tool registries can log / warn about the unusable call."""
+        name, args = _coerce_python_call_payload("call:f('a', 42)")
+        assert name == "f"
+        assert args == {"__positional__": ["a", 42]}
+
+    def test_unquoted_bareword_stashed_as_source(self) -> None:
+        """A bareword identifier isn't a literal — ast.literal_eval would
+        reject it. We stash the source form so debugging is possible
+        instead of dropping the kwarg silently."""
+        name, args = _coerce_python_call_payload("call:f(mode=FAST)")
+        assert name == "f"
+        # The value stays as its source text so the tool registry sees
+        # *something* it can match or log.
+        assert args == {"mode": "FAST"}
+
+    def test_malformed_returns_none(self) -> None:
+        assert _coerce_python_call_payload("not a call") is None
+        assert _coerce_python_call_payload("call:") is None
+        assert _coerce_python_call_payload("call:f(unclosed") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _coerce_python_call_payload("") is None
+
+
+# ── Unit: the JSON path still works ──────────────────────────────────
+
+
+class TestJSONPathStillWorks:
+    """Don't regress PR #63's JSON cases."""
+
+    def test_name_arguments_shape(self) -> None:
+        out = _coerce_text_tool_call_payload(
+            '{"name": "list_orders", "arguments": {"status": "active"}}'
+        )
+        assert out == ("list_orders", {"status": "active"})
+
+    def test_nested_function_shape(self) -> None:
+        out = _coerce_text_tool_call_payload('{"function": {"name": "f", "arguments": {"x": 1}}}')
+        assert out == ("f", {"x": 1})
+
+
+# ── Unit: coercer dispatches JSON first, Python-call fallback ────────
+
+
+class TestCoercerDispatch:
+    def test_json_wins_when_valid(self) -> None:
+        """A payload that parses as JSON goes through the JSON shape,
+        not the Python-call regex."""
+        assert _coerce_text_tool_call_payload('{"name": "f", "arguments": {"x": 1}}') == (
+            "f",
+            {"x": 1},
+        )
+
+    def test_falls_back_to_python_call(self) -> None:
+        assert _coerce_text_tool_call_payload("call:f(x=1)") == ("f", {"x": 1})
+
+    def test_both_unparsable_returns_none(self) -> None:
+        assert _coerce_text_tool_call_payload("plain prose, no call here") is None
+
+
+# ── Integration: native-response plumbing with the production string ──
+
+
+def _fake_response(content: str, tool_calls=None) -> MagicMock:
+    msg = MagicMock()
+    msg.content = content
+    msg.tool_calls = tool_calls
+    choice = MagicMock()
+    choice.message = msg
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = None
+    return resp
+
+
+def _provider_with(client_mock: MagicMock) -> OpenAIProvider:
+    provider = OpenAIProvider(api_key="sk-test")
+    provider._client = client_mock
+    return provider
+
+
+class TestEndToEndNativeResponse:
+    def test_production_reproducer_through_native_response(self) -> None:
+        """The full path: server emits the production string in
+        ``message.content`` with empty structured ``tool_calls`` →
+        ``generate_native_response`` returns a NativeResponse carrying
+        four structured ToolCall objects + empty visible text."""
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(
+            return_value=_fake_response(
+                content=TestProductionReproducer.PRODUCTION_STRING,
+                tool_calls=None,
+            )
+        )
+        provider = _provider_with(client)
+
+        config = LLMConfig(model="gemma-4-26b", provider="openai")
+        resp = asyncio.run(provider.generate_native_response("hi", tools=None, config=config))
+
+        assert len(resp.tool_calls) == 4
+        assert all(c.tool_name == "list_orders" for c in resp.tool_calls)
+        assert resp.text_content == ""
+        # All four ToolCall ids unique so the agent loop can dispatch
+        # them as four independent worker-thread tasks.
+        ids = [c.tool_id for c in resp.tool_calls]
+        assert len(set(ids)) == 4


### PR DESCRIPTION
## Production report

v0.6.0 integrator reports that vLLM launched WITHOUT \`--tool-call-parser gemma4\` emits a form PR #63's salvage didn't match:

\`\`\`
<|tool_call>call:list_orders(status='odprto')<tool_call|>
<|tool_call>call:list_orders(status='poprokan')<tool_call|>
<|tool_call>call:list_orders(status='odprto')<tool_call|>
<|tool_call>call:list_orders(status='poprokan')<tool_call|>
\`\`\`

Four concatenated calls in one response. Gemma wedges in a retry loop when the SDK misses them.

## Two gaps fixed

### 1. Asymmetric markers

Open marker is \`<|tool_call>\` (pipe AFTER the \`<\`), close is \`<tool_call|>\` (pipe BEFORE the \`>\`). PR #63 only matched symmetric \`<|tool_call|>\` / \`<|tool_call|>\` pairs.

New asymmetric entry added as the FIRST marker pair so it wins when both could partially match.

### 2. Python-call payload

Block body is \`call:list_orders(status='active')\` — Python-style, not JSON. PR #63's coercer only handled JSON shapes.

New \`_coerce_python_call_payload\` using \`ast.parse\` + \`ast.literal_eval\`:
- Supports \`call:\`-prefixed and prefix-less forms
- Keyword args with literal values (ints, floats, bools, \`None\`, strings, lists, dicts)
- Empty arg lists
- Positional args land under a \`__positional__\` sentinel (not silently dropped)
- Malformed → \`None\` → block skipped

\`ast.literal_eval\` (not \`eval()\`) → no code-execution risk.

## Multiple-call salvage

Already worked in PR #63 — \`regex.finditer\` iterates all non-overlapping matches, unique \`tool_id\`s per match. Verified explicitly on the 4-call production reproducer: all four calls extracted, unique ids, correct order, empty residual text.

## Tests

23 cases in \`quartermaster-providers/tests/test_v061_gemma4_asymmetric_markers.py\`:
- Asymmetric markers: single + multi-call
- Production reproducer: four calls → four ToolCall, unique ids, preserved order, empty residual
- Python-call coercer shapes: kwargs, mixed types, quoting, lists, nested dicts, no-args, positional sentinel, bareword fallback, malformed, empty
- JSON path unchanged (regression guard)
- Coercer dispatch: JSON wins when valid, Python-call on fallback
- End-to-end through \`generate_native_response\`

**Provider suite: 283 → 306 passing.**

Ship as v0.6.1.