### PR TITLE
feat: hybrid streaming for AgentExecutor (v0.7.1)

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -771,8 +771,11 @@ class AgentExecutor(NodeExecutor):
 
         # Build the LLMConfig once: per-turn fields (system message, max
         # tokens, thinking budget, vision) don't change between iterations
-        # of the same node.  Streaming stays off so the agent can read the
-        # full ``NativeResponse`` (text + tool_calls + stop_reason) atomically.
+        # of the same node.  ``stream=False`` here means "don't return an
+        # AsyncIterator from generate_text_response" — the streaming
+        # tool-aware path below uses ``stream_native_response`` which
+        # internally drives a streaming SSE loop while still assembling
+        # tool_calls atomically.
         config = _build_llm_config(
             context,
             provider_name=provider_name,
@@ -781,11 +784,27 @@ class AgentExecutor(NodeExecutor):
             system_message=system_instruction,
         )
 
+        # v0.7.1: hybrid streaming. Visible-text deltas flow to
+        # ``context.emit_token`` as they arrive (so the chat UI sees a
+        # progressive response instead of one big chunk at end-of-turn);
+        # tool_calls accumulate silently and surface only on the final
+        # NativeResponse so the dispatch logic below stays atomic.
+        # Providers that don't override ``stream_native_response`` get the
+        # base-class shim that emits the full text in one go — matches
+        # the v0.7.0 behaviour for those providers exactly.
+        from quartermaster_providers.cancellation import set_cancel_check
+
         while requires_another_call and (max_iterations == 0 or iteration < max_iterations):
             iteration += 1
 
             try:
-                response = await provider.generate_native_response(prompt, tools, config)
+                with set_cancel_check(lambda: context.cancelled):
+                    response = await provider.stream_native_response(
+                        prompt,
+                        tools,
+                        config,
+                        on_token=context.emit_token,
+                    )
             except Exception as exc:
                 # Bubble the failure into FlowResult.error via the runner's
                 # NodeResult-failure path; keep the verbose detail in logs
@@ -802,8 +821,10 @@ class AgentExecutor(NodeExecutor):
             text_chunk = getattr(response, "text_content", "") or ""
             if text_chunk:
                 final_text = text_chunk
-                # Stream tokens to listeners so the chat UI sees progress.
-                context.emit_token(text_chunk)
+                # Token streaming already happened inside
+                # ``stream_native_response`` via the ``on_token``
+                # callback above — no need to re-emit the buffered text
+                # here (would double up the chat UI's transcript).
 
             tool_calls = list(getattr(response, "tool_calls", None) or [])
 

--- a/quartermaster-engine/tests/test_v071_agent_streaming.py
+++ b/quartermaster-engine/tests/test_v071_agent_streaming.py
@@ -1,0 +1,232 @@
+"""v0.7.1 — ``AgentExecutor`` uses ``stream_native_response`` so the
+chat UI gets incremental tokens instead of one big chunk per turn.
+
+Pre-v0.7.1 the agent loop called ``generate_native_response`` (non-
+streaming) so it could read tool_calls atomically — but that meant the
+entire visible-text reply landed as a single :class:`TokenGenerated`
+event after the model finished. Long answers showed up as a 5-second
+pause then a wall of text.
+
+v0.7.1 swaps to ``stream_native_response`` which threads visible-text
+chunks to ``context.emit_token`` as they arrive while still returning
+the full :class:`NativeResponse` for atomic tool dispatch. This test
+verifies the executor wiring: a streaming-aware provider must result in
+multiple ``TokenGenerated`` events per turn, and the tool-dispatch
+loop must continue working unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from quartermaster_providers import LLMConfig, ProviderRegistry
+from quartermaster_providers.base import AbstractLLMProvider
+from quartermaster_providers.types import NativeResponse, ToolCall
+
+from quartermaster_engine.context.execution_context import ExecutionContext
+from quartermaster_engine.example_runner import AgentExecutor
+from quartermaster_engine.types import GraphNode, GraphSpec, NodeType
+
+
+class _StreamingMockProvider(AbstractLLMProvider):
+    """MockProvider variant that overrides ``stream_native_response`` to
+    emit tokens in chunks — proves the AgentExecutor wires through the
+    callback rather than buffering."""
+
+    PROVIDER_NAME = "streaming_mock"
+
+    def __init__(
+        self,
+        text_chunks: list[str],
+        tool_calls: list[ToolCall] | None = None,
+        finish_reason: str = "stop",
+    ) -> None:
+        self.text_chunks = list(text_chunks)
+        self.tool_calls_to_return = list(tool_calls or [])
+        self.finish_reason = finish_reason
+        self.stream_call_count = 0
+        self.native_call_count = 0
+
+    async def list_models(self) -> list[str]:
+        return ["streaming-mock"]
+
+    def estimate_token_count(self, text: str, model: str) -> int:
+        return len(text)
+
+    def prepare_tool(self, tool: Any) -> Any:
+        return tool
+
+    async def generate_text_response(self, prompt: str, config: LLMConfig) -> Any:
+        raise NotImplementedError
+
+    async def generate_tool_parameters(
+        self, prompt: str, tools: list[Any], config: LLMConfig
+    ) -> Any:
+        raise NotImplementedError
+
+    async def generate_native_response(
+        self,
+        prompt: str,
+        tools: list[Any] | None = None,
+        config: LLMConfig | None = None,
+    ) -> NativeResponse:
+        # Tracked so the test can prove we DIDN'T fall back to non-streaming.
+        self.native_call_count += 1
+        return NativeResponse(
+            text_content="".join(self.text_chunks),
+            thinking=[],
+            tool_calls=self.tool_calls_to_return,
+            stop_reason=self.finish_reason,
+        )
+
+    async def stream_native_response(
+        self,
+        prompt: str,
+        tools: list[Any] | None = None,
+        config: LLMConfig | None = None,
+        on_token: Any = None,
+    ) -> NativeResponse:
+        self.stream_call_count += 1
+        for chunk in self.text_chunks:
+            if on_token is not None:
+                on_token(chunk)
+            await asyncio.sleep(0)  # yield so it actually behaves async-y
+        return NativeResponse(
+            text_content="".join(self.text_chunks),
+            thinking=[],
+            tool_calls=self.tool_calls_to_return,
+            stop_reason=self.finish_reason,
+        )
+
+    async def generate_structured_response(
+        self,
+        prompt: str,
+        response_schema: Any,
+        config: LLMConfig,
+    ) -> Any:
+        raise NotImplementedError
+
+    async def transcribe(self, audio_path: str) -> str:
+        raise NotImplementedError
+
+
+def _make_agent_ctx() -> tuple[ExecutionContext, list[str]]:
+    """Build an ExecutionContext and capture every ``emit_token`` call."""
+    captured: list[str] = []
+
+    node = GraphNode(
+        id=uuid4(),
+        type=NodeType.AGENT,
+        name="Agent",
+        metadata={"llm_provider": "streaming_mock", "llm_model": "streaming-mock"},
+    )
+    graph = GraphSpec(
+        id=uuid4(),
+        agent_id=uuid4(),
+        start_node_id=node.id,
+        nodes=[node],
+        edges=[],
+    )
+    ctx = ExecutionContext(
+        flow_id=uuid4(),
+        node_id=node.id,
+        graph=graph,
+        current_node=node,
+        messages=[],
+        memory={"__user_input__": "tell me a story"},
+        metadata={},
+    )
+
+    # Hook context.emit_token to capture the per-chunk events.
+    original = ctx.emit_token
+
+    def capture(text: str) -> None:
+        captured.append(text)
+        original(text)
+
+    ctx.emit_token = capture  # type: ignore[method-assign]
+    return ctx, captured
+
+
+def _registry_with(provider: AbstractLLMProvider) -> ProviderRegistry:
+    reg = ProviderRegistry()
+    reg.register_instance("streaming_mock", provider)
+    return reg
+
+
+class TestAgentStreamingTokens:
+    """Token chunks must reach ``context.emit_token`` one-per-chunk
+    rather than as one big buffered chunk at end of turn."""
+
+    def test_agent_emits_one_event_per_chunk(self) -> None:
+        provider = _StreamingMockProvider(
+            text_chunks=["Once ", "upon ", "a ", "time."],
+        )
+        ctx, captured = _make_agent_ctx()
+        executor = AgentExecutor(_registry_with(provider))
+
+        result = asyncio.run(executor.execute(ctx))
+
+        assert result.success, result.error
+        assert captured == ["Once ", "upon ", "a ", "time."], (
+            "AgentExecutor must forward each streamed chunk as its own "
+            "emit_token event so the chat UI animates incrementally."
+        )
+
+    def test_agent_does_not_double_emit_buffered_text(self) -> None:
+        """Regression guard — pre-v0.7.1 the executor used to call
+        ``emit_token(text)`` AFTER the call returned. Now token streaming
+        happens inside ``stream_native_response`` via on_token; the
+        post-call branch must NOT re-emit the buffered text."""
+        provider = _StreamingMockProvider(text_chunks=["hello", " ", "world"])
+        ctx, captured = _make_agent_ctx()
+        executor = AgentExecutor(_registry_with(provider))
+
+        asyncio.run(executor.execute(ctx))
+
+        # Three chunks went through, plus zero re-emits = three total.
+        assert len(captured) == 3
+        assert "".join(captured) == "hello world"
+
+    def test_agent_uses_stream_method_not_native(self) -> None:
+        """The executor must reach for ``stream_native_response``, not
+        ``generate_native_response`` — otherwise the chat UI loses
+        progressive feedback on every agent turn."""
+        provider = _StreamingMockProvider(text_chunks=["x", "y"])
+        ctx, _captured = _make_agent_ctx()
+        executor = AgentExecutor(_registry_with(provider))
+
+        asyncio.run(executor.execute(ctx))
+
+        assert provider.stream_call_count == 1
+        assert provider.native_call_count == 0
+
+
+class TestAgentStreamingPreservesToolDispatch:
+    """The whole point of streaming + atomic tool_calls is that tool
+    dispatch keeps working as before. A turn that emits tokens AND a
+    tool_call must still trigger tool execution, not be mistaken for a
+    finalised reply."""
+
+    def test_streamed_tokens_plus_tool_call_triggers_dispatch(self) -> None:
+        """First turn: tokens + a tool_call (model is narrating before
+        calling). With no tools wired up we treat that as final text per
+        the existing ``not tools → break`` rule, but token streaming
+        must have happened on the first turn."""
+        provider = _StreamingMockProvider(
+            text_chunks=["Looking ", "this ", "up..."],
+            tool_calls=[
+                ToolCall(tool_name="search", tool_id="call_0", parameters={"q": "x"}),
+            ],
+        )
+        ctx, captured = _make_agent_ctx()
+        executor = AgentExecutor(_registry_with(provider))
+
+        # No ``tools`` configured on the node — agent loop sees a
+        # tool_call request, can't dispatch, falls through with text.
+        asyncio.run(executor.execute(ctx))
+
+        # Tokens streamed despite the loop terminating early.
+        assert captured == ["Looking ", "this ", "up..."]

--- a/quartermaster-providers/src/quartermaster_providers/base.py
+++ b/quartermaster-providers/src/quartermaster_providers/base.py
@@ -5,15 +5,16 @@ from AbstractLLMProvider and implement its abstract methods.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, AsyncIterator, TypeVar
 
 from quartermaster_providers.config import LLMConfig
 from quartermaster_providers.types import (
     NativeResponse,
     StructuredResponse,
+    TokenResponse,
     ToolCallResponse,
     ToolDefinition,
-    TokenResponse,
 )
 
 T = TypeVar("T")
@@ -146,6 +147,47 @@ class AbstractLLMProvider(ABC):
             NativeResponse containing text, thinking, tool calls, usage.
         """
         ...
+
+    async def stream_native_response(
+        self,
+        prompt: str,
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+        on_token: Callable[[str], None] | None = None,
+    ) -> NativeResponse:
+        """Stream tokens to ``on_token`` while assembling tool_calls atomically.
+
+        The agent loop needs the full response (text + tool_calls + stop_reason)
+        as a unit so it can decide whether to dispatch tools or return; but it
+        also wants to surface visible-text deltas to the UI as they arrive
+        instead of dumping the whole reply at the end of the turn. This method
+        threads the needle: every visible-text chunk flows through ``on_token``
+        as soon as the network emits it, while ``tool_calls`` accumulate
+        silently and are returned in the final :class:`NativeResponse`.
+
+        The default implementation here is a no-op compatibility shim — it
+        delegates to :meth:`generate_native_response` and emits the whole
+        ``text_content`` to ``on_token`` after the response arrives. Real
+        streaming providers (currently :class:`OpenAIProvider`) override this
+        to wire up the SSE chunk loop with assembled-tool-call bookkeeping.
+
+        Args:
+            prompt: Input prompt.
+            tools: Optional list of available tools.
+            config: LLM configuration.
+            on_token: Callable invoked once per visible-text chunk. Tool-call
+                deltas are NOT delivered through this callback; they only
+                appear on the returned :class:`NativeResponse`.
+
+        Returns:
+            :class:`NativeResponse` with the complete text, tool_calls,
+            stop_reason, and usage — same shape as
+            :meth:`generate_native_response`.
+        """
+        response = await self.generate_native_response(prompt, tools, config)
+        if on_token is not None and response.text_content:
+            on_token(response.text_content)
+        return response
 
     @abstractmethod
     async def generate_structured_response(

--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, AsyncIterator, NoReturn, cast
 
@@ -25,11 +26,11 @@ from quartermaster_providers.exceptions import (
 from quartermaster_providers.types import (
     NativeResponse,
     StructuredResponse,
+    TokenResponse,
+    TokenUsage,
     ToolCall,
     ToolCallResponse,
     ToolDefinition,
-    TokenResponse,
-    TokenUsage,
 )
 
 logger = logging.getLogger(__name__)
@@ -841,6 +842,155 @@ class OpenAIProvider(AbstractLLMProvider):
             raise
         except Exception as e:
             self._handle_api_error(e)
+
+    async def stream_native_response(
+        self,
+        prompt: str,
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+        on_token: Callable[[str], None] | None = None,
+    ) -> NativeResponse:
+        """Streaming counterpart to :meth:`generate_native_response`.
+
+        Drives a ``chat.completions.create(stream=True, ...)`` loop and
+        delivers visible-text chunks to ``on_token`` as they arrive while
+        accumulating tool_calls (which split across deltas) into a unified
+        list returned in the final :class:`NativeResponse`. The agent loop
+        gets atomic tool dispatch AND incremental UI feedback.
+
+        Cancellation is honoured between chunks via the
+        :func:`should_cancel` contextvar — same mechanism as
+        :meth:`_stream_text` — so the engine's ``runner.stop(flow_id)``
+        closes the openai AsyncStream and stops vLLM mid-token.
+
+        Tool-call delta assembly:
+          OpenAI streams ``delta.tool_calls`` as a list of partial entries
+          keyed by ``index``. Each delta may contribute id, function.name,
+          or a fragment of function.arguments (typically split across many
+          chunks for large arg payloads). We accumulate per-index,
+          json.loads the assembled arguments at end-of-stream, and emit
+          structured :class:`ToolCall` objects.
+        """
+        from quartermaster_providers.cancellation import should_cancel
+
+        if config is None:
+            raise InvalidRequestError("config is required", provider=self.PROVIDER_NAME)
+
+        client = self._get_client()
+        messages = self._build_messages(prompt, config)
+        prepared_tools = [self.prepare_tool(t) for t in tools] if tools else None
+        params = self._build_params(config, messages, tools=prepared_tools)
+        # Force streaming — config.stream may be False when the agent
+        # executor calls us; this method is the streaming entrypoint
+        # regardless of the flag.
+        params["stream"] = True
+        params["stream_options"] = {"include_usage": True}
+
+        text_buf: list[str] = []
+        # index → {"id": str, "name": str, "args": list[str]}
+        partial_calls: dict[int, dict[str, Any]] = {}
+        finish_reason: str | None = None
+        usage_obj: TokenUsage | None = None
+
+        try:
+            stream = await client.chat.completions.create(**params)
+            try:
+                async for chunk in stream:
+                    # Usage chunk arrives last (when ``include_usage`` is on).
+                    if hasattr(chunk, "usage") and chunk.usage:
+                        usage_obj = TokenUsage(
+                            input_tokens=chunk.usage.prompt_tokens,
+                            output_tokens=chunk.usage.completion_tokens,
+                        )
+
+                    if not chunk.choices:
+                        continue
+                    choice = chunk.choices[0]
+                    delta = getattr(choice, "delta", None)
+                    if choice.finish_reason:
+                        finish_reason = choice.finish_reason
+
+                    if delta is None:
+                        continue
+
+                    # Visible text — flow to caller immediately.
+                    content_chunk = getattr(delta, "content", None) or ""
+                    if not content_chunk:
+                        # Reasoning-channel fallback for o-series / vLLM
+                        # reasoning models — surface as visible text so the
+                        # agent loop sees it.
+                        content_chunk = _extract_reasoning_text(delta)
+                    if content_chunk:
+                        text_buf.append(content_chunk)
+                        if on_token is not None:
+                            on_token(content_chunk)
+
+                    # Tool-call deltas — assemble per index.
+                    delta_tool_calls = getattr(delta, "tool_calls", None) or []
+                    for tc_delta in delta_tool_calls:
+                        idx = getattr(tc_delta, "index", 0) or 0
+                        slot = partial_calls.setdefault(idx, {"id": "", "name": "", "args": []})
+                        tc_id = getattr(tc_delta, "id", None)
+                        if tc_id:
+                            slot["id"] = tc_id
+                        fn = getattr(tc_delta, "function", None)
+                        if fn is not None:
+                            fn_name = getattr(fn, "name", None)
+                            if fn_name:
+                                slot["name"] = fn_name
+                            fn_args = getattr(fn, "arguments", None)
+                            if fn_args:
+                                slot["args"].append(fn_args)
+
+                    if should_cancel():
+                        await _aclose_stream(stream)
+                        finish_reason = "cancelled"
+                        break
+            finally:
+                await _aclose_stream(stream)
+        except (AuthenticationError, RateLimitError, ProviderError):
+            raise
+        except Exception as e:
+            self._handle_api_error(e)
+
+        # ── Post-stream assembly ──────────────────────────────────────
+        text_content = "".join(text_buf)
+        tool_calls: list[ToolCall] = []
+        for idx in sorted(partial_calls.keys()):
+            slot = partial_calls[idx]
+            args_str = "".join(slot["args"])
+            try:
+                parameters = json.loads(args_str) if args_str else {}
+            except json.JSONDecodeError:
+                # The delta concatenation can occasionally fail on
+                # mid-token splits — mirror generate_native_response's
+                # raw-fallback behaviour so the tool name + args still
+                # surface for ops to inspect rather than silently dropping.
+                parameters = {"raw": args_str}
+            tool_calls.append(
+                ToolCall(
+                    tool_name=slot["name"],
+                    tool_id=slot["id"],
+                    parameters=parameters,
+                )
+            )
+
+        # Text-form tool-call salvage — same path as generate_native_response.
+        # Only fires when the server didn't return any structured tool_calls
+        # AND the text contains literal ``<|tool_call|>`` markers.
+        if not tool_calls and text_content:
+            salvaged, residual = _parse_text_form_tool_calls(text_content)
+            if salvaged:
+                tool_calls = salvaged
+                text_content = residual
+
+        return NativeResponse(
+            text_content=text_content,
+            thinking=[],
+            tool_calls=tool_calls,
+            stop_reason=finish_reason,
+            usage=usage_obj,
+        )
 
     async def generate_structured_response(
         self,

--- a/quartermaster-providers/tests/test_v071_stream_native_response.py
+++ b/quartermaster-providers/tests/test_v071_stream_native_response.py
@@ -1,0 +1,325 @@
+"""v0.7.1 — ``stream_native_response`` on the OpenAI provider.
+
+The agent loop needs the full response (text + tool_calls) atomically to
+decide whether to dispatch tools or finalise. The pre-v0.7.1 path used
+``generate_native_response`` (non-streaming), which meant the entire
+visible-text reply landed as ONE big ``TokenGenerated`` event at end of
+turn — chat UIs saw a long pause then a wall of text instead of
+incremental tokens.
+
+``stream_native_response`` solves it: visible-text chunks flow to
+``on_token`` as they arrive, while tool_call deltas (which OpenAI splits
+across many chunks) accumulate per ``index`` and surface only on the
+returned :class:`NativeResponse`. The agent loop gets atomic dispatch
+AND the UI gets streaming tokens.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from quartermaster_providers.config import LLMConfig
+from quartermaster_providers.providers.openai import OpenAIProvider
+
+# ── Helpers: build fake openai SSE chunks ────────────────────────────
+
+
+def _content_delta(content: str, finish_reason: str | None = None) -> MagicMock:
+    """Build a chunk that carries a visible-text fragment."""
+    delta = MagicMock()
+    delta.content = content
+    delta.tool_calls = None
+    # Reasoning fields default to falsy; provider's _extract_reasoning_text
+    # returns "" so they don't accidentally double-fire.
+    delta.reasoning = ""
+    delta.reasoning_content = ""
+    choice = MagicMock()
+    choice.delta = delta
+    choice.finish_reason = finish_reason
+    chunk = MagicMock()
+    chunk.choices = [choice]
+    chunk.usage = None
+    return chunk
+
+
+def _tool_call_delta(
+    index: int,
+    *,
+    tc_id: str | None = None,
+    name: str | None = None,
+    args_fragment: str | None = None,
+    finish_reason: str | None = None,
+) -> MagicMock:
+    """Build a chunk that carries a partial tool_call delta."""
+    fn = MagicMock()
+    fn.name = name
+    fn.arguments = args_fragment
+    tc_delta = MagicMock()
+    tc_delta.index = index
+    tc_delta.id = tc_id
+    tc_delta.function = fn
+    delta = MagicMock()
+    delta.content = ""
+    delta.tool_calls = [tc_delta]
+    delta.reasoning = ""
+    delta.reasoning_content = ""
+    choice = MagicMock()
+    choice.delta = delta
+    choice.finish_reason = finish_reason
+    chunk = MagicMock()
+    chunk.choices = [choice]
+    chunk.usage = None
+    return chunk
+
+
+def _usage_chunk(input_tokens: int, output_tokens: int) -> MagicMock:
+    chunk = MagicMock()
+    chunk.choices = []
+    usage = MagicMock()
+    usage.prompt_tokens = input_tokens
+    usage.completion_tokens = output_tokens
+    chunk.usage = usage
+    return chunk
+
+
+class _AsyncIter:
+    """Minimal async-iterator over a fixed list of chunks. Exposes
+    ``aclose`` so the provider's ``_aclose_stream`` no-op cleanup runs
+    without warnings."""
+
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = list(chunks)
+
+    def __aiter__(self) -> "_AsyncIter":
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _provider_with_chunks(chunks: list[Any]) -> tuple[OpenAIProvider, MagicMock]:
+    provider = OpenAIProvider(api_key="sk-test")
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=_AsyncIter(chunks))
+    provider._client = client
+    return provider, client
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestVisibleTextStreaming:
+    """Visible-text deltas must reach ``on_token`` in order, and the
+    final ``NativeResponse.text_content`` must be the full concatenation."""
+
+    def test_text_chunks_flow_to_on_token_in_order(self) -> None:
+        chunks = [
+            _content_delta("Hello"),
+            _content_delta(", "),
+            _content_delta("world"),
+            _content_delta("!", finish_reason="stop"),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        seen: list[str] = []
+        result = asyncio.run(
+            provider.stream_native_response("hi", tools=None, config=config, on_token=seen.append)
+        )
+
+        assert seen == ["Hello", ", ", "world", "!"]
+        assert result.text_content == "Hello, world!"
+        assert result.stop_reason == "stop"
+        assert result.tool_calls == []
+
+    def test_streaming_request_has_stream_true(self) -> None:
+        """The provider must force ``stream=True`` regardless of
+        ``config.stream`` (which the agent executor leaves False)."""
+        chunks = [_content_delta("x", finish_reason="stop")]
+        provider, client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai", stream=False)
+
+        asyncio.run(provider.stream_native_response("hi", None, config, on_token=None))
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["stream"] is True
+        assert kwargs.get("stream_options") == {"include_usage": True}
+
+    def test_on_token_optional(self) -> None:
+        """``on_token=None`` must still produce a valid response — the
+        executor falls back to this path when nothing wants the
+        stream."""
+        chunks = [
+            _content_delta("ok"),
+            _content_delta(".", finish_reason="stop"),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        result = asyncio.run(provider.stream_native_response("hi", None, config, on_token=None))
+
+        assert result.text_content == "ok."
+
+
+class TestToolCallAssembly:
+    """OpenAI splits large ``arguments`` strings across many deltas. We
+    accumulate per-``index`` and ``json.loads`` once at end-of-stream."""
+
+    def test_single_tool_call_assembled_from_many_arg_fragments(self) -> None:
+        chunks = [
+            _tool_call_delta(0, tc_id="call_abc", name="get_weather"),
+            _tool_call_delta(0, args_fragment='{"city"'),
+            _tool_call_delta(0, args_fragment=': "Zagreb"'),
+            _tool_call_delta(0, args_fragment=', "units": "C"}'),
+            _content_delta("", finish_reason="tool_calls"),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        result = asyncio.run(provider.stream_native_response("hi", tools=None, config=config))
+
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc.tool_id == "call_abc"
+        assert tc.tool_name == "get_weather"
+        assert tc.parameters == {"city": "Zagreb", "units": "C"}
+
+    def test_multiple_tool_calls_kept_separate_by_index(self) -> None:
+        """Two parallel tool calls in one turn — assembled independently
+        even though their deltas interleave."""
+        chunks = [
+            _tool_call_delta(0, tc_id="call_a", name="search"),
+            _tool_call_delta(1, tc_id="call_b", name="fetch"),
+            _tool_call_delta(0, args_fragment='{"q": "abc"}'),
+            _tool_call_delta(1, args_fragment='{"url"'),
+            _tool_call_delta(1, args_fragment=': "x"}'),
+            _content_delta("", finish_reason="tool_calls"),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        result = asyncio.run(provider.stream_native_response("hi", None, config))
+
+        assert [tc.tool_name for tc in result.tool_calls] == ["search", "fetch"]
+        assert [tc.parameters for tc in result.tool_calls] == [
+            {"q": "abc"},
+            {"url": "x"},
+        ]
+
+    def test_text_and_tool_call_in_same_response(self) -> None:
+        """Text deltas and tool_call deltas can be interleaved — both
+        surface correctly in the final response."""
+        chunks = [
+            _content_delta("Calling search"),
+            _tool_call_delta(0, tc_id="call_x", name="search"),
+            _tool_call_delta(0, args_fragment='{"q":"foo"}'),
+            _content_delta("", finish_reason="tool_calls"),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        seen: list[str] = []
+        result = asyncio.run(
+            provider.stream_native_response("hi", None, config, on_token=seen.append)
+        )
+
+        assert seen == ["Calling search"]
+        assert result.text_content == "Calling search"
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].parameters == {"q": "foo"}
+
+    def test_malformed_arguments_stashed_under_raw(self) -> None:
+        """If the assembled ``arguments`` string isn't valid JSON, we
+        stash it under ``parameters["raw"]`` instead of dropping the
+        tool call silently — matches generate_native_response's
+        behaviour."""
+        chunks = [
+            _tool_call_delta(0, tc_id="call_x", name="bad", args_fragment="{not json"),
+            _content_delta("", finish_reason="tool_calls"),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        result = asyncio.run(provider.stream_native_response("hi", None, config))
+
+        assert result.tool_calls[0].parameters == {"raw": "{not json"}
+
+
+class TestUsageCapture:
+    def test_usage_chunk_populates_response(self) -> None:
+        """The trailing ``include_usage`` chunk arrives after content;
+        we capture it onto the final NativeResponse."""
+        chunks = [
+            _content_delta("hi", finish_reason="stop"),
+            _usage_chunk(input_tokens=42, output_tokens=7),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        result = asyncio.run(provider.stream_native_response("hi", None, config))
+
+        assert result.usage is not None
+        assert result.usage.input_tokens == 42
+        assert result.usage.output_tokens == 7
+
+
+class TestTextFormToolCallSalvage:
+    """When a mis-configured vLLM / Ollama emits ``<|tool_call|>``
+    markers in plain text instead of structured tool_calls, we still
+    recover them post-stream — same salvage path as
+    ``generate_native_response``."""
+
+    def test_text_form_block_promoted_to_tool_calls(self) -> None:
+        chunks = [
+            _content_delta('<|tool_call|>{"name": "ping", "arguments": {}}<|tool_call|>'),
+            _content_delta("", finish_reason="stop"),
+        ]
+        provider, _client = _provider_with_chunks(chunks)
+        config = LLMConfig(model="gpt-4o", provider="openai")
+
+        result = asyncio.run(provider.stream_native_response("hi", None, config))
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].tool_name == "ping"
+        # Text content is the residual after the markers are stripped.
+        assert "<|tool_call|>" not in result.text_content
+
+
+class TestDefaultBaseImplementation:
+    """``AbstractLLMProvider.stream_native_response`` provides a
+    no-op streaming shim — it just delegates to
+    ``generate_native_response`` and emits the whole text at the end.
+    Used by every provider that hasn't been migrated yet."""
+
+    def test_base_impl_emits_full_text_via_on_token(self) -> None:
+        from quartermaster_providers.testing import MockProvider
+        from quartermaster_providers.types import NativeResponse, ToolCall
+
+        mock = MockProvider(
+            native_responses=[
+                NativeResponse(
+                    text_content="hello world",
+                    thinking=[],
+                    tool_calls=[ToolCall(tool_name="t", tool_id="x", parameters={"a": 1})],
+                    stop_reason="stop",
+                )
+            ]
+        )
+        config = LLMConfig(model="m", provider="mock")
+
+        seen: list[str] = []
+        result = asyncio.run(mock.stream_native_response("hi", None, config, on_token=seen.append))
+
+        # Base shim emits the full text exactly once — UI experience
+        # matches the pre-v0.7.1 behaviour for providers that haven't
+        # overridden the streaming path.
+        assert seen == ["hello world"]
+        assert result.text_content == "hello world"
+        assert len(result.tool_calls) == 1


### PR DESCRIPTION
## Problem

The agent loop used `generate_native_response` so it could read `tool_calls` atomically before deciding whether to dispatch tools or finalise. The cost: the entire visible-text reply landed as a **single** `TokenGenerated` event at end-of-turn. Long replies showed up as a 5-second pause then a wall of text instead of incremental tokens — UX regression vs the simple `instruction` / `agent`-no-tool path which already streams.

## Fix — hybrid streaming

Visible-text deltas flow through an `on_token` callback as they arrive; tool_call deltas accumulate per-index and surface only on the final `NativeResponse`. Atomic tool dispatch AND streaming UI feedback in the same call.

### `quartermaster-providers`

- New `AbstractLLMProvider.stream_native_response(prompt, tools, config, on_token=None) -> NativeResponse`. Default base impl delegates to `generate_native_response` and emits the full text once at the end — preserves pre-v0.7.1 behaviour for providers that haven't been migrated (Anthropic / Google / Groq / xAI).
- `OpenAIProvider` overrides with a real streaming impl: opens `chat.completions.create(stream=True)`, forwards `delta.content` to `on_token`, accumulates `delta.tool_calls` per index, `json.loads` the assembled `function.arguments` at end-of-stream. Cancellation polls `should_cancel()` between chunks and closes the AsyncStream just like `_stream_text`. Text-form tool-call salvage (v0.6.0/v0.6.1) runs post-stream so vLLM/Ollama without `--tool-call-parser` still works.

### `quartermaster-engine`

- `AgentExecutor` calls `stream_native_response(on_token=context.emit_token)`. The cancellation contextvar is wrapped via `set_cancel_check(lambda: context.cancelled)` so SSE-disconnect / `qm.Cancelled` close the stream mid-token.
- Tool dispatch logic and iteration bookkeeping unchanged.

## Test plan

- [x] 10 provider unit tests: token order, `stream=True` forced regardless of `config.stream`, `on_token=None` tolerated, single + multi-index tool_call assembly, text+tool interleaving, malformed args stashed under `parameters["raw"]`, usage capture from `include_usage` chunk, text-form salvage, base-impl shim emits full text once.
- [x] 4 engine integration tests: one event per chunk, no double-emit, executor calls `stream_native_response` not `generate_native_response`, tool-dispatch preserved when streamed response also has a tool_call.
- [x] Engine suite: 518 → 522 (+4). Providers: 299 → 309 (+10). No regressions.
- [x] `ruff format` + `ruff check` clean on changed files.

## Backward compatibility

- Providers that don't override `stream_native_response` get the base shim — exact same behaviour as v0.7.0.
- Same `NativeResponse` shape returned, same `response.tool_calls` list — agent dispatch unchanged.
- No public API breaks.

## Ships as

v0.7.1 — patch bump. Internal mechanism change with measurable UX win, no API surface additions visible to graph DSL callers.