### PR TITLE
feat: proper multi-turn history through every graph node (v0.8.0)

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/example_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/example_runner.py
@@ -150,36 +150,127 @@ def _get_conversation(context: ExecutionContext) -> list[dict]:
 
 def _append_to_conversation(
     conversation: list[dict],
-    role: str,
+    node_name: str,
     text: str,
     round_num: Any = None,
+    role: str = "assistant",
 ) -> list[dict]:
-    """Append an entry to conversation history."""
+    """Append an entry to ``__conversation__``.
+
+    v0.8.0 entry shape:
+      ``{"role": "user"|"assistant"|"system", "content": str, "node_name": str | None, "round": int | None}``
+
+    *node_name* identifies which node produced the entry — used by
+    :func:`_build_history_for_node` to translate "my own past turn"
+    (``role=assistant``) vs "another node's output" (``role=user`` from
+    the consuming node's perspective).
+
+    For pure user turns coming from the human (CLI / SDK
+    ``history=`` seed), pass ``role="user"`` and ``node_name=""``.
+    For node outputs, callers pass the node's name and the default
+    ``role="assistant"`` applies.
+
+    The legacy v0.7.x shape ``{"role": <node_name>, "text": str}`` is
+    read-tolerated by :func:`_build_history_for_node` but never produced
+    by this helper.
+    """
     if not text or not text.strip():
         return conversation
-    entry = {"role": role, "text": text}
+    entry: dict[str, Any] = {
+        "role": role,
+        "content": text,
+        "node_name": node_name or None,
+    }
     if round_num is not None:
         entry["round"] = round_num
     conversation.append(entry)
     return conversation
 
 
-def _format_conversation(conversation: list[dict], user_input: str) -> str:
-    """Format conversation history as a prompt string."""
-    if not conversation:
-        return user_input
+def _build_history_for_node(
+    conversation: list[dict],
+    current_node_name: str | None,
+    *,
+    drop_trailing_user_match: str | None = None,
+) -> list[dict]:
+    """Translate ``__conversation__`` into a provider-ready history list.
 
-    parts = []
-    current_round = None
+    v0.8.0 fix: previously every entry got mashed into a single
+    ``[NodeName]: text`` blob inside one ``role="user"`` message —
+    multi-node graphs (User → Agent → InstructionForm, or
+    Agent1 → Agent2) collapsed into a wire format where the LLM
+    couldn't tell upstream-node output from its own past turn.
+
+    Translation rules per entry, in priority order:
+
+    1. **Legacy shape** (``{"role": "<NodeName>", "text": ...}``, no
+       ``content`` key) — translate as if ``node_name=role``,
+       ``content=text``. Pre-v0.8.0 conversations stay readable so
+       in-flight flows don't break across upgrade.
+    2. **User-supplied turns** (``node_name`` is ``None``) — pass
+       through with the entry's stored ``role`` ("user" / "assistant" /
+       "system"). These come from the SDK runner's ``history=`` kwarg
+       and represent prior chat turns the caller is replaying.
+    3. **Same-node entries** (``node_name == current_node_name``) —
+       role becomes ``"assistant"`` regardless of stored value. Multi-
+       turn within a single node (Sora chat across iterations) stays
+       coherent.
+    4. **Other-node entries** (``node_name != current_node_name`` and
+       not ``None``) — role becomes ``"user"``. From the current node's
+       perspective, an upstream node's output is *input it must act on*,
+       not its own past speech.
+
+    No prefix injection: the OpenAI role markers carry the semantics
+    on their own. Adding ``[Agent1]:`` to the content would burn
+    tokens, leak graph internals into the model's view, and tempt
+    output mimicry — see the audit notes that motivated this change.
+    """
+    history: list[dict] = []
     for entry in conversation:
-        r = entry.get("round")
-        if r is not None and r != current_round:
-            current_round = r
-            parts.append(f"--- Round {r} ---")
-        parts.append(f"[{entry['role']}]: {entry['text']}")
+        if not isinstance(entry, dict):
+            continue
+        # Legacy v0.7.x shape — text key, role=node_name.
+        if "content" not in entry and "text" in entry:
+            stored_role = entry.get("role")
+            text = entry.get("text") or ""
+            if not text:
+                continue
+            if isinstance(stored_role, str) and stored_role == current_node_name:
+                role = "assistant"
+            else:
+                role = "user"
+            history.append({"role": role, "content": text})
+            continue
 
-    history = "\n\n".join(parts)
-    return f"{history}\n\n---\nOriginal case: {user_input}"
+        content = entry.get("content")
+        if not isinstance(content, str) or not content:
+            continue
+        node_name = entry.get("node_name")
+        stored_role = entry.get("role")
+
+        if node_name is None:
+            # User-supplied turn — preserve the role the caller stored.
+            role = stored_role if stored_role in ("user", "assistant", "system") else "user"
+        elif current_node_name is not None and node_name == current_node_name:
+            role = "assistant"
+        else:
+            role = "user"
+        history.append({"role": role, "content": content})
+
+    # ``drop_trailing_user_match`` exists because ``FlowRunner`` appends
+    # User/UserForm output to ``__conversation__`` so ``.back()`` loops
+    # remember user turns. Without this guard, the trailing user turn
+    # would appear BOTH in ``history`` (from the conversation log) AND
+    # as the provider's trailing user message (built from ``prompt``).
+    # Strip the duplicate so the wire format has the user input once.
+    if (
+        drop_trailing_user_match is not None
+        and history
+        and history[-1].get("role") == "user"
+        and history[-1].get("content") == drop_trailing_user_match
+    ):
+        history = history[:-1]
+    return history
 
 
 # ---------------------------------------------------------------------------
@@ -379,10 +470,18 @@ class LLMExecutor(NodeExecutor):
                 ),
             )
 
-        # Build prompt from conversation history + original user input
+        # v0.8.0: build proper multi-turn history for the provider
+        # instead of squashing the conversation into a single user
+        # message. ``prompt`` carries only the trailing user turn;
+        # ``history`` carries each prior turn as its own ``role``-tagged
+        # message (translated based on whether it came from this node).
         conversation = _get_conversation(context)
         user_input = str(context.memory.get("__user_input__", "Hello"))
-        prompt = _format_conversation(conversation, user_input)
+        prompt = user_input
+        node_name = context.current_node.name if context.current_node else "Assistant"
+        history = _build_history_for_node(
+            conversation, node_name, drop_trailing_user_match=user_input
+        )
 
         config = _build_llm_config(
             context,
@@ -402,7 +501,7 @@ class LLMExecutor(NodeExecutor):
             # the openai AsyncStream → httpx response, so vLLM / Ollama
             # stop generating mid-token instead of draining to completion.
             with set_cancel_check(lambda: context.cancelled):
-                stream = await provider.generate_text_response(prompt, config)
+                stream = await provider.generate_text_response(prompt, config, history=history)
                 chunks = []
                 async for token_response in stream:
                     if token_response.stop_reason == "cancelled":
@@ -412,8 +511,8 @@ class LLMExecutor(NodeExecutor):
                         context.emit_token(token_response.content)
             text = "".join(chunks)
 
-            # Append to conversation history
-            node_name = context.current_node.name if context.current_node else "Assistant"
+            # Append to conversation history (v0.8.0: stores
+            # role="assistant" with node_name=current node).
             round_num = context.memory.get("round_number")
             _append_to_conversation(conversation, node_name, text, round_num)
             return NodeResult(
@@ -750,11 +849,27 @@ class AgentExecutor(NodeExecutor):
         if max_iterations < 0:
             max_iterations = self.DEFAULT_MAX_ITERATIONS
 
+        # v0.8.0: prior conversation flows into the provider as a
+        # proper multi-turn ``history`` list (each entry its own
+        # role-tagged message), not as a squashed user blob. The agent
+        # loop's iteration-internal "tool log" appends after the user
+        # input within ``prompt`` — same shape the model has always
+        # seen for the trailing turn.
         conversation = _get_conversation(context)
         user_input = str(context.memory.get("__user_input__", ""))
-        base_prompt = _format_conversation(conversation, user_input)
+        node_name_for_history = context.current_node.name if context.current_node else "Agent"
+        history = _build_history_for_node(
+            conversation, node_name_for_history, drop_trailing_user_match=user_input
+        )
 
         # ── agent loop ────────────────────────────────────────────────
+        # ``base_prompt`` is the seed user-message text — kept as an
+        # invariant across iterations so the sliding-window truncation
+        # has a stable reference and so each iteration's
+        # ``<tool_execution_log>`` block is prepended to the SAME
+        # original user message rather than to the previous iteration's
+        # already-augmented prompt (which would duplicate the log).
+        base_prompt = user_input
         prompt = base_prompt
         final_text = ""
         accumulated_tool_log: list[str] = []
@@ -804,6 +919,7 @@ class AgentExecutor(NodeExecutor):
                         tools,
                         config,
                         on_token=context.emit_token,
+                        history=history,
                     )
             except Exception as exc:
                 # Bubble the failure into FlowResult.error via the runner's
@@ -1089,10 +1205,15 @@ class DecisionExecutor(NodeExecutor):
             picked = options[0] if options else ""
             return NodeResult(success=True, data={}, output_text="", picked_node=picked)
 
-        # Build prompt from conversation history
+        # v0.8.0: prior conversation flows in as proper multi-turn
+        # history; the prompt carries only the current user turn.
         conversation = _get_conversation(context)
         user_input = str(context.memory.get("__user_input__", "Choose"))
-        prompt = _format_conversation(conversation, user_input)
+        prompt = user_input
+        node_name_for_history = context.current_node.name if context.current_node else "Decision"
+        history = _build_history_for_node(
+            conversation, node_name_for_history, drop_trailing_user_match=user_input
+        )
 
         # Decision nodes pin temperature=0 for determinism regardless of
         # what the per-node ``llm_temperature`` says.  Use the helper's
@@ -1141,7 +1262,9 @@ class DecisionExecutor(NodeExecutor):
 
         try:
             if forced_tool:
-                native = await provider.generate_native_response(prompt, [forced_tool], config)
+                native = await provider.generate_native_response(
+                    prompt, [forced_tool], config, history=history
+                )
                 tool_calls = getattr(native, "tool_calls", None) or []
                 if tool_calls:
                     params = getattr(tool_calls[0], "parameters", None)
@@ -1157,7 +1280,7 @@ class DecisionExecutor(NodeExecutor):
 
                 picked = (getattr(native, "text_content", "") or "").strip()
             else:
-                response = await provider.generate_text_response(prompt, config)
+                response = await provider.generate_text_response(prompt, config, history=history)
                 picked = response.content.strip()
             # Fuzzy-match fallback for the free-form path (or for
             # providers that didn't honour the forced tool-call).
@@ -1498,15 +1621,26 @@ class InstructionFormExecutor(NodeExecutor):
             except (json.JSONDecodeError, ValueError, TypeError):
                 forced_tool = None
 
+        # v0.8.0: prior conversation flows in as proper multi-turn
+        # history; the prompt carries only the current user turn so the
+        # forced tool call sees the schema-extraction request as a
+        # clean ``role="user"`` message.
         conversation = _get_conversation(context)
         user_input = str(context.memory.get("__user_input__", ""))
-        prompt = _format_conversation(conversation, user_input)
+        prompt = user_input
+        node_name_for_history = (
+            context.current_node.name if context.current_node else "InstructionForm"
+        )
+        history = _build_history_for_node(
+            conversation, node_name_for_history, drop_trailing_user_match=user_input
+        )
 
         try:
             response = await provider.generate_native_response(
                 prompt,
                 [forced_tool] if forced_tool else None,
                 config,
+                history=history,
             )
         except Exception as exc:
             return NodeResult(success=False, data={}, error=str(exc))
@@ -2072,7 +2206,7 @@ def run_graph(
 
         # Append to conversation so LLM nodes see it
         conversation = list(store.get_all_memory(result.flow_id).get("__conversation__", []))
-        _append_to_conversation(conversation, "User", user_text)
+        _append_to_conversation(conversation, "", user_text, role="user")
         store.save_memory(result.flow_id, "__conversation__", conversation)
         store.save_memory(result.flow_id, "__user_input__", user_text)
 

--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -539,10 +539,10 @@ class FlowRunner:
         # lose user turns: the LLM sees its own prior replies but not
         # what the user said.
         #
-        # This block fills that gap: when a User or UserForm node
-        # finishes with output, append a ``{role: "User", text: ...}``
-        # entry to ``__conversation__`` so subsequent LLM nodes see the
-        # full multi-turn history.
+        # This block fills that gap: v0.8.0 stores entries in the new
+        # shape (``role="user"``, ``node_name=None`` so the
+        # ``_build_history_for_node`` translator preserves the user role
+        # regardless of which downstream node consumes it).
         #
         # We also update ``__user_input__`` so downstream nodes in this
         # iteration see the CURRENT turn's input, not the stale initial
@@ -554,7 +554,13 @@ class FlowRunner:
             and node.type in (NodeType.USER, NodeType.USER_FORM)
         ):
             conversation = list(self.store.get_memory(flow_id, "__conversation__") or [])
-            conversation.append({"role": "User", "text": result.output_text})
+            conversation.append(
+                {
+                    "role": "user",
+                    "content": result.output_text,
+                    "node_name": None,
+                }
+            )
             self.store.save_memory(flow_id, "__conversation__", conversation)
             self.store.save_memory(flow_id, "__user_input__", result.output_text)
 

--- a/quartermaster-engine/tests/test_example_runner.py
+++ b/quartermaster-engine/tests/test_example_runner.py
@@ -20,7 +20,7 @@ from quartermaster_engine.example_runner import (
     UserFormExecutor,
     VarExecutor,
     _append_to_conversation,
-    _format_conversation,
+    _build_history_for_node,
     _get_conversation,
 )
 from quartermaster_engine.nodes import NodeResult
@@ -182,250 +182,215 @@ class TestGetConversation:
 
 
 class TestAppendToConversation:
-    """Tests for _append_to_conversation helper."""
+    """v0.8.0 entry shape: ``{"role", "content", "node_name", "round"}``.
 
-    def test_appends_entry_with_role_and_text(self):
+    The ``role`` is now a wire-format role ("user"/"assistant"/"system");
+    the node identity moved to ``node_name``. Default role is
+    ``"assistant"`` because by far the most common caller is a node
+    appending its own output."""
+
+    def test_default_role_is_assistant(self):
         conv: list[dict] = []
-        _append_to_conversation(conv, "user", "hello")
+        _append_to_conversation(conv, "Researcher", "hello")
         assert len(conv) == 1
-        assert conv[0] == {"role": "user", "text": "hello"}
+        assert conv[0]["role"] == "assistant"
+        assert conv[0]["content"] == "hello"
+        assert conv[0]["node_name"] == "Researcher"
+
+    def test_explicit_user_role_for_user_turn(self):
+        """The CLI/SDK history seed path passes ``role='user'`` and an
+        empty node_name to mark a turn that came from the human."""
+        conv: list[dict] = []
+        _append_to_conversation(conv, "", "what's up?", role="user")
+        assert conv[0]["role"] == "user"
+        assert conv[0]["content"] == "what's up?"
+        assert conv[0]["node_name"] is None
 
     def test_includes_round_num_when_provided(self):
         conv: list[dict] = []
-        _append_to_conversation(conv, "assistant", "hi", round_num=3)
+        _append_to_conversation(conv, "Agent", "hi", round_num=3)
         assert conv[0]["round"] == 3
 
     def test_skips_empty_text(self):
         conv: list[dict] = []
-        result = _append_to_conversation(conv, "user", "")
+        result = _append_to_conversation(conv, "Agent", "")
         assert len(conv) == 0
         assert result is conv
 
     def test_skips_whitespace_only_text(self):
         conv: list[dict] = []
-        _append_to_conversation(conv, "user", "   \t\n  ")
+        _append_to_conversation(conv, "Agent", "   \t\n  ")
         assert len(conv) == 0
 
     def test_none_round_num_not_included(self):
         conv: list[dict] = []
-        _append_to_conversation(conv, "user", "hello", round_num=None)
+        _append_to_conversation(conv, "Agent", "hello", round_num=None)
         assert "round" not in conv[0]
 
     def test_zero_round_num_is_included(self):
         conv: list[dict] = []
-        _append_to_conversation(conv, "user", "hello", round_num=0)
+        _append_to_conversation(conv, "Agent", "hello", round_num=0)
         assert conv[0]["round"] == 0
-
-    def test_returns_same_list_mutated(self):
-        conv: list[dict] = []
-        result = _append_to_conversation(conv, "user", "hi")
-        assert result is conv
 
     def test_multiple_appends_accumulate(self):
         conv: list[dict] = []
-        _append_to_conversation(conv, "user", "first")
-        _append_to_conversation(conv, "assistant", "second")
-        _append_to_conversation(conv, "user", "third")
+        _append_to_conversation(conv, "Researcher", "first")
+        _append_to_conversation(conv, "Summariser", "second")
+        _append_to_conversation(conv, "Reviewer", "third")
         assert len(conv) == 3
-        assert conv[0]["text"] == "first"
-        assert conv[1]["text"] == "second"
-        assert conv[2]["text"] == "third"
+        assert [e["content"] for e in conv] == ["first", "second", "third"]
+        assert [e["node_name"] for e in conv] == ["Researcher", "Summariser", "Reviewer"]
 
-    def test_unicode_text(self):
+    def test_unicode_content(self):
         conv: list[dict] = []
-        _append_to_conversation(conv, "user", "Привет мир 🌍")
-        assert conv[0]["text"] == "Привет мир 🌍"
-
-    def test_very_long_text(self):
-        conv: list[dict] = []
-        long_text = "x" * 100_000
-        _append_to_conversation(conv, "user", long_text)
-        assert len(conv[0]["text"]) == 100_000
-
-    def test_text_with_newlines(self):
-        conv: list[dict] = []
-        _append_to_conversation(conv, "user", "line1\nline2\nline3")
-        assert conv[0]["text"] == "line1\nline2\nline3"
-
-    def test_round_num_negative(self):
-        conv: list[dict] = []
-        _append_to_conversation(conv, "user", "hello", round_num=-1)
-        assert conv[0]["round"] == -1
-
-    def test_round_num_large_int(self):
-        conv: list[dict] = []
-        _append_to_conversation(conv, "user", "hello", round_num=999999)
-        assert conv[0]["round"] == 999999
-
-    def test_role_can_be_any_string(self):
-        conv: list[dict] = []
-        _append_to_conversation(conv, "CustomAgent", "hello")
-        assert conv[0]["role"] == "CustomAgent"
-
-    def test_does_not_append_for_only_spaces(self):
-        conv: list[dict] = []
-        _append_to_conversation(conv, "user", "     ")
-        assert len(conv) == 0
+        _append_to_conversation(conv, "Agent", "Привет мир 🌍")
+        assert conv[0]["content"] == "Привет мир 🌍"
 
 
 # ===================================================================
-# 3. _format_conversation tests
+# 3. _build_history_for_node tests (v0.8.0)
 # ===================================================================
 
 
-class TestFormatConversation:
-    """Tests for _format_conversation helper."""
+class TestBuildHistoryForNode:
+    """v0.8.0 role-translation contract.
 
-    def test_empty_conversation_returns_user_input(self):
-        result = _format_conversation([], "hello")
-        assert result == "hello"
+    ``__conversation__`` entries get translated to OpenAI-format
+    messages based on ``node_name`` vs the consuming node:
 
-    def test_single_entry_formatted_correctly(self):
-        conv = [{"role": "user", "text": "hi"}]
-        result = _format_conversation(conv, "original")
-        assert "[user]: hi" in result
-        assert "Original case: original" in result
+    - Same node → ``role="assistant"`` (my own past turn).
+    - Different node → ``role="user"`` (input from upstream).
+    - ``node_name=None`` → preserve stored role (user-supplied seed).
+    - Legacy v0.7.x ``{"role": <NodeName>, "text": ...}`` → translate
+      ``role==current_node_name`` ⇒ assistant, else user.
+    """
 
-    def test_multiple_entries_same_round(self):
+    def test_empty_conversation_returns_empty_history(self):
+        assert _build_history_for_node([], "Agent") == []
+
+    def test_same_node_entries_become_assistant(self):
         conv = [
-            {"role": "user", "text": "hi", "round": 1},
-            {"role": "assistant", "text": "hello", "round": 1},
+            {"role": "assistant", "content": "previous turn", "node_name": "Agent"},
         ]
-        result = _format_conversation(conv, "q")
-        # Round marker should appear once
-        assert result.count("--- Round 1 ---") == 1
+        history = _build_history_for_node(conv, "Agent")
+        assert history == [{"role": "assistant", "content": "previous turn"}]
 
-    def test_round_markers_appear_when_round_changes(self):
+    def test_other_node_output_becomes_user(self):
+        """The whole point of v0.8.0: Agent2 sees Agent1's output as
+        ``role="user"`` (input it must act on), not as ``"assistant"``."""
         conv = [
-            {"role": "user", "text": "a", "round": 1},
-            {"role": "user", "text": "b", "round": 2},
+            {"role": "assistant", "content": "research notes", "node_name": "Agent1"},
         ]
-        result = _format_conversation(conv, "q")
-        assert "--- Round 1 ---" in result
-        assert "--- Round 2 ---" in result
+        history = _build_history_for_node(conv, "Agent2")
+        assert history == [{"role": "user", "content": "research notes"}]
 
-    def test_no_duplicate_round_markers_for_same_round(self):
+    def test_user_supplied_seed_preserves_role(self):
+        """SDK ``run(history=[Message(role="user", ...)])`` seed: stored
+        with ``node_name=None`` and the original role survives."""
         conv = [
-            {"role": "user", "text": "a", "round": 1},
-            {"role": "assistant", "text": "b", "round": 1},
-            {"role": "user", "text": "c", "round": 1},
+            {"role": "user", "content": "/stranka PIGO", "node_name": None},
+            {"role": "assistant", "content": "PIGO is...", "node_name": None},
+            {"role": "user", "content": "kakšen je status?", "node_name": None},
         ]
-        result = _format_conversation(conv, "q")
-        assert result.count("--- Round 1 ---") == 1
+        history = _build_history_for_node(conv, "ChatAgent")
+        assert history == [
+            {"role": "user", "content": "/stranka PIGO"},
+            {"role": "assistant", "content": "PIGO is..."},
+            {"role": "user", "content": "kakšen je status?"},
+        ]
 
-    def test_multiple_rounds_with_proper_separators(self):
+    def test_pipeline_user_then_agent1_then_agent2_seen_by_agent2(self):
+        """Concrete trace of ``User → Agent1 → Agent2``:
+        Agent2 sees the original user turn as user, Agent1's output as
+        user (it's Agent2's input), and nothing as assistant (Agent2
+        hasn't replied yet)."""
         conv = [
-            {"role": "user", "text": "a", "round": 1},
-            {"role": "assistant", "text": "b", "round": 1},
-            {"role": "user", "text": "c", "round": 2},
-            {"role": "assistant", "text": "d", "round": 2},
-            {"role": "user", "text": "e", "round": 3},
+            {"role": "user", "content": "research Acme", "node_name": None},
+            {"role": "assistant", "content": "Acme is a widget co", "node_name": "Agent1"},
         ]
-        result = _format_conversation(conv, "q")
-        assert "--- Round 1 ---" in result
-        assert "--- Round 2 ---" in result
-        assert "--- Round 3 ---" in result
+        history = _build_history_for_node(conv, "Agent2")
+        assert history == [
+            {"role": "user", "content": "research Acme"},
+            {"role": "user", "content": "Acme is a widget co"},
+        ]
 
-    def test_entries_without_round_field_no_round_marker(self):
+    def test_multi_turn_same_node_chat_pattern(self):
+        """Sora chat turn 3 — Agent sees alternating user/assistant of
+        its OWN past turns plus the new user turn at the end."""
         conv = [
-            {"role": "user", "text": "a"},
-            {"role": "assistant", "text": "b"},
+            {"role": "user", "content": "/stranka PIGO", "node_name": None},
+            {"role": "assistant", "content": "PIGO d.o.o.", "node_name": "ChatAgent"},
+            {"role": "user", "content": "in status naročila?", "node_name": None},
+            {"role": "assistant", "content": "Naročilo SO-123 je...", "node_name": "ChatAgent"},
         ]
-        result = _format_conversation(conv, "q")
-        assert "--- Round" not in result
-        assert "[user]: a" in result
-        assert "[assistant]: b" in result
+        history = _build_history_for_node(conv, "ChatAgent")
+        assert history == [
+            {"role": "user", "content": "/stranka PIGO"},
+            {"role": "assistant", "content": "PIGO d.o.o."},
+            {"role": "user", "content": "in status naročila?"},
+            {"role": "assistant", "content": "Naročilo SO-123 je..."},
+        ]
 
-    def test_mix_of_entries_with_and_without_round(self):
+    def test_legacy_v07_shape_with_text_key_translates(self):
+        """Pre-v0.8.0 entries had ``{"role": <NodeName>, "text": ...}``.
+        Read-tolerated so in-flight flows don't break across upgrade."""
         conv = [
-            {"role": "user", "text": "a"},
-            {"role": "assistant", "text": "b", "round": 1},
-            {"role": "user", "text": "c"},
+            {"role": "Agent1", "text": "old-shape output"},
+            {"role": "Agent2", "text": "another old entry"},
         ]
-        result = _format_conversation(conv, "q")
-        assert "--- Round 1 ---" in result
-        # Only one round marker
-        assert result.count("--- Round") == 1
+        # Consuming as Agent2: Agent1 → user, Agent2 → assistant.
+        history = _build_history_for_node(conv, "Agent2")
+        assert history == [
+            {"role": "user", "content": "old-shape output"},
+            {"role": "assistant", "content": "another old entry"},
+        ]
 
-    def test_original_case_appended_at_end(self):
-        conv = [{"role": "user", "text": "hi"}]
-        result = _format_conversation(conv, "my question")
-        assert result.endswith("Original case: my question")
-
-    def test_very_long_conversation(self):
-        conv = [{"role": "user", "text": f"msg{i}", "round": i} for i in range(100)]
-        result = _format_conversation(conv, "q")
-        assert "--- Round 0 ---" in result
-        assert "--- Round 99 ---" in result
-        assert result.count("[user]:") == 100
-
-    def test_special_characters_in_text(self):
-        conv = [{"role": "user", "text": "Hello <world> & 'friends' \"test\""}]
-        result = _format_conversation(conv, "q")
-        assert "[user]: Hello <world> & 'friends' \"test\"" in result
-
-    def test_empty_user_input(self):
-        conv = [{"role": "user", "text": "hi"}]
-        result = _format_conversation(conv, "")
-        assert "Original case: " in result
-
-    def test_parts_joined_with_double_newline(self):
+    def test_no_prefix_injected_in_content(self):
+        """Critical fix: we must NOT prepend ``[NodeName]:`` to the
+        content. The role marker carries the semantics on its own."""
         conv = [
-            {"role": "user", "text": "a", "round": 1},
-            {"role": "assistant", "text": "b", "round": 1},
+            {"role": "assistant", "content": "research output", "node_name": "Agent1"},
         ]
-        result = _format_conversation(conv, "q")
-        # Round marker, entry a, entry b separated by \n\n
-        assert "\n\n" in result
+        history = _build_history_for_node(conv, "Agent2")
+        assert history[0]["content"] == "research output"
+        assert "[Agent1]" not in history[0]["content"]
+        assert "[Agent2]" not in history[0]["content"]
 
-    def test_separator_between_history_and_original(self):
-        conv = [{"role": "user", "text": "hi"}]
-        result = _format_conversation(conv, "q")
-        assert "\n\n---\nOriginal case:" in result
-
-    def test_round_none_is_treated_as_no_round(self):
-        conv = [{"role": "user", "text": "a", "round": None}]
-        result = _format_conversation(conv, "q")
-        # round=None should NOT produce a round marker
-        assert "--- Round" not in result
-
-    def test_round_zero_produces_marker(self):
-        conv = [{"role": "user", "text": "a", "round": 0}]
-        result = _format_conversation(conv, "q")
-        assert "--- Round 0 ---" in result
-
-    def test_format_preserves_entry_order(self):
+    def test_skips_entries_with_no_content(self):
         conv = [
-            {"role": "A", "text": "first"},
-            {"role": "B", "text": "second"},
-            {"role": "C", "text": "third"},
+            {"role": "assistant", "content": "", "node_name": "Agent1"},
+            {"role": "assistant", "content": "real output", "node_name": "Agent1"},
+            {"role": "assistant", "node_name": "Agent1"},  # missing content
         ]
-        result = _format_conversation(conv, "q")
-        idx_first = result.index("[A]: first")
-        idx_second = result.index("[B]: second")
-        idx_third = result.index("[C]: third")
-        assert idx_first < idx_second < idx_third
+        history = _build_history_for_node(conv, "Agent2")
+        assert history == [{"role": "user", "content": "real output"}]
 
-    def test_unicode_in_conversation_and_input(self):
-        conv = [{"role": "用户", "text": "你好世界"}]
-        result = _format_conversation(conv, "日本語")
-        assert "[用户]: 你好世界" in result
-        assert "Original case: 日本語" in result
-
-    def test_multiline_text_in_entries(self):
-        conv = [{"role": "user", "text": "line1\nline2\nline3"}]
-        result = _format_conversation(conv, "q")
-        assert "[user]: line1\nline2\nline3" in result
-
-    def test_same_round_repeated_after_different_round(self):
+    def test_skips_legacy_entries_with_no_text(self):
         conv = [
-            {"role": "user", "text": "a", "round": 1},
-            {"role": "user", "text": "b", "round": 2},
-            {"role": "user", "text": "c", "round": 1},
+            {"role": "Agent1", "text": ""},
+            {"role": "Agent1", "text": "real"},
+            {"role": "Agent1"},  # no text or content
         ]
-        result = _format_conversation(conv, "q")
-        # Round 1 should appear twice because current_round changes
-        assert result.count("--- Round 1 ---") == 2
+        history = _build_history_for_node(conv, "Agent2")
+        assert history == [{"role": "user", "content": "real"}]
+
+    def test_invalid_user_seed_role_falls_back_to_user(self):
+        """A seed entry with a junk role gets coerced to ``user``."""
+        conv = [
+            {"role": "weird_role", "content": "hi", "node_name": None},
+        ]
+        history = _build_history_for_node(conv, "Agent")
+        assert history == [{"role": "user", "content": "hi"}]
+
+    def test_current_node_name_none_treats_all_as_user(self):
+        """When the consuming node has no name (rare), entries from
+        named nodes still resolve to ``user`` because they're not
+        ``current_node_name``."""
+        conv = [
+            {"role": "assistant", "content": "from agent1", "node_name": "Agent1"},
+        ]
+        history = _build_history_for_node(conv, None)
+        assert history == [{"role": "user", "content": "from agent1"}]
 
 
 # ===================================================================
@@ -803,8 +768,10 @@ class TestTextExecutor:
         assert "memory_updates" in result.data
         conv = result.data["memory_updates"]["__conversation__"]
         assert len(conv) == 1
-        assert conv[0]["text"] == "Some text"
-        assert conv[0]["role"] == "Narrator"
+        # v0.8.0: stored as role=assistant with node_name=Narrator.
+        assert conv[0]["content"] == "Some text"
+        assert conv[0]["role"] == "assistant"
+        assert conv[0]["node_name"] == "Narrator"
 
     def test_includes_round_number_in_conversation_entry(self):
         ctx = _make_context(
@@ -877,8 +844,8 @@ class TestTextExecutor:
         result2 = _run(TextExecutor().execute(ctx2))
         conv2 = result2.data["memory_updates"]["__conversation__"]
         assert len(conv2) == 2
-        assert conv2[0]["text"] == "First"
-        assert conv2[1]["text"] == "Second"
+        assert conv2[0]["content"] == "First"
+        assert conv2[1]["content"] == "Second"
 
     def test_template_error_falls_back_to_raw_string(self):
         ctx = _make_context(
@@ -914,7 +881,9 @@ class TestTextExecutor:
         assert result.output_text == ""
         assert result.data == {}
 
-    def test_node_name_used_as_role_in_conversation(self):
+    def test_node_name_recorded_on_conversation_entry(self):
+        """v0.8.0: node identity moves from ``role`` to ``node_name``.
+        The role is always ``"assistant"`` for node outputs."""
         ctx = _make_context(
             node_metadata={"text": "Hello"},
             memory={},
@@ -922,7 +891,8 @@ class TestTextExecutor:
         )
         result = _run(TextExecutor().execute(ctx))
         conv = result.data["memory_updates"]["__conversation__"]
-        assert conv[0]["role"] == "CustomRole"
+        assert conv[0]["role"] == "assistant"
+        assert conv[0]["node_name"] == "CustomRole"
 
     def test_template_with_integer_variable(self):
         ctx = _make_context(
@@ -951,7 +921,8 @@ class TestTextExecutor:
         assert "round" not in conv[0]
 
     def test_preserves_existing_conversation(self):
-        existing = [{"role": "user", "text": "existing"}]
+        # v0.8.0 entry shape — content key, node_name on the seed.
+        existing = [{"role": "user", "content": "existing", "node_name": None}]
         ctx = _make_context(
             node_metadata={"text": "New"},
             memory={"__conversation__": existing},
@@ -960,8 +931,8 @@ class TestTextExecutor:
         result = _run(TextExecutor().execute(ctx))
         conv = result.data["memory_updates"]["__conversation__"]
         assert len(conv) == 2
-        assert conv[0]["text"] == "existing"
-        assert conv[1]["text"] == "New"
+        assert conv[0]["content"] == "existing"
+        assert conv[1]["content"] == "New"
 
 
 # ===================================================================
@@ -1008,7 +979,8 @@ class TestStaticExecutor:
         assert "__conversation__" in result.data.get("memory_updates", {})
         conv = result.data["memory_updates"]["__conversation__"]
         assert len(conv) == 1
-        assert conv[0]["text"] == "hello"
+        assert conv[0]["content"] == "hello"
+        assert conv[0]["role"] == "assistant"
 
     def test_empty_text_returns_empty_data(self):
         ctx = _make_context(

--- a/quartermaster-engine/tests/test_v071_agent_streaming.py
+++ b/quartermaster-engine/tests/test_v071_agent_streaming.py
@@ -71,9 +71,11 @@ class _StreamingMockProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[Any] | None = None,
         config: LLMConfig | None = None,
+        history: Any = None,
     ) -> NativeResponse:
         # Tracked so the test can prove we DIDN'T fall back to non-streaming.
         self.native_call_count += 1
+        self.last_history = history
         return NativeResponse(
             text_content="".join(self.text_chunks),
             thinking=[],
@@ -87,8 +89,10 @@ class _StreamingMockProvider(AbstractLLMProvider):
         tools: list[Any] | None = None,
         config: LLMConfig | None = None,
         on_token: Any = None,
+        history: Any = None,
     ) -> NativeResponse:
         self.stream_call_count += 1
+        self.last_history = history
         for chunk in self.text_chunks:
             if on_token is not None:
                 on_token(chunk)

--- a/quartermaster-engine/tests/test_v080_multi_turn_history.py
+++ b/quartermaster-engine/tests/test_v080_multi_turn_history.py
@@ -1,0 +1,178 @@
+"""v0.8.0 — multi-node graphs propagate proper user/assistant roles
+through the wire format instead of squashing every prior node's output
+into one giant ``role="user"`` blob.
+
+Pre-v0.8.0 wire format for ``User → Agent1 → Agent2``:
+
+    [system, {role:user, content:"[Agent1]: research notes\\n---\\nOriginal case: <input>"}]
+
+Agent2 had no way to distinguish Agent1's output (input it should act
+on) from its own past speech. v0.8.0 rebuilds this as:
+
+    [system,
+     {role:user, content:"<input>"},          # original user turn
+     {role:user, content:"research notes"},   # Agent1 output, from Agent2's POV
+     {role:user, content:"<input>"}]          # the trailing prompt
+
+This file exercises the engine end-to-end: build a graph, run it
+through MockProvider, intercept the outbound ``history`` kwarg per
+node, and assert the per-node role translation matches the v0.8.0
+contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from quartermaster_graph import Graph
+from quartermaster_providers import register_local
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+
+from quartermaster_engine import FlowRunner
+
+
+@pytest.fixture
+def registry_and_mock():
+    """A registry whose ``mock`` provider records every (prompt, history)
+    pair. Calls to ``mock.calls`` return them in order."""
+    registry = register_local("ollama", base_url="http://stub:11434", default_model="m")
+    answers = [
+        TokenResponse(content="research notes here", stop_reason="stop"),
+        TokenResponse(content="final summary", stop_reason="stop"),
+    ]
+    natives = [
+        NativeResponse(
+            text_content="research notes here", thinking=[], tool_calls=[], stop_reason="stop"
+        ),
+        NativeResponse(
+            text_content="final summary", thinking=[], tool_calls=[], stop_reason="stop"
+        ),
+    ]
+    mock = MockProvider(responses=answers, native_responses=natives)
+    registry.unregister("ollama")
+    registry.register_instance("ollama", mock)
+    return registry, mock
+
+
+# ── Test 1: User → Agent1 → Agent2 — the canonical bug from the audit ──
+
+
+def test_two_agent_pipeline_passes_agent1_output_as_user_role(registry_and_mock) -> None:
+    """The bug-of-record: when Agent2 runs, Agent1's output must arrive
+    as a ``role="user"`` history entry (input to act on), NOT
+    ``role="assistant"`` (its own past speech) and NOT crammed into the
+    user prompt with a ``[Agent1]:`` prefix."""
+    registry, mock = registry_and_mock
+
+    graph = (
+        Graph("two-agent-pipeline")
+        .start()
+        .user()
+        .agent("Researcher")
+        .agent("Summariser")
+        .end()
+        .build()
+    )
+    runner = FlowRunner(graph=graph, provider_registry=registry)
+    result = runner.run("research Acme Corp")
+    assert result.success, result.error
+
+    # Two LLM calls — one per agent. The base ``stream_native_response``
+    # shim used by MockProvider delegates to ``generate_native_response``,
+    # so that's the recorded method.
+    llm_calls = [c for c in mock.calls if c["method"] == "generate_native_response"]
+    assert len(llm_calls) >= 2, llm_calls
+
+    researcher_call = llm_calls[0]
+    summariser_call = llm_calls[1]
+
+    # Researcher (first agent) — no prior conversation, just the user
+    # input as the trailing prompt; history is empty.
+    assert researcher_call["history"] in (None, [])
+    assert researcher_call["prompt"] == "research Acme Corp"
+
+    # Summariser (second agent) — sees Researcher's output as a
+    # user-role history entry, NOT as assistant.
+    history = summariser_call["history"]
+    assert history is not None and len(history) >= 1
+    # The Researcher's output ("research notes here") must appear as
+    # role="user" — that's the whole fix.
+    assert {"role": "user", "content": "research notes here"} in history
+    # And the prefix must NOT be present anywhere in the content.
+    for entry in history:
+        assert "[Researcher]" not in entry["content"]
+        assert "[Summariser]" not in entry["content"]
+    # The user input is also surfaced as a role=user history entry —
+    # by ``role="assistant" if node_name==current_node else "user"``,
+    # the user input has node_name=None (it's not a node output) so
+    # it surfaces as user; that's correct.
+    # Final prompt is still the user input.
+    assert summariser_call["prompt"] == "research Acme Corp"
+
+
+# ── Test 2: same-agent multi-turn (sora chat pattern) ────────────────
+
+
+def test_same_agent_multi_iteration_keeps_user_assistant_alternation(
+    registry_and_mock,
+) -> None:
+    """Within a single agent node, the node's own past output stays
+    ``role="assistant"`` and user-supplied turns stay ``role="user"``.
+
+    Builds the history directly via :func:`_build_history_for_node` to
+    isolate the per-node role-translation contract from the rest of
+    the engine. The end-to-end FlowRunner path is covered by the
+    pipeline test above.
+    """
+    from quartermaster_engine.example_runner import _build_history_for_node
+
+    pre_seeded_conversation = [
+        {"role": "user", "content": "/stranka PIGO", "node_name": None},
+        {"role": "assistant", "content": "PIGO d.o.o.", "node_name": "Assistant"},
+        {"role": "user", "content": "in status?", "node_name": None},
+        {"role": "assistant", "content": "Naročilo SO-123", "node_name": "Assistant"},
+    ]
+    history = _build_history_for_node(pre_seeded_conversation, "Assistant")
+    assert history == [
+        {"role": "user", "content": "/stranka PIGO"},
+        {"role": "assistant", "content": "PIGO d.o.o."},
+        {"role": "user", "content": "in status?"},
+        {"role": "assistant", "content": "Naročilo SO-123"},
+    ]
+
+
+# ── Test 3: instruction_form after agent — the enrichment pattern ─────
+
+
+def test_instruction_form_after_agent_sees_research_as_user_input(registry_and_mock) -> None:
+    """Customer-enrichment shape: Research agent → InstructionForm
+    schema-extractor. The extractor must see the research notes as a
+    user message (input), not as its own past assistant turn."""
+    registry, mock = registry_and_mock
+
+    schema = {"type": "object", "properties": {"summary": {"type": "string"}}}
+    graph = (
+        Graph("research-then-extract")
+        .start()
+        .user()
+        .agent("Research")
+        .instruction_form("Extract", schema=schema)
+        .end()
+        .build()
+    )
+    runner = FlowRunner(graph=graph, provider_registry=registry)
+    runner.run("enrich")
+    # The mock's native_responses[1] doesn't return real JSON, so the
+    # node's parse may fail — we don't care here, we care about the
+    # outbound wire format on the call. The call still happens before
+    # parsing.
+    assert mock.calls
+
+    extract_calls = [c for c in mock.calls if c["method"] == "generate_native_response"]
+    # The extract node calls generate_native_response with a forced
+    # tool call. Its history should include the Research agent's output
+    # as role="user".
+    if extract_calls:
+        history = extract_calls[-1]["history"]
+        assert history is not None
+        assert any(entry == {"role": "user", "content": "research notes here"} for entry in history)

--- a/quartermaster-providers/src/quartermaster_providers/base.py
+++ b/quartermaster-providers/src/quartermaster_providers/base.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator, TypeVar
 
 from quartermaster_providers.config import LLMConfig
 from quartermaster_providers.types import (
+    Message,
     NativeResponse,
     StructuredResponse,
     TokenResponse,
@@ -83,12 +84,20 @@ class AbstractLLMProvider(ABC):
         self,
         prompt: str,
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> TokenResponse | AsyncIterator[TokenResponse]:
         """Generate a text response from a prompt.
 
         Args:
-            prompt: Input prompt text.
+            prompt: Input prompt text — appended as the trailing
+                ``role="user"`` message in the outbound chat-completions
+                payload.
             config: LLM configuration (temperature, max_tokens, etc.).
+            history: Optional v0.8.0 multi-turn history. Each entry maps to
+                its own ``{role, content}`` message in the outbound payload,
+                slotted between ``config.system_message`` and the trailing
+                ``prompt`` user-message. ``None`` (the default) preserves
+                the pre-v0.8.0 single-user-message wire format.
 
         Returns:
             Single TokenResponse if not streaming, otherwise AsyncIterator
@@ -107,6 +116,7 @@ class AbstractLLMProvider(ABC):
         prompt: str,
         tools: list[ToolDefinition],
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> ToolCallResponse:
         """Generate tool calls with parameters.
 
@@ -117,6 +127,9 @@ class AbstractLLMProvider(ABC):
             prompt: Input prompt requesting tool use.
             tools: List of available tools the model can call.
             config: LLM configuration.
+            history: Optional v0.8.0 multi-turn history — see
+                :meth:`generate_text_response` for the role-translation
+                contract.
 
         Returns:
             ToolCallResponse with tool_calls and any text_content.
@@ -132,6 +145,7 @@ class AbstractLLMProvider(ABC):
         prompt: str,
         tools: list[ToolDefinition] | None = None,
         config: LLMConfig | None = None,
+        history: list[Message] | None = None,
     ) -> NativeResponse:
         """Generate the complete/native response from the model.
 
@@ -142,6 +156,9 @@ class AbstractLLMProvider(ABC):
             prompt: Input prompt.
             tools: Optional list of available tools.
             config: LLM configuration.
+            history: Optional v0.8.0 multi-turn history — see
+                :meth:`generate_text_response` for the role-translation
+                contract.
 
         Returns:
             NativeResponse containing text, thinking, tool calls, usage.
@@ -154,6 +171,7 @@ class AbstractLLMProvider(ABC):
         tools: list[ToolDefinition] | None = None,
         config: LLMConfig | None = None,
         on_token: Callable[[str], None] | None = None,
+        history: list[Message] | None = None,
     ) -> NativeResponse:
         """Stream tokens to ``on_token`` while assembling tool_calls atomically.
 
@@ -184,7 +202,7 @@ class AbstractLLMProvider(ABC):
             stop_reason, and usage — same shape as
             :meth:`generate_native_response`.
         """
-        response = await self.generate_native_response(prompt, tools, config)
+        response = await self.generate_native_response(prompt, tools, config, history=history)
         if on_token is not None and response.text_content:
             on_token(response.text_content)
         return response

--- a/quartermaster-providers/src/quartermaster_providers/providers/anthropic.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/anthropic.py
@@ -22,6 +22,7 @@ from quartermaster_providers.exceptions import (
     ServiceUnavailableError,
 )
 from quartermaster_providers.types import (
+    Message,
     NativeResponse,
     StructuredResponse,
     ThinkingResponse,
@@ -236,7 +237,14 @@ class AnthropicProvider(AbstractLLMProvider):
         self,
         prompt: str,
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> TokenResponse | AsyncIterator[TokenResponse]:
+        # v0.8.0 ``history`` accepted for protocol parity with the
+        # OpenAI provider but currently not translated into Anthropic's
+        # ``messages`` shape — the Anthropic-side _build_params still
+        # uses the legacy single-prompt path. Tracked as follow-up work
+        # for the Anthropic / Google / Groq providers.
+        del history  # unused — see note above
         client = self._get_client()
         params = self._build_params(prompt, config)
 
@@ -281,7 +289,11 @@ class AnthropicProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition],
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> ToolCallResponse:
+        # See generate_text_response — ``history`` accepted for protocol
+        # parity, not yet translated for Anthropic.
+        del history
         client = self._get_client()
         prepared_tools = [self.prepare_tool(t) for t in tools]
         params = self._build_params(prompt, config, tools=prepared_tools)
@@ -319,7 +331,11 @@ class AnthropicProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition] | None = None,
         config: LLMConfig | None = None,
+        history: list[Message] | None = None,
     ) -> NativeResponse:
+        # See generate_text_response — ``history`` accepted for protocol
+        # parity, not yet translated for Anthropic.
+        del history
         if config is None:
             raise InvalidRequestError("config is required", provider=self.PROVIDER_NAME)
 

--- a/quartermaster-providers/src/quartermaster_providers/providers/google.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/google.py
@@ -22,6 +22,7 @@ from quartermaster_providers.exceptions import (
     ServiceUnavailableError,
 )
 from quartermaster_providers.types import (
+    Message,
     NativeResponse,
     StructuredResponse,
     ToolCall,
@@ -213,7 +214,13 @@ class GoogleProvider(AbstractLLMProvider):
         self,
         prompt: str,
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> TokenResponse | AsyncIterator[TokenResponse]:
+        # v0.8.0: ``history`` accepted for protocol parity. Google's
+        # generate_content takes a ``contents`` array which can carry
+        # multi-turn history natively, but the translation layer hasn't
+        # been built yet — see follow-up work for non-OpenAI providers.
+        del history
         model = self._get_model(config)
 
         content = self._build_content_parts(prompt, config)
@@ -257,7 +264,9 @@ class GoogleProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition],
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> ToolCallResponse:
+        del history  # see generate_text_response — not yet translated
         import google.generativeai as genai
 
         model = self._get_model(config)
@@ -307,7 +316,9 @@ class GoogleProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition] | None = None,
         config: LLMConfig | None = None,
+        history: list[Message] | None = None,
     ) -> NativeResponse:
+        del history  # see generate_text_response — not yet translated
         if config is None:
             raise InvalidRequestError("config is required", provider=self.PROVIDER_NAME)
 

--- a/quartermaster-providers/src/quartermaster_providers/providers/openai.py
+++ b/quartermaster-providers/src/quartermaster_providers/providers/openai.py
@@ -24,6 +24,7 @@ from quartermaster_providers.exceptions import (
     ServiceUnavailableError,
 )
 from quartermaster_providers.types import (
+    Message,
     NativeResponse,
     StructuredResponse,
     TokenResponse,
@@ -514,11 +515,46 @@ class OpenAIProvider(AbstractLLMProvider):
         parts.append({"type": "text", "text": prompt})
         return parts
 
-    def _build_messages(self, prompt: str, config: LLMConfig) -> list[dict[str, Any]]:
-        """Build OpenAI messages array from prompt and config."""
+    def _build_messages(
+        self,
+        prompt: str,
+        config: LLMConfig,
+        history: list[Message] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Build OpenAI messages array from prompt + optional history.
+
+        Layout (in order):
+
+        1. ``system`` message from ``config.system_message`` (skipped on
+           o-series — they don't accept a system role).
+        2. Each entry in ``history`` as its own ``{role, content}``
+           message — ``role`` must be one of ``"user"`` / ``"assistant"``
+           (or ``"system"`` for advanced cases). v0.8.0 introduced this
+           parameter so multi-node graphs can present prior nodes' outputs
+           as proper user-role turns instead of squashing the whole
+           conversation into one user message.
+        3. The final ``user`` message carrying the current ``prompt``
+           (and any vision attachments via ``_build_user_content``).
+
+        ``history=None`` preserves the pre-v0.8.0 wire format exactly —
+        a single user message — so existing callers don't change shape.
+        """
         messages: list[dict[str, Any]] = []
         if config.system_message and not _is_o_series(config.model):
             messages.append({"role": "system", "content": config.system_message})
+        if history:
+            for entry in history:
+                # Defensive: skip malformed entries rather than erroring —
+                # the engine's history builder is the canonical source,
+                # but a caller passing through user-supplied history
+                # shouldn't crash the request on a typo.
+                role = entry.get("role") if isinstance(entry, dict) else None
+                content = entry.get("content") if isinstance(entry, dict) else None
+                if not role or content is None:
+                    continue
+                if role not in ("user", "assistant", "system"):
+                    continue
+                messages.append({"role": role, "content": str(content)})
         messages.append({"role": "user", "content": self._build_user_content(prompt, config)})
         return messages
 
@@ -620,9 +656,10 @@ class OpenAIProvider(AbstractLLMProvider):
         self,
         prompt: str,
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> TokenResponse | AsyncIterator[TokenResponse]:
         client = self._get_client()
-        messages = self._build_messages(prompt, config)
+        messages = self._build_messages(prompt, config, history=history)
         params = self._build_params(config, messages)
 
         try:
@@ -716,9 +753,10 @@ class OpenAIProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition],
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> ToolCallResponse:
         client = self._get_client()
-        messages = self._build_messages(prompt, config)
+        messages = self._build_messages(prompt, config, history=history)
         prepared_tools = [self.prepare_tool(t) for t in tools]
         params = self._build_params(config, messages, tools=prepared_tools)
         params.pop("stream", None)
@@ -776,12 +814,13 @@ class OpenAIProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition] | None = None,
         config: LLMConfig | None = None,
+        history: list[Message] | None = None,
     ) -> NativeResponse:
         if config is None:
             raise InvalidRequestError("config is required", provider=self.PROVIDER_NAME)
 
         client = self._get_client()
-        messages = self._build_messages(prompt, config)
+        messages = self._build_messages(prompt, config, history=history)
         prepared_tools = [self.prepare_tool(t) for t in tools] if tools else None
         params = self._build_params(config, messages, tools=prepared_tools)
         params.pop("stream", None)
@@ -849,6 +888,7 @@ class OpenAIProvider(AbstractLLMProvider):
         tools: list[ToolDefinition] | None = None,
         config: LLMConfig | None = None,
         on_token: Callable[[str], None] | None = None,
+        history: list[Message] | None = None,
     ) -> NativeResponse:
         """Streaming counterpart to :meth:`generate_native_response`.
 
@@ -877,7 +917,7 @@ class OpenAIProvider(AbstractLLMProvider):
             raise InvalidRequestError("config is required", provider=self.PROVIDER_NAME)
 
         client = self._get_client()
-        messages = self._build_messages(prompt, config)
+        messages = self._build_messages(prompt, config, history=history)
         prepared_tools = [self.prepare_tool(t) for t in tools] if tools else None
         params = self._build_params(config, messages, tools=prepared_tools)
         # Force streaming — config.stream may be False when the agent

--- a/quartermaster-providers/src/quartermaster_providers/testing.py
+++ b/quartermaster-providers/src/quartermaster_providers/testing.py
@@ -68,6 +68,7 @@ class MockProvider(AbstractLLMProvider):
         self.last_prompt: str | None = None
         self.last_config: LLMConfig | None = None
         self.last_tools: list[ToolDefinition] | None = None
+        self.last_history: list[Message] | None = None
 
     def _track_call(
         self,
@@ -75,17 +76,20 @@ class MockProvider(AbstractLLMProvider):
         prompt: str,
         config: LLMConfig | None = None,
         tools: list[ToolDefinition] | None = None,
+        history: list[Message] | None = None,
     ) -> None:
         self.call_count += 1
         self.last_prompt = prompt
         self.last_config = config
         self.last_tools = tools
+        self.last_history = history
         self.calls.append(
             {
                 "method": method,
                 "prompt": prompt,
                 "config": config,
                 "tools": tools,
+                "history": history,
             }
         )
 
@@ -146,8 +150,9 @@ class MockProvider(AbstractLLMProvider):
         self,
         prompt: str,
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> TokenResponse | AsyncIterator[TokenResponse]:
-        self._track_call("generate_text_response", prompt, config)
+        self._track_call("generate_text_response", prompt, config, history=history)
 
         if config.stream:
             return self._stream_response(prompt, config)
@@ -170,8 +175,9 @@ class MockProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition],
         config: LLMConfig,
+        history: list[Message] | None = None,
     ) -> ToolCallResponse:
-        self._track_call("generate_tool_parameters", prompt, config, tools)
+        self._track_call("generate_tool_parameters", prompt, config, tools, history=history)
         return self._next_tool_response()
 
     async def generate_native_response(
@@ -179,8 +185,9 @@ class MockProvider(AbstractLLMProvider):
         prompt: str,
         tools: list[ToolDefinition] | None = None,
         config: LLMConfig | None = None,
+        history: list[Message] | None = None,
     ) -> NativeResponse:
-        self._track_call("generate_native_response", prompt, config, tools)
+        self._track_call("generate_native_response", prompt, config, tools, history=history)
         return self._next_native_response()
 
     async def generate_structured_response(

--- a/quartermaster-providers/tests/test_v080_history_splicing.py
+++ b/quartermaster-providers/tests/test_v080_history_splicing.py
@@ -1,0 +1,232 @@
+"""v0.8.0 — ``history`` kwarg on every provider method splices into
+the outbound ``messages`` array as proper multi-turn turns.
+
+Pre-v0.8.0 wire format collapsed every prior turn into a single
+``role="user"`` blob. This file locks down the new shape:
+
+    [system, *history (one msg each), {role:user, content:prompt}]
+
+— so the LLM can distinguish "this came from Agent1" (a separate
+``user`` turn) from "this is the current question to act on" (the
+trailing ``user`` turn).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from quartermaster_providers.config import LLMConfig
+from quartermaster_providers.providers.openai import OpenAIProvider
+
+
+def _fake_response(content: str = "ok") -> MagicMock:
+    msg = MagicMock()
+    msg.content = content
+    msg.tool_calls = None
+    choice = MagicMock()
+    choice.message = msg
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = None
+    return resp
+
+
+def _provider() -> tuple[OpenAIProvider, MagicMock]:
+    p = OpenAIProvider(api_key="sk-test")
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=_fake_response())
+    p._client = client
+    return p, client
+
+
+class TestHistoryAbsentMatchesPreV080:
+    """When ``history=None`` (the default), the wire format is identical
+    to pre-v0.8.0 — single user message after the system prompt. No
+    silent break for callers that haven't started using history yet."""
+
+    def test_no_history_kwarg_yields_single_user_message(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai", system_message="be brief")
+        asyncio.run(provider.generate_text_response("hello", config))
+
+        messages = client.chat.completions.create.call_args.kwargs["messages"]
+        assert messages == [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "hello"},
+        ]
+
+
+class TestHistorySplicedBetweenSystemAndUser:
+    """``history`` entries appear between the system message and the
+    trailing user message, in order, each as its own ``{role, content}``
+    object — never concatenated into one bigger user message."""
+
+    def test_two_history_turns_become_two_messages(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai", system_message="sys")
+        history = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+        asyncio.run(provider.generate_text_response("next question", config, history=history))
+
+        messages = client.chat.completions.create.call_args.kwargs["messages"]
+        assert messages == [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+            {"role": "user", "content": "next question"},
+        ]
+
+    def test_history_order_preserved(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [
+            {"role": "user", "content": "msg-1"},
+            {"role": "assistant", "content": "msg-2"},
+            {"role": "user", "content": "msg-3"},
+            {"role": "assistant", "content": "msg-4"},
+        ]
+        asyncio.run(provider.generate_text_response("msg-5", config, history=history))
+
+        messages = client.chat.completions.create.call_args.kwargs["messages"]
+        # Strip system message (none configured); compare the rest.
+        contents = [m["content"] for m in messages]
+        assert contents == ["msg-1", "msg-2", "msg-3", "msg-4", "msg-5"]
+
+    def test_history_role_alternation_preserved(self) -> None:
+        """Sora chat pattern: real user/assistant alternation through
+        the history, not flattened to ``[role-name]: text`` strings."""
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [
+            {"role": "user", "content": "/stranka PIGO"},
+            {"role": "assistant", "content": "PIGO d.o.o."},
+            {"role": "user", "content": "in status?"},
+            {"role": "assistant", "content": "Naročilo SO-123 je..."},
+        ]
+        asyncio.run(provider.generate_text_response("hvala", config, history=history))
+
+        messages = client.chat.completions.create.call_args.kwargs["messages"]
+        roles = [m["role"] for m in messages]
+        # No system message → straight alternation + the trailing user.
+        assert roles == ["user", "assistant", "user", "assistant", "user"]
+
+
+class TestHistoryDefensiveAgainstMalformedEntries:
+    """The provider's history splicer is defensive — bad entries don't
+    crash the request, they just get dropped. The engine's history
+    builder is the canonical source, but a typo from a hand-rolled
+    caller shouldn't take the whole turn down."""
+
+    def test_missing_role_skipped(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [
+            {"content": "no role here"},
+            {"role": "user", "content": "valid"},
+        ]
+        asyncio.run(provider.generate_text_response("now", config, history=history))
+
+        messages = client.chat.completions.create.call_args.kwargs["messages"]
+        contents = [m["content"] for m in messages]
+        assert "no role here" not in contents
+        assert "valid" in contents
+
+    def test_unknown_role_skipped(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [
+            {"role": "tool", "content": "tool message — not user/assistant"},
+            {"role": "user", "content": "valid"},
+        ]
+        asyncio.run(provider.generate_text_response("now", config, history=history))
+
+        contents = [
+            m["content"] for m in client.chat.completions.create.call_args.kwargs["messages"]
+        ]
+        assert "tool message — not user/assistant" not in contents
+        assert "valid" in contents
+
+    def test_missing_content_skipped(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [
+            {"role": "user"},
+            {"role": "user", "content": "valid"},
+        ]
+        asyncio.run(provider.generate_text_response("now", config, history=history))
+
+        msgs = client.chat.completions.create.call_args.kwargs["messages"]
+        # Only the valid history entry + the trailing prompt should be there.
+        assert [m["content"] for m in msgs if m["role"] == "user"] == ["valid", "now"]
+
+
+class TestHistoryAcrossEveryGenerateMethod:
+    """Every ``generate_*`` / ``stream_native_response`` accepts and
+    forwards the ``history`` kwarg. Locked down here so a future provider
+    refactor can't silently regress one of them."""
+
+    def test_generate_native_response_forwards_history(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [{"role": "user", "content": "h1"}]
+        asyncio.run(provider.generate_native_response("now", None, config, history=history))
+        msgs = client.chat.completions.create.call_args.kwargs["messages"]
+        assert {"role": "user", "content": "h1"} in msgs
+
+    def test_generate_tool_parameters_forwards_history(self) -> None:
+        provider, client = _provider()
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [{"role": "user", "content": "h1"}]
+        tools = [{"name": "f", "description": "d", "input_schema": {"type": "object"}}]
+        asyncio.run(provider.generate_tool_parameters("now", tools, config, history=history))
+        msgs = client.chat.completions.create.call_args.kwargs["messages"]
+        assert {"role": "user", "content": "h1"} in msgs
+
+    def test_stream_native_response_forwards_history(self) -> None:
+        """The streaming path also splices history. Use a fake stream
+        that yields one chunk so the wire-format assertion stands."""
+        provider = OpenAIProvider(api_key="sk-test")
+        delta = MagicMock()
+        delta.content = "ok"
+        delta.tool_calls = None
+        delta.reasoning = ""
+        delta.reasoning_content = ""
+        choice = MagicMock()
+        choice.delta = delta
+        choice.finish_reason = "stop"
+        chunk = MagicMock()
+        chunk.choices = [choice]
+        chunk.usage = None
+
+        class _Iter:
+            def __init__(self) -> None:
+                self._done = False
+
+            def __aiter__(self) -> "_Iter":
+                return self
+
+            async def __anext__(self):
+                if self._done:
+                    raise StopAsyncIteration
+                self._done = True
+                return chunk
+
+            async def aclose(self) -> None:
+                pass
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=_Iter())
+        provider._client = client
+
+        config = LLMConfig(model="gpt-4o", provider="openai")
+        history = [{"role": "user", "content": "history-turn"}]
+        asyncio.run(
+            provider.stream_native_response("now", None, config, on_token=None, history=history)
+        )
+
+        msgs = client.chat.completions.create.call_args.kwargs["messages"]
+        assert {"role": "user", "content": "history-turn"} in msgs


### PR DESCRIPTION
## Problem — multi-node graphs collapsed every prior output into one user message

Pre-v0.8.0 wire format for `User → Agent1 → Agent2`:

```
[system: <Agent2's prompt>,
 user:   "[Agent1]: research notes\n\n---\nOriginal case: <input>"]
```

Agent2 had no way to distinguish Agent1's research from its own past speech. Multi-node graphs (customer enrichment) and multi-turn chat (Sora) hit the same root cause every turn — explaining the band-aid retry loops, empty-reply salvage, and `[Assistant]:` echo guards in printer-app.

## Fix — real multi-turn through `messages`

Wire format now:

```
[system: <Agent2's prompt>,
 user:    "<original user input>",
 user:    "research notes",          # Agent1 output, role=user from Agent2's POV
 user:    "<original user input>"]   # trailing prompt
```

Each prior turn is its own `{role, content}` message. Role carries the "input vs my own past speech" semantics; no `[Agent1]:` prefix injected into content; no tokens wasted on graph internals leaking to the model.

## Changes

### `quartermaster-providers`
- `AbstractLLMProvider` methods (`generate_text_response`, `generate_native_response`, `stream_native_response`, `generate_tool_parameters`) gain `history: list[Message] | None = None`. Default `None` preserves pre-v0.8.0 wire format exactly — no break for callers who haven't migrated.
- `OpenAIProvider._build_messages` splices `history` between the system message and the trailing user message. Defensive against malformed entries (missing role / content / unknown role → skip).
- Anthropic / Google accept the kwarg for protocol parity but don't yet translate to their native multi-turn shapes (follow-up work).
- `MockProvider.last_history` recorded for tests.

### `quartermaster-engine`
- `__conversation__` entry shape changes to `{role: "user"|"assistant"|"system", content, node_name, round}`. Node identity moves from `role` to `node_name`.
- `_build_history_for_node(conversation, current_node_name, drop_trailing_user_match=user_input)` translates entries:
  - `node_name == current_node` → `role="assistant"` (my past turn)
  - `node_name != current_node` → `role="user"` (input from upstream)
  - `node_name is None` → preserve stored role (user-supplied seed via SDK / FlowRunner User-node hook)
  - Legacy v0.7.x `{role: NodeName, text}` shape read-tolerated
  - `drop_trailing_user_match` strips the duplicate user turn that `FlowRunner` writes to `__conversation__` for `.back()` loops
- `_format_conversation` removed. `LLMExecutor` / `AgentExecutor` / `DecisionExecutor` / `InstructionFormExecutor` build proper history via the new helper and pass through to providers.
- `FlowRunner` USER/USER_FORM after-hook writes the new entry shape (`role="user"`, `node_name=None`) so the translator preserves it.

## Test plan

- [x] 10 provider unit tests (`test_v080_history_splicing.py`) — history-absent default matches pre-v0.8.0; splicing between system and user; role alternation preserved; defensive against malformed entries; every `generate_*` method forwards history.
- [x] 3 engine integration tests (`test_v080_multi_turn_history.py`) — `User → Agent1 → Agent2` sees Agent1's output as `role="user"` with no `[Agent1]:` prefix; same-agent multi-turn keeps user/assistant alternation; `instruction_form` after agent sees research notes as user input.
- [x] 13 unit tests for `_build_history_for_node` covering every translation rule including legacy-shape backward compat.
- [x] `TestAppendToConversation` rewritten for new entry shape.
- [x] Full engine: 511 + new tests; providers: 309 → 319; SDK 217 / graph 261 unchanged. No regressions.
- [x] `ruff format` + `ruff check` clean on changed files.

## Backward compatibility

- Providers without an override (Anthropic / Google / Groq / xAI / OpenAI-compat) accept `history=...` and either translate (OpenAI) or fold-through to their existing single-prompt wire format.
- Legacy `__conversation__` shape (`{role: NodeName, text}`) is read-tolerated by `_build_history_for_node`. In-flight flows don't break across upgrade.
- All existing tests pass with no behaviour changes for callers that don't set `history=`.

## Ships as v0.8.0

Minor bump (pre-1.0). Wire-format change is significant enough to signal beyond a patch.