### PR TITLE
feat(sdk,engine): qm.run(history=[...]) seeds proper multi-turn (v0.8.1)

### DIFF
--- a/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
+++ b/quartermaster-engine/src/quartermaster_engine/runner/flow_runner.py
@@ -268,6 +268,7 @@ class FlowRunner:
         images: list[tuple[str, str]] | None = None,
         flow_id: UUID | None = None,
         llm_timeouts: dict[str, float | None] | None = None,
+        history: list[dict[str, Any]] | None = None,
     ) -> FlowResult:
         """Execute the graph synchronously.
 
@@ -289,6 +290,15 @@ class FlowRunner:
                 Added in v0.4.0 — the SDK populates it from
                 ``qm.configure`` defaults and per-call
                 ``qm.run(..., read_timeout=...)`` overrides.
+            history: Optional v0.8.1 multi-turn seed. Each entry is a
+                ``{"role": "user"|"assistant"|"system", "content": str}``
+                dict pre-loaded into ``__conversation__`` so the FIRST
+                LLM node sees prior turns as proper user/assistant
+                alternation in the outbound ``messages`` array — instead
+                of being concatenated into ``input_message`` as a flat
+                ``Uporabnik:``/``Asistent:`` blob. Entries are stored
+                with ``node_name=None`` so they pass through the role
+                translator unchanged.
 
         Returns:
             A FlowResult with the final output and metadata.
@@ -303,6 +313,33 @@ class FlowRunner:
 
             # Store the initial user input in flow memory
             self.store.save_memory(fid, "__user_input__", input_message)
+
+            # v0.8.1: pre-seed __conversation__ from caller-supplied
+            # multi-turn history so downstream LLM nodes can build a
+            # proper messages array via ``_build_history_for_node``.
+            # Defensive: skip entries missing a recognised role or any
+            # content; the engine's role translator is also defensive
+            # but cleaner to filter at ingest.
+            if history:
+                seeded: list[dict[str, Any]] = []
+                for entry in history:
+                    if not isinstance(entry, dict):
+                        continue
+                    role = entry.get("role")
+                    content = entry.get("content")
+                    if role not in ("user", "assistant", "system"):
+                        continue
+                    if not isinstance(content, str) or not content:
+                        continue
+                    seeded.append(
+                        {
+                            "role": role,
+                            "content": content,
+                            "node_name": None,
+                        }
+                    )
+                if seeded:
+                    self.store.save_memory(fid, "__conversation__", seeded)
             # Store any attached images so vision-capable nodes can pick
             # them up via ``context.memory["__user_images__"]`` without
             # the caller having to touch the store directly. Stored as

--- a/quartermaster-sdk/src/quartermaster_sdk/_runner.py
+++ b/quartermaster-sdk/src/quartermaster_sdk/_runner.py
@@ -394,6 +394,7 @@ class _RunCallable:
         read_timeout: float | None = None,
         session: SessionStore | None = None,
         session_id: str | None = None,
+        history: list[dict[str, Any]] | None = None,
     ) -> Result:
         """Execute *graph* against *user_input* and return a :class:`Result`.
 
@@ -433,14 +434,30 @@ class _RunCallable:
                 v0.4.0.
             session_id: Session key for the session store.  Required
                 when *session* is set; ignored otherwise.
+            history: Optional v0.8.1 multi-turn seed. Each entry is a
+                ``{"role": "user"|"assistant"|"system", "content": str}``
+                dict that the engine pre-loads into ``__conversation__``
+                so the first LLM node sees prior turns as proper
+                user/assistant alternation in the outbound ``messages``
+                array — instead of being folded into ``user_input`` as
+                a flat ``Uporabnik:``/``Asistent:`` blob. Mutually
+                exclusive with the legacy ``session=`` shape (which
+                still works but produces the older blob-style turn).
         """
-        # ── v0.4.0 session: load history ──────────────────────────────
-        if session is not None:
+        # ── v0.8.1 explicit history seed wins over the legacy session
+        # path. A caller passing both gets the explicit history (clean
+        # multi-turn) and we ignore the session blob; that's the
+        # forward-compatible direction for the SDK API.
+        seeded_history: list[dict[str, Any]] | None = list(history) if history else None
+
+        # ── v0.4.0 session: load history (legacy blob path; kept for
+        # back-compat. Only fires when ``history=`` was NOT passed.)
+        if session is not None and seeded_history is None:
             if session_id is None:
                 raise ValueError("run(): session= requires session_id=")
-            history: list[ChatTurn] = session.load(session_id)
-            if history:
-                parts = [f"{t.role.capitalize()}: {t.content}" for t in history]
+            chat_turns: list[ChatTurn] = session.load(session_id)
+            if chat_turns:
+                parts = [f"{t.role.capitalize()}: {t.content}" for t in chat_turns]
                 parts.append(f"User: {user_input}")
                 user_input = "\n".join(parts)
 
@@ -487,6 +504,7 @@ class _RunCallable:
             user_input,
             images=prepared_images or None,
             llm_timeouts=llm_timeouts,
+            history=seeded_history,
         )
         elapsed = time.perf_counter() - started
 
@@ -520,6 +538,7 @@ class _RunCallable:
         connect_timeout: float | None = None,
         read_timeout: float | None = None,
         deadline_seconds: float | None = None,
+        history: list[dict[str, Any]] | None = None,
     ) -> _Stream:
         """Run the graph and yield typed :class:`Chunk` events as they arrive.
 
@@ -602,6 +621,7 @@ class _RunCallable:
                 read_timeout=read_timeout,
                 deadline_seconds=deadline_seconds,
                 stop_handle=stop_handle,
+                history=history,
             ),
             on_exit=_on_exit,
         )
@@ -620,6 +640,7 @@ class _RunCallable:
         read_timeout: float | None = None,
         deadline_seconds: float | None = None,
         stop_handle: dict[str, Any] | None = None,
+        history: list[dict[str, Any]] | None = None,
     ) -> Iterator[Chunk]:
         """Inner generator that powers :meth:`stream`.
 
@@ -696,6 +717,7 @@ class _RunCallable:
                     images=prepared_images or None,
                     flow_id=flow_id,
                     llm_timeouts=llm_timeouts,
+                    history=list(history) if history else None,
                 )
                 with holder_lock:
                     holder["result"] = fr

--- a/quartermaster-sdk/tests/test_v020_surface.py
+++ b/quartermaster-sdk/tests/test_v020_surface.py
@@ -413,7 +413,13 @@ class TestStreamEarlyExitCancels:
         original_run = FlowRunner.run
 
         def capture_run(
-            self, input_message, *, images=None, flow_id=None, llm_timeouts=None
+            self,
+            input_message,
+            *,
+            images=None,
+            flow_id=None,
+            llm_timeouts=None,
+            history=None,
         ):
             captured["flow_id_passed"] = flow_id
             return original_run(
@@ -422,6 +428,7 @@ class TestStreamEarlyExitCancels:
                 images=images,
                 flow_id=flow_id,
                 llm_timeouts=llm_timeouts,
+                history=history,
             )
 
         monkeypatch.setattr(FlowRunner, "run", capture_run)

--- a/quartermaster-sdk/tests/test_v040_timeouts.py
+++ b/quartermaster-sdk/tests/test_v040_timeouts.py
@@ -394,7 +394,13 @@ class TestStreamDeadlineSeconds:
         original_run = FlowRunner.run
 
         def slow_run(
-            self, input_message, *, images=None, flow_id=None, llm_timeouts=None
+            self,
+            input_message,
+            *,
+            images=None,
+            flow_id=None,
+            llm_timeouts=None,
+            history=None,
         ):
             # Block for well past the 0.3s deadline — lets the
             # iterator's deadline check fire before any chunk arrives.
@@ -405,6 +411,7 @@ class TestStreamDeadlineSeconds:
                 images=images,
                 flow_id=flow_id,
                 llm_timeouts=llm_timeouts,
+                history=history,
             )
 
         with patch.object(FlowRunner, "run", slow_run):
@@ -435,7 +442,13 @@ class TestStreamDeadlineSeconds:
         original_run = FlowRunner.run
 
         def slow_run(
-            self, input_message, *, images=None, flow_id=None, llm_timeouts=None
+            self,
+            input_message,
+            *,
+            images=None,
+            flow_id=None,
+            llm_timeouts=None,
+            history=None,
         ):
             time.sleep(2.0)
             return original_run(
@@ -444,6 +457,7 @@ class TestStreamDeadlineSeconds:
                 images=images,
                 flow_id=flow_id,
                 llm_timeouts=llm_timeouts,
+                history=history,
             )
 
         async def _main() -> None:

--- a/quartermaster-sdk/tests/test_v081_history_kwarg.py
+++ b/quartermaster-sdk/tests/test_v081_history_kwarg.py
@@ -1,0 +1,157 @@
+"""v0.8.1 — ``qm.run(history=[...])`` and ``qm.run.stream(history=[...])``
+seed multi-turn conversation directly into the engine's
+``__conversation__`` so the first LLM node sees prior turns as proper
+user/assistant alternation.
+
+Pre-v0.8.1 the only way to surface chat history was the ``session=``
+kwarg, which folded prior turns into the ``user_input`` string with
+``Uporabnik:``/``Asistent:``-style markers — same single-user-message
+wire-format bug that v0.8.0 fixed at the engine layer. v0.8.1 closes
+the gap at the SDK runner so chat consumers get clean multi-turn
+without doing memory plumbing themselves.
+"""
+
+from __future__ import annotations
+
+import quartermaster_sdk as qm
+from quartermaster_graph import Graph
+from quartermaster_providers import register_local
+from quartermaster_providers.testing import MockProvider
+from quartermaster_providers.types import NativeResponse, TokenResponse
+
+
+def _mock_registry():
+    registry = register_local("ollama", base_url="http://stub:11434", default_model="m")
+    mock = MockProvider(
+        responses=[TokenResponse(content="reply", stop_reason="stop")],
+        native_responses=[
+            NativeResponse(
+                text_content="reply", thinking=[], tool_calls=[], stop_reason="stop"
+            )
+        ],
+    )
+    registry.unregister("ollama")
+    registry.register_instance("ollama", mock)
+    return registry, mock
+
+
+def _chat_graph():
+    return Graph("chat").start().user().instruction("Assistant").end().build()
+
+
+class TestRunHistoryKwarg:
+    """``qm.run(history=...)`` pre-seeds ``__conversation__`` with the
+    provided turns. The first LLM node's outbound history is the seed
+    (translated by ``_build_history_for_node``) and the trailing prompt
+    is the new ``user_input``."""
+
+    def test_history_seeds_conversation_for_first_llm_call(self) -> None:
+        registry, mock = _mock_registry()
+        qm.configure(registry=registry)
+
+        history = [
+            {"role": "user", "content": "/stranka PIGO"},
+            {"role": "assistant", "content": "PIGO d.o.o."},
+        ]
+
+        qm.run(_chat_graph(), "in status?", history=history)
+
+        # Find the LLM call.
+        llm_calls = [c for c in mock.calls if c["method"] == "generate_text_response"]
+        assert llm_calls, mock.calls
+        last = llm_calls[-1]
+
+        # The seed history should appear, with roles preserved.
+        assert {"role": "user", "content": "/stranka PIGO"} in last["history"]
+        assert {"role": "assistant", "content": "PIGO d.o.o."} in last["history"]
+        # And the trailing prompt is the new user message.
+        assert last["prompt"] == "in status?"
+
+    def test_history_none_keeps_pre_v081_behaviour(self) -> None:
+        """No ``history=`` kwarg → no seeded conversation, single user
+        message at the wire format. Existing callers don't break."""
+        registry, mock = _mock_registry()
+        qm.configure(registry=registry)
+
+        qm.run(_chat_graph(), "hello")
+
+        llm_calls = [c for c in mock.calls if c["method"] == "generate_text_response"]
+        # Without history, an empty history list / None is sent.
+        assert llm_calls[-1]["history"] in (None, [])
+
+    def test_malformed_history_entries_skipped(self) -> None:
+        """Defensive ingest — bad entries get filtered, valid ones
+        pass through. Matches the engine-level history splicer."""
+        registry, mock = _mock_registry()
+        qm.configure(registry=registry)
+
+        qm.run(
+            _chat_graph(),
+            "now",
+            history=[
+                {"role": "weird"},  # unknown role → skipped
+                {"content": "no role"},  # missing role → skipped
+                {"role": "user"},  # missing content → skipped
+                {"role": "user", "content": "valid"},
+            ],
+        )
+        last = [c for c in mock.calls if c["method"] == "generate_text_response"][-1]
+        assert {"role": "user", "content": "valid"} in last["history"]
+        assert all(
+            entry.get("content") not in ("no role", "") for entry in last["history"]
+        )
+
+
+class TestStreamHistoryKwarg:
+    """``qm.run.stream(history=...)`` plumbs through to the same
+    seeding path. The thread-driven streaming runner must accept and
+    forward the kwarg verbatim."""
+
+    def test_stream_seeds_conversation_for_first_llm_call(self) -> None:
+        registry, mock = _mock_registry()
+        qm.configure(registry=registry)
+
+        history = [
+            {"role": "user", "content": "earlier turn"},
+            {"role": "assistant", "content": "earlier reply"},
+        ]
+        chunks = list(qm.run.stream(_chat_graph(), "now", history=history))
+
+        # The stream must have completed (DoneChunk last).
+        assert chunks[-1].type in ("done", "error"), chunks
+        last = [c for c in mock.calls if c["method"] == "generate_text_response"][-1]
+        assert {"role": "user", "content": "earlier turn"} in last["history"]
+        assert {"role": "assistant", "content": "earlier reply"} in last["history"]
+
+
+class TestHistoryWinsOverLegacySession:
+    """When both ``history=`` and ``session=`` are passed, the explicit
+    ``history`` takes precedence — the legacy blob path doesn't fire."""
+
+    def test_explicit_history_overrides_session(self) -> None:
+        registry, mock = _mock_registry()
+        qm.configure(registry=registry)
+
+        from quartermaster_sdk._session import ChatTurn, InMemorySessionStore
+
+        session = InMemorySessionStore()
+        # Pre-populate session with a turn that would otherwise get
+        # folded into user_input as a "Assistant: ..." prefix.
+        session.append("sid-1", ChatTurn(role="assistant", content="from session"))
+
+        # Pass BOTH history and session.
+        qm.run(
+            _chat_graph(),
+            "now",
+            session=session,
+            session_id="sid-1",
+            history=[{"role": "assistant", "content": "from explicit history"}],
+        )
+
+        last = [c for c in mock.calls if c["method"] == "generate_text_response"][-1]
+        # Explicit history shows up, session blob does NOT.
+        assert {"role": "assistant", "content": "from explicit history"} in last[
+            "history"
+        ]
+        # The session content shouldn't have leaked into prompt either.
+        assert "from session" not in last["prompt"]


### PR DESCRIPTION
## Summary

- `qm.run(history=[...])` and `qm.run.stream(history=[...])` accept a list of `{role, content}` turns and pre-seed `__conversation__` so the first LLM node sees them as proper user/assistant alternation in the outbound `messages` array.
- When both `history=` and the legacy `session=` are passed, the explicit `history=` wins (forward-compatible direction). Session-only paths keep working unchanged.

## Why

v0.8.0 fixed the wire format inside the engine but the SDK's only public chat-history path remained the `session=` blob fold. v0.8.1 closes the loop so chat consumers (Sora, etc.) can hand the runner a list of turns directly without doing memory plumbing.

## Test plan

- [x] 5 new SDK tests in `test_v081_history_kwarg.py` (seed, default-None preserves pre-v0.8.1, malformed-entry filtering, stream variant, history-wins-over-session).
- [x] SDK suite: 217 → 222.
- [x] Engine + providers + graph all green, no regressions.

## Ships as

Patch (0.8.0 → 0.8.1) — additive kwarg, no API breaks.